### PR TITLE
[WIP] Fix intermittent failure that occurs with specific seed

### DIFF
--- a/spec/features/dashboard/trading_names_edit_spec.rb
+++ b/spec/features/dashboard/trading_names_edit_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'The dashboard trading name edit page' do
 
   def then_i_see_the_edit_page_for_the_first_trading_name
     expect(trading_name_edit_page).to be_displayed
-    expect(trading_name_edit_page.firm_name).to have_text @principal.firm.trading_names.first.registered_name
+    expect(trading_name_edit_page.firm_name).to have_text @principal.firm.trading_names[0].registered_name
   end
 
   def when_i_change_the_information


### PR DESCRIPTION
Running `bundle exec rspec --seed 43693` causes a repeatable test
failure.

Fix seems to be due to the difference between using the `.first` scope
compared with fetch the first record in an expected result set.

`.first` seems to add additional constraints (e.g. order).