### PR TITLE
Resolves issue with cut & pasted copy

### DIFF
--- a/app/views/advisers/new.html.erb
+++ b/app/views/advisers/new.html.erb
@@ -80,7 +80,7 @@
 
       <section>
         <%= heading_tag(t('questionnaire.adviser.advisers_qualifications.heading'), level: 2, class: 'heading-small') %>
-        <p class="l-questionnaire__section-description"><%= t('questionnaire.adviser.geographical_coverage.description') %></p>
+        <p class="l-questionnaire__section-description"><%= t('questionnaire.adviser.advisers_qualifications.description') %></p>
 
         <fieldset class="form__group">
           <legend class="l-questionnaire__legend"><%= t('questionnaire.adviser.accreditations.heading') %></legend>


### PR DESCRIPTION
Prior to this change a duplicate key was used thus the form appeared as:

![screen shot 2015-02-01 at 17 23 20](https://cloud.githubusercontent.com/assets/41963/5992775/9652daf6-aa37-11e4-8e41-afa680224465.png)
