### PR TITLE
In the dashboard, handle the case when there are no trading names

### DIFF
--- a/app/views/dashboard/firms/_table_available_trading_names.html.erb
+++ b/app/views/dashboard/firms/_table_available_trading_names.html.erb
@@ -1,0 +1,24 @@
+<div class="table-wrapper">
+  <table class="l-half-width">
+    <thead>
+      <tr>
+        <th><%= Firm.human_attribute_name(:fca_number) %></th>
+        <th><%= Firm.human_attribute_name(:registered_name) %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody class="js-filter-rows">
+      <% @lookup_names.each do |lookup_name| %>
+        <tr class="t-available-trading-name-table-row">
+          <td class="js-filterable t-frn"><%= lookup_name.fca_number %></td>
+          <td class="js-filterable t-firm-name">
+            <%= lookup_name.name %>
+          </td>
+          <td>
+            <%= link_to t('dashboard.firms_index.new_trading_name_link'), new_dashboard_trading_name_path(lookup_id: lookup_name.id), class: 'button button--small t-edit-link' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/firms/_table_empty_trading_names.html.erb
+++ b/app/views/dashboard/firms/_table_empty_trading_names.html.erb
@@ -1,0 +1,18 @@
+<div class="table-wrapper">
+  <table class="l-half-width">
+    <thead>
+      <tr>
+        <th><%= Firm.human_attribute_name(:fca_number) %></th>
+        <th><%= Firm.human_attribute_name(:registered_name)  %></th>
+        <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="t-add-trading-names-prompt" colspan="3">
+          <%= t('dashboard.firms_index.add_trading_names_prompt') %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/firms/_table_parent_firm.html.erb
+++ b/app/views/dashboard/firms/_table_parent_firm.html.erb
@@ -1,0 +1,22 @@
+<div class="table-wrapper">
+  <table class="l-half-width">
+    <thead>
+      <tr>
+        <th><%= Firm.human_attribute_name(:fca_number) %></th>
+        <th><%= Firm.human_attribute_name(:registered_name) %></th>
+        <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="t-parent-firm-table-row">
+        <td class="t-frn"><%= @firm.fca_number %></td>
+        <td class="t-firm-name">
+          <%= link_to edit_dashboard_firm_path(@firm), class: 't-edit-link' do %>
+            <%= @firm.registered_name %>
+          <% end %>
+        </td>
+        <td class="t-principal-name"><%= @firm.principal.full_name %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/firms/_table_trading_names.html.erb
+++ b/app/views/dashboard/firms/_table_trading_names.html.erb
@@ -1,0 +1,24 @@
+<div class="table-wrapper">
+  <table class="l-half-width">
+    <thead>
+      <tr>
+        <th><%= Firm.human_attribute_name(:fca_number) %></th>
+        <th><%= Firm.human_attribute_name(:registered_name)  %></th>
+        <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
+      </tr>
+    </thead>
+    <tbody class="js-filter-rows">
+      <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
+        <tr class="t-trading-name-table-row">
+          <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
+          <td class="js-filterable t-firm-name">
+            <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
+              <%= trading_name.registered_name %>
+            <% end %>
+          </td>
+          <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/firms/index.html.erb
+++ b/app/views/dashboard/firms/index.html.erb
@@ -3,77 +3,17 @@
 
 <div class="l-constrained">
   <h2><%= t('dashboard.firms_index.firm_heading') %></h2>
-  <div class="table-wrapper">
-    <table class="l-half-width">
-      <thead>
-        <tr>
-          <th><%= Firm.human_attribute_name(:fca_number) %></th>
-          <th><%= Firm.human_attribute_name(:registered_name) %></th>
-          <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="t-parent-firm-table-row">
-          <td class="t-frn"><%= @firm.fca_number %></td>
-          <td class="t-firm-name">
-            <%= link_to edit_dashboard_firm_path(@firm), class: 't-edit-link' do %>
-              <%= @firm.registered_name %>
-            <% end %>
-          </td>
-          <td class="t-principal-name"><%= @firm.principal.full_name %></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <%= render 'table_parent_firm' %>
 
   <% if @trading_names.present? || @lookup_names.present? %>
     <div id="firm-list" class="t-trading-names-block" data-dough-component="FilterTable">
       <h2><%= t('dashboard.firms_index.trading_names_heading') %></h2>
+
       <% if @lookup_names.present? %>
-        <div class="table-wrapper">
-          <table class="l-half-width">
-            <thead>
-              <tr>
-                <th><%= Firm.human_attribute_name(:fca_number) %></th>
-                <th><%= Firm.human_attribute_name(:registered_name)  %></th>
-                <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="t-add-trading-names-prompt" colspan="3">
-                  <%= t('dashboard.firms_index.add_trading_names_prompt') %>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <%= render 'table_empty_trading_names' %>
       <% else %>
         <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
