### PR TITLE
Adds AJAX/JSON endpoint for `Lookup::Adviser`

### DIFF
--- a/app/controllers/lookup/advisers_controller.rb
+++ b/app/controllers/lookup/advisers_controller.rb
@@ -3,7 +3,11 @@ module Lookup
     def show
       @adviser = Lookup::Adviser.find_by(reference_number: params[:id])
 
-      render json: { name: @adviser.name }
+      if @adviser
+        render json: { name: @adviser.name }
+      else
+        head :not_found
+      end
     end
   end
 end

--- a/app/controllers/lookup/advisers_controller.rb
+++ b/app/controllers/lookup/advisers_controller.rb
@@ -1,0 +1,9 @@
+module Lookup
+  class AdvisersController < ApplicationController
+    def show
+      @adviser = Lookup::Adviser.find_by(reference_number: params[:id])
+
+      render json: { name: @adviser.name }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
       resource :questionnaire, only: [:edit, :update]
       resources :advisers
     end
+
+    namespace :lookup do
+      resources :advisers, only: :show
+    end
   end
 
   resource :contact, only: :create

--- a/spec/features/principal_creates_adviser_spec.rb
+++ b/spec/features/principal_creates_adviser_spec.rb
@@ -40,6 +40,20 @@ RSpec.feature 'Principal creates Adviser', type: :request do
     and_i_am_given_the_advisers_name
   end
 
+  scenario 'Attempting to match a non-existent Adviser' do
+    given_i_have_created_a_firm
+    when_i_request_a_non_existent_adviser
+    then_the_endpoint_responds_404
+  end
+
+
+  def when_i_request_a_non_existent_adviser
+    get principal_lookup_adviser_path(principal, 'BAD12345')
+  end
+
+  def then_the_endpoint_responds_404
+    expect(response.status).to eq(404)
+  end
 
   def when_i_request_the_advisers_name
     get principal_lookup_adviser_path(principal, reference)

--- a/spec/features/principal_creates_adviser_spec.rb
+++ b/spec/features/principal_creates_adviser_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Principal creates Adviser' do
+RSpec.feature 'Principal creates Adviser', type: :request do
   let(:reference) { 'ABC12345' }
   let(:principal) { create(:principal) }
   let(:adviser_page) { AdviserPage.new }
@@ -32,6 +32,28 @@ RSpec.feature 'Principal creates Adviser' do
     and_i_can_try_another_adviser_reference_number
   end
 
+  scenario 'Matching an Adviser' do
+    given_i_have_created_a_firm
+    and_the_adviser_is_matched
+    when_i_request_the_advisers_name
+    then_the_endpoint_responds_ok
+    and_i_am_given_the_advisers_name
+  end
+
+
+  def when_i_request_the_advisers_name
+    get principal_lookup_adviser_path(principal, reference)
+  end
+
+  def then_the_endpoint_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_i_am_given_the_advisers_name
+    JSON.parse(response.body).tap do |json|
+      expect(json['name']).to eq('Daisy Lovell')
+    end
+  end
 
   def when_the_adviser_is_not_matched
     adviser_page.submit.click

--- a/spec/support/adviser_page.rb
+++ b/spec/support/adviser_page.rb
@@ -1,5 +1,5 @@
 class AdviserPage < SitePrism::Page
-  set_url 'principals/{principal}/firm/advisers/new'
+  set_url '/principals/{principal}/firm/advisers/new'
   set_url_matcher %r{/principals/[a-f0-9]{8}/firm/advisers/new}
 
   element :reference_number, '.t-reference-number'

--- a/spec/support/firm_page.rb
+++ b/spec/support/firm_page.rb
@@ -1,5 +1,5 @@
 class FirmPage < SitePrism::Page
-  set_url 'principals/{principal}/firm'
+  set_url '/principals/{principal}/firm'
   set_url_matcher %r{/principals/[a-f0-9]{8}/firm}
 
   element :firm_title, '.t-firm-title'


### PR DESCRIPTION
`GET /principals/:token/lookup/advisers/:reference_number`

Responds with `{"name":"Advisers Name"}` and `200` when found.

`404` when not matched.