### PR TITLE
Let admin users delete advisers themselves.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,22 +17,18 @@ gem 'dough-ruby',
   github: 'moneyadviceservice/dough',
   require: 'dough',
   ref: 'cf08913'
+gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mas-rad_core'
 gem 'pg'
 gem 'ransack'
 gem 'rollbar'
+gem 'sass-rails'
 gem 'sidekiq'
 gem 'sinatra', require: false
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
-
-group :assets do
-  gem 'coffee-rails'
-  gem 'jquery-rails'
-  gem 'sass-rails'
-end
 
 group :test, :development do
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,13 +74,6 @@ GEM
       timers (~> 4.0.0)
     cliver (0.3.2)
     coderay (1.1.0)
-    coffee-rails (4.1.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1.1)
     connection_pool (2.2.0)
     database_cleaner (1.4.1)
     diff-lcs (1.2.5)
@@ -267,7 +260,6 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.3)
   bowndler!
   capybara
-  coffee-rails
   database_cleaner
   dough-ruby!
   factory_girl_rails

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,2 +1,3 @@
 //= require jquery
+//= require jquery_ujs
 //= require bootstrap-sprockets

--- a/app/controllers/admin/advisers_controller.rb
+++ b/app/controllers/admin/advisers_controller.rb
@@ -25,6 +25,13 @@ class Admin::AdvisersController < Admin::ApplicationController
     end
   end
 
+  def destroy
+    @adviser = adviser
+    @adviser.destroy
+
+    redirect_to admin_advisers_path
+  end
+
   private
 
   def firm

--- a/app/views/admin/advisers/show.html.erb
+++ b/app/views/admin/advisers/show.html.erb
@@ -48,4 +48,5 @@
   </div>
 </div>
 
-<p><%= link_to('Edit Adviser', edit_admin_adviser_path) %></p>
+<p><%= link_to 'Edit Adviser', edit_admin_adviser_path %></p>
+<p><%= link_to 'Delete adviser', admin_adviser_path, method: :delete, class: 't-delete-adviser', data: {confirm: 'Are you sure you want to delete this adviser?'} %></p>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -9,6 +9,7 @@
   <meta name="author" content="Team A">
   <title>RAD Administration</title>
   <%= stylesheet_link_tag 'admin' %>
+  <%= csrf_meta_tags %>
 </head>
 
 <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'pages#home'
-    resources :advisers, only: [:index, :show, :edit, :update]
+    resources :advisers, only: [:index, :show, :edit, :update, :destroy]
+
     resources :firms, only: [:index, :show] do
       resources :advisers, only: :index
     end

--- a/spec/features/admin/access_spec.rb
+++ b/spec/features/admin/access_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature 'Accessing the admin area' do
+  let(:admin_adviser_page) { AdminAdviserPage.new }
   let(:username) { 'admin' }
   let(:password) { 'password' }
 

--- a/spec/features/admin/delete_adviser_spec.rb
+++ b/spec/features/admin/delete_adviser_spec.rb
@@ -1,0 +1,31 @@
+RSpec.feature 'Deleting an adviser from the admin interface' do
+  let(:admin_adviser_page) { AdminAdviserPage.new }
+
+  scenario 'Deleting an adviser' do
+    given_there_is_an_adviser
+    when_i_visit_an_adviser_page
+    and_i_click_delete_adviser
+    then_the_adviser_is_deleted
+    and_i_am_redirected_to_the_adviser_list_page
+  end
+end
+
+def given_there_is_an_adviser
+  @adviser = create(:adviser)
+end
+
+def when_i_visit_an_adviser_page
+  visit(admin_adviser_path(@adviser))
+end
+
+def and_i_click_delete_adviser
+  admin_adviser_page.delete_adviser.click
+end
+
+def then_the_adviser_is_deleted
+  expect(Adviser.find_by_id(@adviser.id)).to be_nil
+end
+
+def and_i_am_redirected_to_the_adviser_list_page
+  expect(page.current_path).to eq admin_advisers_path
+end

--- a/spec/support/admin_adviser_page.rb
+++ b/spec/support/admin_adviser_page.rb
@@ -1,0 +1,6 @@
+class AdminAdviserPage < SitePrism::Page
+  set_url '/admin/advisers/{adviser}'
+  set_url_matcher %r{/admin/advisers/[a-f0-9]{8}}
+
+  element :delete_adviser, '.t-delete-adviser'
+end


### PR DESCRIPTION
Every few days we have to go through the help requests and delete a bunch of advisers. It will be quicker and easier for everyone if admin users can do it themselves.

I even managed to write one of these funny rspec feature specs.

@munckymagik 