### PR TITLE
add #field_order to ContactForm

### DIFF
--- a/app/forms/contact_form.rb
+++ b/app/forms/contact_form.rb
@@ -5,4 +5,8 @@ class ContactForm
 
   validates_presence_of :message, :email
   validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
+
+  def field_order
+    %i(email message)
+  end
 end

--- a/spec/forms/contact_form_spec.rb
+++ b/spec/forms/contact_form_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ContactForm, type: :model do
 
   subject { described_class.new(params) }
 
+  describe '#field_order' do
+    it { expect(subject.field_order).to eql(%i(email message)) }
+  end
+
   context 'with an empty message' do
     let(:params) do {
       email: email,


### PR DESCRIPTION
Dough will order errors based on #field_order

![rad-field-order](https://cloud.githubusercontent.com/assets/92580/5579449/f1b2990a-9032-11e4-9eed-efbd9b438bb1.png)
