### PR TITLE
Rejig fca number validation

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -6,11 +6,13 @@ class Principal < ActiveRecord::Base
 
   has_one :firm, primary_key: :fca_number, foreign_key: :fca_number
 
+  validates_presence_of :fca_number
+
   validates :fca_number,
-    presence: true,
     uniqueness: true,
     length: { is: 6 },
-    numericality: { only_integer: true }
+    numericality: { only_integer: true },
+    if: :fca_number?
 
   validates :email_address,
     presence: true,
@@ -31,7 +33,7 @@ class Principal < ActiveRecord::Base
 
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
-  validate :match_fca_number
+  validate :match_fca_number, if: :fca_number?
 
   def to_param
     token.parameterize

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe Principal do
     end
 
     describe 'FCA number' do
+      it 'must be a present' do
+        build(:principal).tap do |p|
+          p.fca_number = nil
+          expect(p).to_not be_valid
+        end
+      end
+
       it 'must be a 6 digit number' do
         build(:principal).tap do |p|
           p.fca_number = 12345


### PR DESCRIPTION
Prevent further checks when the number hasn't been supplied at all.