### PR TITLE
Adds statsd gauges for adviser and firm counts

### DIFF
--- a/app/controllers/advisers_controller.rb
+++ b/app/controllers/advisers_controller.rb
@@ -7,8 +7,7 @@ class AdvisersController < ApplicationController
     @adviser = advisers.create(adviser_params)
 
     if @adviser.valid?
-      Stats.increment('radsignup.adviser.registered')
-
+      stat
       redirect_to principal_firm_adviser_path(id: @adviser)
     else
       render :new
@@ -20,6 +19,13 @@ class AdvisersController < ApplicationController
   end
 
   private
+
+  def stat
+    'radsignup.adviser.registered'.tap do |key|
+      Stats.increment(key)
+      Stats.gauge(key, Adviser.count)
+    end
+  end
 
   def advisers
     Firm

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -7,8 +7,7 @@ class QuestionnairesController < ApplicationController
     @firm = firm_or_subsidiary
 
     if @firm.update(firm_params)
-      Stats.increment('radsignup.firm.registered')
-
+      stat
       redirect_to new_principal_firm_adviser_path(current_user, @firm)
     else
       render :edit
@@ -16,6 +15,13 @@ class QuestionnairesController < ApplicationController
   end
 
   private
+
+  def stat
+    'radsignup.firm.registered'.tap do |key|
+      Stats.increment(key)
+      Stats.gauge(key, Firm.registered.count)
+    end
+  end
 
   def firm_or_subsidiary
     Firm.find_by(id: params[:firm_id], fca_number: current_user.fca_number)

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -1,4 +1,6 @@
 class Firm < ActiveRecord::Base
+  scope :registered, -> { where.not(email_address: nil) }
+
   has_and_belongs_to_many :in_person_advice_methods
   has_and_belongs_to_many :other_advice_methods
   has_and_belongs_to_many :initial_advice_fee_structures

--- a/config/initializers/stats.rb
+++ b/config/initializers/stats.rb
@@ -3,6 +3,10 @@ module Stats
     client.increment(*args) if key
   end
 
+  def self.gauge(*args)
+    client.gauge(*args) if key
+  end
+
   def self.client
     $statsd ||= Statsd.new('statsd.hostedgraphite.com', 8125).tap do |n|
       n.namespace = key


### PR DESCRIPTION
Adds gauges for running totals of registered advisers and firms.

Introduces `registered` scope on `Firm`, since `email_address` is
required, we can guarantee if this attribute is present, the `Firm` can
be determined `registered`.