-        <div class="table-wrapper">
-          <table class="l-half-width">
-            <thead>
-              <tr>
-                <th><%= Firm.human_attribute_name(:fca_number) %></th>
-                <th><%= Firm.human_attribute_name(:registered_name)  %></th>
-                <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
-              </tr>
-            </thead>
-            <tbody class="js-filter-rows">
-              <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
-                <tr class="t-trading-name-table-row">
-                  <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
-                  <td class="js-filterable t-firm-name">
-                    <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
-                      <%= trading_name.registered_name %>
-                    <% end %>
-                  </td>
-                  <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
+        <%= render 'table_trading_names' %>
       <% end %>
     </div>
   <% end %>
@@ -81,31 +21,9 @@
   <% if @lookup_names.present? %>
     <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="FilterTable">
       <h2><%= t('dashboard.firms_index.available_trading_names_heading') %></h2>
+
       <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.available_trading_names_filter' %>
-      <div class="table-wrapper">
-        <table class="l-half-width">
-          <thead>
-            <tr>
-              <th><%= Firm.human_attribute_name(:fca_number) %></th>
-              <th><%= Firm.human_attribute_name(:registered_name) %></th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody class="js-filter-rows">
-            <% @lookup_names.each do |lookup_name| %>
-              <tr class="t-available-trading-name-table-row">
-                <td class="js-filterable t-frn"><%= lookup_name.fca_number %></td>
-                <td class="js-filterable t-firm-name">
-                  <%= lookup_name.name %>
-                </td>
-                <td>
-                  <%= link_to t('dashboard.firms_index.new_trading_name_link'), new_dashboard_trading_name_path(lookup_id: lookup_name.id), class: 'button button--small t-edit-link' %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+      <%= render 'table_available_trading_names' %>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboard/firms/index.html.erb
+++ b/app/views/dashboard/firms/index.html.erb
@@ -26,38 +26,47 @@
     </table>
   </div>
 
-  <% unless @trading_names.empty? %>
+  <% if @trading_names.present? || @lookup_names.present? %>
     <div id="firm-list" class="t-trading-names-block" data-dough-component="FilterTable">
       <h2><%= t('dashboard.firms_index.trading_names_heading') %></h2>
-      <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
-      <div class="table-wrapper">
-        <table class="l-half-width">
-          <thead>
-            <tr>
-              <th><%= Firm.human_attribute_name(:fca_number) %></th>
-              <th><%= Firm.human_attribute_name(:registered_name)  %></th>
-              <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
-            </tr>
-          </thead>
-          <tbody class="js-filter-rows">
-            <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
-              <tr class="t-trading-name-table-row">
-                <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
-                <td class="js-filterable t-firm-name">
-                  <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
-                    <%= trading_name.registered_name %>
-                  <% end %>
-                </td>
-                <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
+      <% if @lookup_names.present? %>
+        <div class="t-add-trading-names-prompt">
+          <p>
+            You have not added any trading names to the directory. You can add
+            a trading name from the list of available trading names below.
+          </p>
+        </div>
+      <% else %>
+        <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
+        <div class="table-wrapper">
+          <table class="l-half-width">
+            <thead>
+              <tr>
+                <th><%= Firm.human_attribute_name(:fca_number) %></th>
+                <th><%= Firm.human_attribute_name(:registered_name)  %></th>
+                <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody class="js-filter-rows">
+              <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
+                <tr class="t-trading-name-table-row">
+                  <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
+                  <td class="js-filterable t-firm-name">
+                    <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
+                      <%= trading_name.registered_name %>
+                    <% end %>
+                  </td>
+                  <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
     </div>
   <% end %>
 
-  <% unless @lookup_names.empty? %>
+  <% if @lookup_names.present? %>
     <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="FilterTable">
       <h2><%= t('dashboard.firms_index.available_trading_names_heading') %></h2>
       <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.available_trading_names_filter' %>

--- a/app/views/dashboard/firms/index.html.erb
+++ b/app/views/dashboard/firms/index.html.erb
@@ -42,8 +42,7 @@
             <tbody>
               <tr>
                 <td class="t-add-trading-names-prompt" colspan="3">
-                  You have not added any trading names to the directory. You can add
-                  a trading name from the list of available trading names below.
+                  <%= t('dashboard.firms_index.add_trading_names_prompt') %>
                 </td>
               </tr>
             </tbody>

--- a/app/views/dashboard/firms/index.html.erb
+++ b/app/views/dashboard/firms/index.html.erb
@@ -30,11 +30,24 @@
     <div id="firm-list" class="t-trading-names-block" data-dough-component="FilterTable">
       <h2><%= t('dashboard.firms_index.trading_names_heading') %></h2>
       <% if @lookup_names.present? %>
