### PR TITLE
Pulling both register links into one place

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,8 @@ module ApplicationHelper
   def render_breadcrumbs(crumbs)
     render 'shared/breadcrumbs', breadcrumbs: crumbs
   end
+
+  def register_path
+    prequalify_principals_path
+  end
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %>
+  <%= link_to t('authentication_sign_up'), register_path %>
 <% end -%>|
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -5,7 +5,7 @@
         <%= link_to t('authentication_sign_in'), new_user_session_path, class: 'navigation__link' %>
       </li>
       <li class='navigation__item navigation__item--last'>
-        <%= link_to t('authentication_sign_up'), prequalify_principals_path, class: 'navigation__link' %>
+        <%= link_to t('authentication_sign_up'), register_path, class: 'navigation__link' %>
       </li>
     <% else %>
       <li class='navigation__item'>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,4 +10,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       helper.render_breadcrumbs []
     end
   end
+
+  describe '#register_path' do
+    it 'provides the start of the registration flow' do
+      expect(helper.register_path).to eq(prequalify_principals_path)
+    end
+  end
 end


### PR DESCRIPTION
The 'sign up' / 'registration' part of the app is the main flow currently available in RAD.

When pulling in devise I missed one of the 'Sign up' links in the generated views that was routing to a devise/sign_up controller. This PR is to rectify that.