### PR TITLE
5853 Geocode Advisers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.5)
+    mas-rad_core (0.0.7)
       geocoder
       pg
       rails (~> 4.2.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150210113610) do
+ActiveRecord::Schema.define(version: 20150222092417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 20150210113610) do
     t.boolean  "confirmed_disclaimer",              null: false
     t.string   "postcode",             default: "", null: false
     t.integer  "travel_distance",      default: 0,  null: false
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|

--- a/spec/features/adviser_postcode_is_geocoded_spec.rb
+++ b/spec/features/adviser_postcode_is_geocoded_spec.rb
@@ -1,0 +1,14 @@
+RSpec.feature 'Adviser postcode is geocoded' do
+  scenario 'Valid Adviser is scheduled for geocoding' do
+    when_i_have_created_a_valid_adviser
+    then_it_is_scheduled_for_geocoding
+  end
+
+  def when_i_have_created_a_valid_adviser
+    @adviser = build(:adviser)
+  end
+
+  def then_it_is_scheduled_for_geocoding
+    expect { @adviser.save! }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(1)
+  end
+end


### PR DESCRIPTION
Upgrades to the latest version of `mas-rad_core` and adds a feature spec to ensure the adviser is scheduled for geocoding.