### PR TITLE
Fix javascript bug when returning to page one

### DIFF
--- a/app/assets/javascripts/modules/FieldToggleVisibility.js
+++ b/app/assets/javascripts/modules/FieldToggleVisibility.js
@@ -27,9 +27,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     this.$triggers = this.$el.find('[data-dough-field-trigger]');
     this.$targets = this.$el.find('[data-dough-field-target]');
 
-    if (!this.$triggers.filter('[data-dough-field-trigger-type="show"]').is(':checked')) {
-      this.$targets.addClass('is-hidden');
-    }
+    this.hideRelevantTargets();
   }
 
   /**
@@ -64,7 +62,23 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     this._initialisedSuccess(initialised);
 
     return this;
-  }
+  };
+
+  FieldToggleVisibilityProto.hideRelevantTargets = function() {
+    var self = this;
+
+    this.$triggers.filter('[data-dough-field-trigger-type="show"]').each(function() {
+      var $trigger = $(this),
+        target = $trigger.attr('data-dough-field-trigger'),
+        $target = self.$targets.filter('[data-dough-field-target="' + target + '"]');
+
+      if (!$trigger.is(':checked')) {
+        $target.addClass('is-hidden');
+      }
+    });
+
+    return this;
+  };
 
   FieldToggleVisibilityProto.onChange = function($trigger, triggerTarget, triggerAction) {
     var $target = this.$el.find('[data-dough-field-target="' + triggerTarget + '"]');

--- a/app/assets/javascripts/modules/FieldToggleVisibility.js
+++ b/app/assets/javascripts/modules/FieldToggleVisibility.js
@@ -67,14 +67,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   FieldToggleVisibilityProto.hideRelevantTargets = function() {
     var self = this;
 
-    this.$triggers.filter('[data-dough-field-trigger-type="show"]').each(function() {
+    this.$triggers.filter('[data-dough-field-trigger-type="show"]:not(:checked)').each(function() {
       var $trigger = $(this),
         target = $trigger.attr('data-dough-field-trigger'),
         $target = self.$targets.filter('[data-dough-field-target="' + target + '"]');
 
-      if (!$trigger.is(':checked')) {
         $target.addClass('is-hidden');
-      }
     });
 
     return this;

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -48,7 +48,7 @@
 
       <div data-dough-component="FieldToggleVisibility">
         <%= f.form_row :status_question do %>
-          <fieldset class="form__group form__group--inline t-status-question" >
+          <fieldset class="form__group form__group--inline t-status-question">
             <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.status_question.heading') %></legend>
             <p><%= t('registration.status_question.description') %></p>
 
@@ -93,7 +93,7 @@
           <% end %>
 
           <%= f.form_row :consider_available_providers_question do %>
-            <fieldset class="form__group form__group--inline is-hidden t-consider-available-providers-question" data-dough-field-target="2">
+            <fieldset class="form__group form__group--inline t-consider-available-providers-question" data-dough-field-target="2">
               <legend class="l-pre-qualification__question"><%= t('registration.consider_available_providers_question.heading') %></legend>
 
               <div class="form__group-item">


### PR DESCRIPTION
Fixes a bug where after selecting hidden options, progressing to the next page, and the clicking the back button the hidden options would remain selected but hide themselves again.

props to @benbarnett 

@benlovell 