### PR TITLE
Extra validations on `Adviser`

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -16,6 +16,10 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
+  def field_order
+    %i(reference_number confirmed_disclaimer)
+  end
+
   private
 
   def match_reference_number

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -6,6 +6,8 @@ class Adviser < ActiveRecord::Base
   has_and_belongs_to_many :professional_standings
   has_and_belongs_to_many :professional_bodies
 
+  validates_acceptance_of :confirmed_disclaimer, accept: true
+
   validates :reference_number,
     presence: true,
     format: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
   questionnaire:
     adviser:
       reference_number_un_matched: could not be matched with an existing adviser reference
-      title: Yours Advisers
+      title: Your Advisers
       description: Please provide details of advisers in your firm who are eligible to be entered onto the Retirement Advice Directory.
 
       advisers_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,10 +22,6 @@ en:
       <p>If you do not receive an email from us within 15 minutes, please contact <a href="mailto:RADenquiries@moneyadviceservice.org.uk">RADenquiries@moneyadviceservice.org.uk</a>.</p>
       <p>You can close this window now.</p>
 
-  questionnaire:
-    adviser:
-      reference_number_un_matched: could not be matched with an existing adviser reference
-
   registration:
     heading: Register your firm
     introduction: Register your firm on our Retirement Adviser Directory
@@ -97,6 +93,7 @@ en:
 
   questionnaire:
     adviser:
+      reference_number_un_matched: could not be matched with an existing adviser reference
       title: Yours Advisers
       description: Please provide details of advisers in your firm who are eligible to be entered onto the Retirement Advice Directory.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   activerecord:
     attributes:
+      adviser:
+        confirmed_disclaimer: Truth confirmation statement
       principal:
         fca_number: FCA Number
         confirmed_disclaimer: Truth confirmation statement

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Adviser do
       expect(build(:adviser)).to be_valid
     end
 
+    describe 'statement of truth' do
+      it 'must be confirmed' do
+        expect(build(:adviser, confirmed_disclaimer: false)).to_not be_valid
+      end
+    end
+
     describe 'reference number' do
       it 'is required' do
         expect(build(:adviser, reference_number: nil)).to_not be_valid

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe Adviser do
       expect(build(:adviser)).to be_valid
     end
 
+    it 'orders fields correctly for dough' do
+      expect(build(:adviser).field_order).to contain_exactly(
+        :reference_number,
+        :confirmed_disclaimer
+      )
+    end
+
     describe 'statement of truth' do
       it 'must be confirmed' do
         expect(build(:adviser, confirmed_disclaimer: false)).to_not be_valid


### PR DESCRIPTION
* Corrects validation message for un-matched reference
* Adds field ordering for Dough's validation summary
* Requires acceptance of truth statement to proceed