### PR TITLE
Switches ActiveJob over to the `sidekiq` adapter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+worker: bundle exec sidekiq

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,4 +87,6 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method     = :smtp
   config.action_mailer.default_url_options = { host: ENV['EMAIL_HOST'] }
+
+  config.active_job.queue_adapter = :sidekiq
 end


### PR DESCRIPTION
We have been using inline processing until now.

Once this gets merged, we'll need to enable a worker dyno in heroku before
deploying these changes to both QA and production environments.