### PR TITLE
Remove FuzzySearch

### DIFF
--- a/app/assets/javascripts/modules/FilterTable.js
+++ b/app/assets/javascripts/modules/FilterTable.js
@@ -7,8 +7,8 @@
  * See test fixture for sample markup - /spec/js/fixtures/FilterTable.html
  */
 
-define(['jquery', 'DoughBaseComponent', 'List', 'ListFuzzySearch'],
-       function($, DoughBaseComponent, List, ListFuzzySearch) {
+define(['jquery', 'DoughBaseComponent', 'List'],
+       function($, DoughBaseComponent, List) {
   'use strict';
 
   var FilterTableProto,
@@ -69,8 +69,7 @@ define(['jquery', 'DoughBaseComponent', 'List', 'ListFuzzySearch'],
     var firmOptions = {
       valueNames: this.makeFilterTargetClasses(),
       searchClass: this.config.filterFieldClass,
-      listClass: this.config.filterListClass,
-      plugins: [ListFuzzySearch()]
+      listClass: this.config.filterListClass
     };
 
     new List(this.$el.attr('id'), firmOptions);

--- a/app/assets/javascripts/modules/FilterTable.js
+++ b/app/assets/javascripts/modules/FilterTable.js
@@ -65,18 +65,6 @@ define(['jquery', 'DoughBaseComponent', 'List', 'ListFuzzySearch'],
     return $.unique(filterClasses);
   };
 
-  /**
-   * enableFuzzySearch
-   *
-   * Find input field with class filterFieldClass then add fuzzy-search class to it.
-   *
-   */
-  FilterTableProto.enableFuzzySearch = function () {
-    this.$el.find('.' + this.config.filterFieldClass).each(function(_, cell) {
-      $(cell).addClass('fuzzy-search');
-    });
-  };
-
   FilterTableProto.bindFilterToElements = function() {
     var firmOptions = {
       valueNames: this.makeFilterTargetClasses(),
@@ -84,8 +72,6 @@ define(['jquery', 'DoughBaseComponent', 'List', 'ListFuzzySearch'],
       listClass: this.config.filterListClass,
       plugins: [ListFuzzySearch()]
     };
-
-    this.enableFuzzySearch();
 
     new List(this.$el.attr('id'), firmOptions);
   };

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -4,7 +4,6 @@
 //= depend_on_asset modules/DataTransform
 //= depend_on_asset modules/FilterTable
 //= depend_on_asset list.js/dist/list.js
-//= depend_on_asset list.fuzzysearch.js/dist/list.fuzzysearch.js
 
 <%
   def requirejs_path(asset)
@@ -17,7 +16,6 @@
     paths: {
       jquery: requirejs_path('jquery/dist/jquery'),
       List: requirejs_path('list.js/dist/list.js'),
-      ListFuzzySearch: requirejs_path('list.fuzzysearch.js/dist/list.fuzzysearch.js'),
       FieldToggleVisibility: requirejs_path('modules/FieldToggleVisibility'),
       AdviserAjaxCall: requirejs_path('modules/AdviserAjaxCall'),
       DataTransform: requirejs_path('modules/DataTransform'),

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -5,7 +5,6 @@
     "yeast": "git://github.com/moneyadviceservice/yeast.git#master",
     "requirejs": "2.1.*",
     "jquery": "1.11.*",
-    "list.js": "1.1.1",
-    "list.fuzzysearch.js": "0.1.0"
+    "list.js": "1.1.1"
   }
 }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -34,6 +34,5 @@ Rails.application.configure do
     requirejs/require.js
     modernizer-flexbox-cssclasses.js
     list.js/dist/list.js
-    list.fuzzysearch.js/dist/list.fuzzysearch.js
   )
 end

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -27,8 +27,7 @@ require.config({
     jquery: 'vendor/assets/bower_components/jquery/dist/jquery',
     FieldToggleVisibility: 'app/assets/javascripts/modules/FieldToggleVisibility',
     FilterTable: 'app/assets/javascripts/modules/FilterTable',
-    List: 'vendor/assets/bower_components/list.js/dist/list',
-    ListFuzzySearch: 'vendor/assets/bower_components/list.fuzzysearch.js/dist/list.fuzzysearch'
+    List: 'vendor/assets/bower_components/list.js/dist/list'
   },
 
   shim: {

--- a/spec/javascripts/tests/FilterTable_spec.js
+++ b/spec/javascripts/tests/FilterTable_spec.js
@@ -92,17 +92,5 @@ describe('filter table based on text field criteria', function () {
         expect(this.getRows().eq(0).text()).to.include('Alex');
       });
     });
-
-    describe('when text matching across multiple columns', function() {
-      beforeEach(function() {
-        this.$field.val('orse ondon');
-        fireKeyup(this.$field);
-      });
-
-      it('shows only that row', function () {
-        expect(this.getRows().length).to.eq(1);
-        expect(this.getRows().eq(0).text()).to.include('Horse');
-      });
-    });
   });
 });


### PR DESCRIPTION
It's just one thing after another!

So FuzzySearch doesn't search on the text contents of the elements, it searches on the HTML contents of the elements. Additionally, FuzzySearch expects the match to be at the beginning of the string, and ignores any matches after ~40 characters.

Even more additionally, there's a bug in FuzzySearch that ignores all the options we could pass to it to make it behave as we want.

All this together made us think we should trash the fuzzy search and just use regular old search.