### PR TITLE
Change postcode field to validate lowercase

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -22,7 +22,7 @@ class Adviser < ActiveRecord::Base
 
   validates :postcode,
     presence: true,
-    format: { with: /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ },
+    format: { with: /(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))/ },
     unless: :covers_whole_of_uk?
 
   validates :reference_number,

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -10,7 +10,7 @@ class Adviser < ActiveRecord::Base
 
   before_validation :clear_geographical_coverage, if: :covers_whole_of_uk?
 
-  before_validation :uppercase_postcode
+  before_validation :upcase_postcode
 
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
@@ -48,8 +48,8 @@ class Adviser < ActiveRecord::Base
 
   private
 
-  def uppercase_postcode
-    self.postcode.upcase!
+  def upcase_postcode
+    postcode.upcase! if postcode.present?
   end
 
   def clear_geographical_coverage

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -10,6 +10,8 @@ class Adviser < ActiveRecord::Base
 
   before_validation :clear_geographical_coverage, if: :covers_whole_of_uk?
 
+  before_validation :uppercase_postcode
+
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
   validates :covers_whole_of_uk,
@@ -22,7 +24,7 @@ class Adviser < ActiveRecord::Base
 
   validates :postcode,
     presence: true,
-    format: { with: /(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))/ },
+    format: { with: /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ },
     unless: :covers_whole_of_uk?
 
   validates :reference_number,
@@ -45,6 +47,10 @@ class Adviser < ActiveRecord::Base
   end
 
   private
+
+  def uppercase_postcode
+    self.postcode.upcase!
+  end
 
   def clear_geographical_coverage
     self.postcode = ''

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -37,7 +37,7 @@ class Firm < ActiveRecord::Base
 
   validates :address_postcode,
     presence: true,
-    format: { with: /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ }
+    format: { with: /(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))/ }
 
   validates :address_town,
     :address_county,

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -18,6 +18,8 @@ class Firm < ActiveRecord::Base
 
   attr_accessor :percent_total
 
+  before_validation :uppercase_postcode
+
   validates :email_address,
     presence: true,
     length: { maximum: 50 },
@@ -37,7 +39,7 @@ class Firm < ActiveRecord::Base
 
   validates :address_postcode,
     presence: true,
-    format: { with: /(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))/ }
+    format: { with: /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ }
 
   validates :address_town,
     :address_county,
@@ -108,6 +110,10 @@ class Firm < ActiveRecord::Base
   end
 
   private
+
+  def uppercase_postcode
+    self.address_postcode.upcase!
+  end
 
   def sum_of_percentages_equals_one_hundred
     total = retirement_income_products_percent.to_i \

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -18,7 +18,7 @@ class Firm < ActiveRecord::Base
 
   attr_accessor :percent_total
 
-  before_validation :uppercase_postcode
+  before_validation :upcase_postcode
 
   validates :email_address,
     presence: true,
@@ -111,8 +111,8 @@ class Firm < ActiveRecord::Base
 
   private
 
-  def uppercase_postcode
-    self.address_postcode.upcase!
+  def upcase_postcode
+    address_postcode.upcase! if address_postcode.present?
   end
 
   def sum_of_percentages_equals_one_hundred

--- a/app/views/advisers/new.html.erb
+++ b/app/views/advisers/new.html.erb
@@ -59,7 +59,7 @@
               <div>
                 <%= f.errors_for :postcode %>
                 <%= f.label :postcode, t('questionnaire.adviser.geographical_coverage.postcode'), class: 'form__label-heading' %>
-                <%= f.text_field :postcode, class: 't-postcode form__input-container--medium', data: { transform: '' } %>
+                <%= f.text_field :postcode, class: 't-postcode form__input-container--medium' %>
               </div>
             <% end %>
 

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -75,7 +75,7 @@
               <%= f.form_row :address_postcode do %>
                 <%= f.errors_for :address_postcode %>
                 <%= f.label :address_postcode, t('questionnaire.address.label_five'), class: 'form__label-heading' %>
-                <%= f.text_field :address_postcode, class: 'form__input-container--medium', data: { transform: ''} %>
+                <%= f.text_field :address_postcode, class: 'form__input-container--medium' %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
@benlovell @lshepstone @jongilbraith 

I think this is a better approach than forcing the user to enter uppercase, or relying on javascript to convert the characters to uppercase which introduces a possible point of error.