### PR TITLE
Default to `false` for "Covers Whole of UK"

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -8,7 +8,7 @@ class Adviser < ActiveRecord::Base
 
   before_validation :assign_name, if: :reference_number?
 
-  before_validation :clear_geographical_coverage, if: :whole_of_uk?
+  before_validation :clear_geographical_coverage, if: :covers_whole_of_uk?
 
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
@@ -18,12 +18,12 @@ class Adviser < ActiveRecord::Base
   validates :travel_distance,
     presence: true,
     inclusion: { in: TravelDistance.all },
-    unless: :whole_of_uk?
+    unless: :covers_whole_of_uk?
 
   validates :postcode,
     presence: true,
     format: { with: /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ },
-    unless: :whole_of_uk?
+    unless: :covers_whole_of_uk?
 
   validates :reference_number,
     presence: true,
@@ -45,10 +45,6 @@ class Adviser < ActiveRecord::Base
   end
 
   private
-
-  def whole_of_uk?
-    covers_whole_of_uk || covers_whole_of_uk.nil?
-  end
 
   def clear_geographical_coverage
     self.postcode = ''

--- a/db/migrate/20150128155644_default_to_nil_for_adviser_covers_whole_of_uk.rb
+++ b/db/migrate/20150128155644_default_to_nil_for_adviser_covers_whole_of_uk.rb
@@ -1,9 +1,0 @@
-class DefaultToNilForAdviserCoversWholeOfUk < ActiveRecord::Migration
-  def up
-    change_column :advisers, :covers_whole_of_uk, :boolean, default: nil
-  end
-
-  def down
-    change_column :advisers, :covers_whole_of_uk, :boolean, default: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150128155644) do
+ActiveRecord::Schema.define(version: 20150127084858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,15 +31,15 @@ ActiveRecord::Schema.define(version: 20150128155644) do
   add_index "accreditations_advisers", ["adviser_id", "accreditation_id"], name: "advisers_accreditations_index", unique: true, using: :btree
 
   create_table "advisers", force: :cascade do |t|
-    t.string   "reference_number",                  null: false
-    t.string   "name",                              null: false
-    t.integer  "firm_id",                           null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.boolean  "confirmed_disclaimer",              null: false
-    t.string   "postcode",             default: "", null: false
-    t.integer  "travel_distance",      default: 0,  null: false
-    t.boolean  "covers_whole_of_uk",                null: false
+    t.string   "reference_number",                     null: false
+    t.string   "name",                                 null: false
+    t.integer  "firm_id",                              null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.boolean  "confirmed_disclaimer",                 null: false
+    t.string   "postcode",             default: "",    null: false
+    t.integer  "travel_distance",      default: 0,     null: false
+    t.boolean  "covers_whole_of_uk",   default: false, null: false
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -33,20 +33,6 @@ RSpec.describe Adviser do
         it 'is required' do
           expect(build(:adviser, covers_whole_of_uk: nil)).to_not be_valid
         end
-
-        context 'when not selected' do
-          let(:adviser) { build(:adviser, covers_whole_of_uk: nil) }
-
-          before { adviser.valid? }
-
-          it 'does not contain errors for postcode' do
-            expect(adviser.errors).to_not include(:postcode)
-          end
-
-          it 'does not contain errors for travel distance' do
-            expect(adviser.errors).to_not include(:travel_distance)
-          end
-        end
       end
 
       context 'when the adviser covers whole of UK' do


### PR DESCRIPTION
@benlovell @jongilbraith 

Turns out, Dough's so good, @alexwllms needn't do a thing.

Sad to see the "regression spec" go for when `covers_whole_of_uk` is `nil`, but given the defaults, and then the required validation conditional hacks, best to be out with it.