### PR TITLE
Remove go back and try again button from the rejection page

### DIFF
--- a/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
+++ b/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
@@ -11,10 +11,6 @@
   }
 }
 
-.l-pre-qualification-questions__try-again {
-  margin: $baseline-unit*4 0 $baseline-unit*8 0;
-}
-
 .l-pre-qualification-questions__heading {
   margin-bottom: 0;
 }
@@ -32,6 +28,10 @@
   + p {
     margin-top: 0;
   }
+}
+
+.l-pre-qualification-questions__reasons {
+  margin-bottom: $baseline-unit*10;
 }
 
 .l-pre-qualification-questions__question-group {

--- a/app/views/principals/rejection_form.html.erb
+++ b/app/views/principals/rejection_form.html.erb
@@ -5,12 +5,12 @@
     <%= heading_tag(t('rejection.heading'), level: 1, class: 'l-pre-qualification-questions__heading') %>
     <p class="l-pre-qualification-questions__subheading"><%= t('rejection.subheading') %></p>
 
-    <% t('rejection.reasons').each do |item| %>
-      <%= heading_tag(item[:heading], level: 2, class: 'l-pre-qualification-questions__question') %>
-      <p><%= item[:explanation] %></p>
-    <% end %>
-
-    <%= link_to t('rejection.try_again'), prequalify_principals_path, class: 'l-pre-qualification-questions__try-again button button-secondary t-back' %>
+    <section class="l-pre-qualification-questions__reasons">
+      <% t('rejection.reasons').each do |item| %>
+        <%= heading_tag(item[:heading], level: 2, class: 'l-pre-qualification-questions__question') %>
+        <p><%= item[:explanation] %></p>
+      <% end %>
+    </section>
 
     <p class="form__label-heading"><%= t('rejection.input_label') %></p>
 

--- a/spec/features/principal_pre_qualification_spec.rb
+++ b/spec/features/principal_pre_qualification_spec.rb
@@ -16,7 +16,6 @@ RSpec.feature 'Principal answers pre-qualification questions' do
     given_i_answer_a_question_no
     then_i_am_notified_i_cannot_proceed
     and_i_am_able_to_send_a_message_to_the_administrator
-    and_i_am_able_to_go_back_and_modify_my_answers
   end
 
 
@@ -44,10 +43,5 @@ RSpec.feature 'Principal answers pre-qualification questions' do
 
   def and_i_am_able_to_send_a_message_to_the_administrator
     expect(rejection_page.administrator_message).to be_present
-  end
-
-  def and_i_am_able_to_go_back_and_modify_my_answers
-    rejection_page.go_back.click
-    expect(pre_qualification_page).to be_displayed
   end
 end

--- a/spec/support/rejection_page.rb
+++ b/spec/support/rejection_page.rb
@@ -6,8 +6,6 @@ class RejectionPage < SitePrism::Page
   element :administrator_message, '.t-message'
   element :send_message, '.button--primary'
 
-  element :go_back, '.t-back'
-
   def valid?
     has_css?('validation-summary--hidden')
   end


### PR DESCRIPTION
@benlovell @lshepstone 

As per "bug" #5310 I've removed the go back link. I've also tried to remove the go back scenario from the tests, but may have missed something so do let me know.