### PR TITLE
Shows a message if the adviser already exists.

### DIFF
--- a/app/assets/javascripts/modules/AdviserAjaxCall.js
+++ b/app/assets/javascripts/modules/AdviserAjaxCall.js
@@ -10,7 +10,6 @@ define(['jquery'], function($) {
         $error = $('[data-notice="error"]'),
         $inputFieldValue = $(this).val(),
         url = $(this).attr('data-url') + $inputFieldValue + ".json",
-        error404 = "<p>We cannot find that adviser. Please try entering the reference number again.</p>",
         error500 = "<p>The server is not responding. We are unable to check whether that individual reference number is valid. Please try again later.</p>";
 
     $.ajax(url, {
@@ -29,11 +28,15 @@ define(['jquery'], function($) {
       },
 
       statusCode: {
-        404: function() {
-          $error.html(error404);
+        404: function(request) {
+          $error.html("<p>" + request.responseJSON.error + "</p>");
         },
 
-        500: function() {
+        409: function(request) {
+          $error.html("<p>" + request.responseJSON.error + "</p>");
+        },
+
+        500: function(request) {
           $error.html(error500);
         }
       }

--- a/app/assets/javascripts/modules/AdviserAjaxCall.js
+++ b/app/assets/javascripts/modules/AdviserAjaxCall.js
@@ -36,7 +36,7 @@ define(['jquery'], function($) {
           $error.html("<p>" + request.responseJSON.error + "</p>");
         },
 
-        500: function(request) {
+        default: function(request) {
           $error.html(error500);
         }
       }

--- a/app/controllers/lookup/advisers_controller.rb
+++ b/app/controllers/lookup/advisers_controller.rb
@@ -6,7 +6,7 @@ module Lookup
       if @adviser
         stat :already_matched
 
-        render json: { error: t('questionnaire.adviser.advisers_details.already_exists_error') }, status: 409
+        render json: { error: t('questionnaire.adviser.error_responses.already_exists') }, status: 409
       else
         @lookup_adviser = Adviser.find_by(reference_number: params[:id])
 
@@ -17,7 +17,7 @@ module Lookup
         else
           stat :unmatched
 
-          render json: { error: t('questionnaire.adviser.advisers_details.not_found_error') }, status: 404
+          render json: { error: t('questionnaire.adviser.error_responses.not_found') }, status: 404
         end
       end
     end

--- a/app/controllers/lookup/advisers_controller.rb
+++ b/app/controllers/lookup/advisers_controller.rb
@@ -1,29 +1,41 @@
 module Lookup
   class AdvisersController < ApplicationController
     def show
-      @adviser = ::Adviser.find_by(reference_number: params[:id])
-
-      if @adviser
-        stat :already_matched
-
-        render json: { error: t('questionnaire.adviser.error_responses.already_exists') }, status: 409
+      if @adviser = ::Adviser.find_by(reference_number: params[:id])
+        errors_for :conflict
       else
-        @lookup_adviser = Adviser.find_by(reference_number: params[:id])
-
-        if @lookup_adviser
-          stat :matched
-
-          render json: { name: @lookup_adviser.name }
+        if @lookup_adviser = Adviser.find_by(reference_number: params[:id])
+          json_for @lookup_adviser
         else
-          stat :unmatched
-
-          render json: { error: t('questionnaire.adviser.error_responses.not_found') }, status: 404
+          errors_for :not_found
         end
       end
     end
 
+    private
+
     def stat(key)
       Stats.increment("radsignup.adviser.#{key}")
+    end
+
+    def json_for(lookup_adviser)
+      stat :matched
+
+      render json: { name: lookup_adviser.name }
+    end
+
+    def errors_for(status)
+      stat stat_key_for(status)
+
+      render json: { error: t("questionnaire.adviser.error_responses.{status}") }, status: status
+    end
+
+    def stat_key_for(status)
+      if status == :not_found
+        :unmatched
+      else
+        :already_matched
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,8 @@ en:
         heading: Enter the Adviser’s FCA individual reference number.
         description: You will then be asked to complete some basic information about that Adviser.
         label: Adviser FCA individual reference number *
+        already_exists_error: An adviser with that reference number already exists.
+        not_found_error: We cannot find that adviser. Please try entering the reference number again.
 
       accreditations:
         heading: Accreditations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
       button_add: Add adviser
 
       error_responses:
-        already_exists: An adviser with that reference number already exists.
+        conflict: An adviser with that reference number already exists.
         not_found: We cannot find that adviser. Please try entering the reference number again.
 
       geographical_coverage:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,10 @@ en:
       description: Please provide details of advisers in your firm who are eligible to be entered onto the Retirement Adviser Directory.
       button_add: Add adviser
 
+      error_responses:
+        already_exists: An adviser with that reference number already exists.
+        not_found: We cannot find that adviser. Please try entering the reference number again.
+
       geographical_coverage:
         heading: Geographical coverage *
         description: Please provide details of the area your adviser is willing to travel to provide their services.
@@ -129,8 +133,6 @@ en:
         heading: Enter the Adviser’s FCA individual reference number.
         description: You will then be asked to complete some basic information about that Adviser.
         label: Adviser FCA individual reference number *
-        already_exists_error: An adviser with that reference number already exists.
-        not_found_error: We cannot find that adviser. Please try entering the reference number again.
 
       accreditations:
         heading: Accreditations


### PR DESCRIPTION
Regarding error messages, I think it's a good idea to have them in one place, and not in the JS or view (of course), so I've set this up to return the localised error messages from the lookup endpoint, though there other ways to do this.

@alexwllms @benlovell @jongilbraith