### PR TITLE
Revert rubocop fix as Time.zone is unavailable without Rails.

### DIFF
--- a/fca_import_scripts/lib/ext_to_sql.rb
+++ b/fca_import_scripts/lib/ext_to_sql.rb
@@ -2,7 +2,7 @@ require 'date'
 require 'yaml'
 
 class ExtToSql
-  TIMESTAMP = Time.zone.now.strftime('%Y-%m-%d %H:%M:%S.%N') # Time in UTC
+  TIMESTAMP = Time.now.strftime('%Y-%m-%d %H:%M:%S.%N') # rubocop:disable Rails/TimeZone
   REPAIR_FILE = File.join(File.dirname(__FILE__), '..', 'repairs.yml')
 
   module COLUMNS


### PR DESCRIPTION
Also disable Rubocop check, as it's a rails cop and not applicable here.

I wanted to disable all the rails cops for the whole file but couldn't figure out how to do that.