-        <div class="t-add-trading-names-prompt">
-          <p>
-            You have not added any trading names to the directory. You can add
-            a trading name from the list of available trading names below.
-          </p>
+        <div class="table-wrapper">
+          <table class="l-half-width">
+            <thead>
+              <tr>
+                <th><%= Firm.human_attribute_name(:fca_number) %></th>
+                <th><%= Firm.human_attribute_name(:registered_name)  %></th>
+                <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="t-add-trading-names-prompt" colspan="3">
+                  You have not added any trading names to the directory. You can add
+                  a trading name from the list of available trading names below.
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       <% else %>
         <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>

--- a/app/views/dashboard/firms/index.html.erb
+++ b/app/views/dashboard/firms/index.html.erb
@@ -26,61 +26,65 @@
     </table>
   </div>
 
-  <div id="firm-list" data-dough-component="FilterTable">
-    <h2><%= t('dashboard.firms_index.trading_names_heading') %></h2>
-    <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
-    <div class="table-wrapper">
-      <table class="l-half-width">
-        <thead>
-          <tr>
-            <th><%= Firm.human_attribute_name(:fca_number) %></th>
-            <th><%= Firm.human_attribute_name(:registered_name)  %></th>
-            <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
-          </tr>
-        </thead>
-        <tbody class="js-filter-rows">
-          <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
-            <tr class="t-trading-name-table-row">
-              <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
-              <td class="js-filterable t-firm-name">
-                <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
-                  <%= trading_name.registered_name %>
-                <% end %>
-              </td>
-              <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
+  <% unless @trading_names.empty? %>
+    <div id="firm-list" class="t-trading-names-block" data-dough-component="FilterTable">
+      <h2><%= t('dashboard.firms_index.trading_names_heading') %></h2>
+      <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
+      <div class="table-wrapper">
+        <table class="l-half-width">
+          <thead>
+            <tr>
+              <th><%= Firm.human_attribute_name(:fca_number) %></th>
+              <th><%= Firm.human_attribute_name(:registered_name)  %></th>
+              <th><%= t('dashboard.firms_index.principal_column_heading') %></th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody class="js-filter-rows">
+            <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
+              <tr class="t-trading-name-table-row">
+                <td class="js-filterable t-frn"><%= trading_name.fca_number %></td>
+                <td class="js-filterable t-firm-name">
+                  <%= link_to edit_dashboard_trading_name_path(trading_name), class: 't-edit-link' do %>
+                    <%= trading_name.registered_name %>
+                  <% end %>
+                </td>
+                <td class="js-filterable t-principal-name"><%= trading_name.principal.full_name %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  <% end %>
 
-  <div id="trading-name-list" data-dough-component="FilterTable">
-    <h2><%= t('dashboard.firms_index.available_trading_names_heading') %></h2>
-    <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.available_trading_names_filter' %>
-    <div class="table-wrapper">
-      <table class="l-half-width">
-        <thead>
-          <tr>
-            <th><%= Firm.human_attribute_name(:fca_number) %></th>
-            <th><%= Firm.human_attribute_name(:registered_name) %></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody class="js-filter-rows">
-          <% @lookup_names.each do |lookup_name| %>
-            <tr class="t-available-trading-name-table-row">
-              <td class="js-filterable t-frn"><%= lookup_name.fca_number %></td>
-              <td class="js-filterable t-firm-name">
-                <%= lookup_name.name %>
-              </td>
-              <td>
-                <%= link_to t('dashboard.firms_index.new_trading_name_link'), new_dashboard_trading_name_path(lookup_id: lookup_name.id), class: 'button button--small t-edit-link' %>
-              </td>
+  <% unless @lookup_names.empty? %>
+    <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="FilterTable">
+      <h2><%= t('dashboard.firms_index.available_trading_names_heading') %></h2>
+      <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.available_trading_names_filter' %>
+      <div class="table-wrapper">
+        <table class="l-half-width">
+          <thead>
+            <tr>
+              <th><%= Firm.human_attribute_name(:fca_number) %></th>
+              <th><%= Firm.human_attribute_name(:registered_name) %></th>
+              <th></th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody class="js-filter-rows">
+            <% @lookup_names.each do |lookup_name| %>
+              <tr class="t-available-trading-name-table-row">
+                <td class="js-filterable t-frn"><%= lookup_name.fca_number %></td>
+                <td class="js-filterable t-firm-name">
+                  <%= lookup_name.name %>
+                </td>
+                <td>
+                  <%= link_to t('dashboard.firms_index.new_trading_name_link'), new_dashboard_trading_name_path(lookup_id: lookup_name.id), class: 'button button--small t-edit-link' %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -18,6 +18,9 @@ en:
     firms_index:
       firm_heading: Parent Firm
       trading_names_heading: Trading Names
