### PR TITLE
Set field order for the Firm model.

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -85,6 +85,28 @@ class Firm < ActiveRecord::Base
     parent.present?
   end
 
+  def field_order
+    [
+      :email_address,
+      :telephone_number,
+      :address_line_one,
+      :address_line_two,
+      :address_town,
+      :address_county,
+      :address_postcode,
+      :in_person_advice_methods,
+      :free_initial_meeting,
+      :initial_meeting_duration,
+      :initial_advice_fee_structures,
+      :ongoing_advice_fee_structures,
+      :allowed_payment_methods,
+      :minimum_fixed_fee,
+      :percent_total,
+      *I18n.t('questionnaire.retirement_advice.business_split.advice_options').keys,
+      :investment_sizes
+    ]
+  end
+
   private
 
   def sum_of_percentages_equals_one_hundred

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Firm do
       expect(firm).to be_valid
     end
 
+    it 'orders fields correctly for dough' do
+      expect(firm.field_order).not_to be_empty
+    end
+
     describe 'email address' do
       context 'when not present' do
         before { firm.email_address = nil }


### PR DESCRIPTION
Mistakenly did this while addressing the error ordering on the adviser form, but it would seem the errors do still need sorting in the Firm model.

Currently postcode is numbered ahead of town and county.
