### PR TITLE
Move delete button away from edit, make both more obvious.

### DIFF
--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -48,3 +48,16 @@ code {
   width: 100%;
   margin-bottom: 20px;
 }
+
+.adviser__actions {
+  @include make-row;
+}
+
+.adviser__actions__delete {
+  @include make-xs-column(6);
+  text-align: right;
+}
+
+.adviser__actions__edit {
+  @include make-xs-column(6);
+}

--- a/app/views/admin/advisers/show.html.erb
+++ b/app/views/admin/advisers/show.html.erb
@@ -48,5 +48,11 @@
   </div>
 </div>
 
-<p><%= link_to 'Edit Adviser', edit_admin_adviser_path %></p>
-<p><%= link_to 'Delete adviser', admin_adviser_path, method: :delete, class: 't-delete-adviser', data: {confirm: 'Are you sure you want to delete this adviser?'} %></p>
+<div class="adviser__actions">
+  <div class="adviser__actions__edit">
+    <%= link_to 'Edit Adviser', edit_admin_adviser_path, class: 'btn btn-success' %>
+  </div>
+  <div class="adviser__actions__delete">
+    <%= button_to 'Delete adviser', admin_adviser_path, class: 't-delete-adviser btn btn-danger', method: :delete, data: {confirm: 'Are you sure you want to delete this adviser?'} %></p>
+  </div>
+</div>


### PR DESCRIPTION
Users rightly pointed out that having the delete and edit buttons close together was perhaps not the best idea. So we've moved the delete button to the right. While we're here, we can make them a little more obvious using the default bootstrap button styles.