+      add_trading_names_prompt: >-
+        You have not added any trading names to the directory. You can add a
+        trading name from the list of available trading names below.
       available_trading_names_heading: Available Trading Names
       principal_column_heading: Principal
       trading_names_filter_label: "Filter trading names:"

--- a/spec/features/dashboard/firms_index_spec.rb
+++ b/spec/features/dashboard/firms_index_spec.rb
@@ -104,7 +104,8 @@ RSpec.feature 'The dashboard firm list page' do
 
   def and_the_trading_names_section_is_showing_a_prompt_to_add_a_trading_name
     expect(firms_index_page).to have_trading_names_block
-    expect(firms_index_page).to have_add_trading_names_prompt
+    expect(firms_index_page).to have_add_trading_names_prompt(
+      text: I18n.t('dashboard.firms_index.add_trading_names_prompt'))
     expect(firms_index_page).not_to have_trading_names
   end
 end

--- a/spec/features/dashboard/firms_index_spec.rb
+++ b/spec/features/dashboard/firms_index_spec.rb
@@ -28,12 +28,16 @@ RSpec.feature 'The dashboard firm list page' do
 
   def and_i_have_a_firm_with_trading_names
     @lookup_trading_name = FactoryGirl.create(:lookup_subsidiary, fca_number: @principal.fca_number)
-    firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: @principal.fca_number)
+    firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names,
+                                            fca_number: @principal.fca_number,
+                                            registered_name: @principal.lookup_firm.registered_name)
     @principal.firm.update_attributes(firm_attrs)
   end
 
   def and_i_have_a_firm_with_no_trading_names
-    firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: @principal.fca_number)
+    firm_attrs = FactoryGirl.attributes_for(:firm,
+                                            fca_number: @principal.fca_number,
+                                            registered_name: @principal.lookup_firm.registered_name)
     @principal.firm.update_attributes(firm_attrs)
   end
 

--- a/spec/support/dashboard/firms_index_page.rb
+++ b/spec/support/dashboard/firms_index_page.rb
@@ -4,7 +4,9 @@ module Dashboard
     set_url_matcher %r{/dashboard/firms}
 
     section :parent_firm, FirmTableRowSection, '.t-parent-firm-table-row'
+    element :trading_names_block, '.t-trading-names-block'
     sections :trading_names, FirmTableRowSection, '.t-trading-name-table-row'
+    element :available_trading_names_block, '.t-available-trading-names-block'
     sections :available_trading_names, FirmTableRowSection, '.t-available-trading-name-table-row'
   end
 end

--- a/spec/support/dashboard/firms_index_page.rb
+++ b/spec/support/dashboard/firms_index_page.rb
@@ -5,6 +5,7 @@ module Dashboard
 
     section :parent_firm, FirmTableRowSection, '.t-parent-firm-table-row'
     element :trading_names_block, '.t-trading-names-block'
+    element :add_trading_names_prompt, '.t-add-trading-names-prompt'
     sections :trading_names, FirmTableRowSection, '.t-trading-name-table-row'
     element :available_trading_names_block, '.t-available-trading-names-block'
     sections :available_trading_names, FirmTableRowSection, '.t-available-trading-name-table-row'


### PR DESCRIPTION
Adds a message to explain why the trading names table is empty if there are none.
![screen shot 2015-06-12 at 15 54 38 copy](https://cloud.githubusercontent.com/assets/306583/8158059/90a2c2dc-1351-11e5-95c2-4094118abf73.png)

Or hides both the "Trading Names" and "Available Trading Names" sections if there are neither associated with the currently logged in principal/firm.

## Testing Locally

1. Follow the RAD set up instructions in the README.
2. Fire up a Rails console
3. Run the following to create a user/principal who has available trading names but hasn't added any yet:

```ruby
principal = FactoryGirl.create(:principal)
user = FactoryGirl.create(:user, principal: principal)
firm_attrs = FactoryGirl.attributes_for(:firm,
                                        fca_number: principal.fca_number,
                                        registered_name: principal.lookup_firm.registered_name)
principal.firm.update_attributes(firm_attrs)
lookup_trading_name = FactoryGirl.create(:lookup_subsidiary, fca_number: principal.fca_number)
"Log in as #{user.email}"
```

The username is whatever is in `user.email` and the test password from the Factory is `Password1!`.

4. Fire up the local Rails development server 
5. Navigate to [http://localhost:3000/dashboard/firms](http://localhost:3000/dashboard/firms)
