### PR TITLE
On the dashboard, handle the case when no advisers have been added to one or any firms yet

### DIFF
--- a/app/views/dashboard/advisers/_advisers_table.html.erb
+++ b/app/views/dashboard/advisers/_advisers_table.html.erb
@@ -9,20 +9,31 @@
       </tr>
     </thead>
     <tbody>
-      <% advisers.each do |adviser| %>
-        <tr class="t-advisers-table-row">
-          <td class="t-adviser-reference-number"><%= adviser.reference_number %></td>
-          <td class="t-adviser-name">
-            <%= link_to adviser.name, edit_dashboard_firm_adviser_path(adviser.firm, adviser), class: 't-edit-link' %>
+      <% if firm.advisers.present? %>
+        <% firm.advisers.each do |adviser| %>
+          <tr class="t-advisers-table-row">
+            <td class="t-adviser-reference-number"><%= adviser.reference_number %></td>
+            <td class="t-adviser-name">
+              <%= link_to adviser.name, edit_dashboard_firm_adviser_path(adviser.firm, adviser), class: 't-edit-link' %>
+            </td>
+            <td>
+              <ul class="l-comma-separated-list">
+                <% adviser.qualifications.each do |qualification| %>
+                  <li class="t-adviser-qualification"><%= qualification.name %></li>
+                <% end %>
+              </ul>
+            </td>
+            <td class="t-adviser-postcode"><%= adviser.postcode %></td>
+          </tr>
+        <% end %>
+      <% else %>
+        <tr>
+          <td class="t-no-advisers-message" colspan="4">
+            <%= t('dashboard.advisers_index.no_advisers_message') %>
+            <%= link_to(t('dashboard.advisers_index.add_adviser_link', firm_name: firm.registered_name),
+                        new_dashboard_firm_adviser_path(firm),
+                        class: 't-add-adviser-link')  %>
           </td>
-          <td>
-            <ul class="l-comma-separated-list">
-              <% adviser.qualifications.each do |qualification| %>
-                <li class="t-adviser-qualification"><%= qualification.name %></li>
-              <% end %>
-            </ul>
-          </td>
-          <td class="t-adviser-postcode"><%= adviser.postcode %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/dashboard/advisers/index.html.erb
+++ b/app/views/dashboard/advisers/index.html.erb
@@ -8,7 +8,7 @@
 
   <div class="t-parent-firm">
     <h2><%= @firm.registered_name %></h2>
-    <%= render 'dashboard/advisers/advisers_table', advisers: @firm.advisers %>
+    <%= render 'dashboard/advisers/advisers_table', firm: @firm %>
   </div>
 
   <% @trading_names.each do |trading_name| %>
@@ -18,7 +18,7 @@
       </div>
 
       <h2><%= t('dashboard.advisers_index.trading_names_heading', trading_name: trading_name.registered_name) %></h2>
-      <%= render 'dashboard/advisers/advisers_table', advisers: trading_name.advisers %>
+      <%= render 'dashboard/advisers/advisers_table', firm: trading_name %>
     </div>
   <% end %>
 </div>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -13,6 +13,8 @@ en:
       trading_names_heading: "Trading Name: %{trading_name}"
       add_adviser_button: Add an adviser
       add_adviser_button_full: Add an adviser to %{firm_name}
+      add_adviser_link: Add an adviser to %{firm_name}.
+      no_advisers_message: You have not added any advisers to this firm.
 
     adviser_new:
       new_adviser_heading: Add an adviser

--- a/spec/features/dashboard/advisers_index_spec.rb
+++ b/spec/features/dashboard/advisers_index_spec.rb
@@ -10,14 +10,28 @@ RSpec.feature 'The dashboard adviser list page' do
     then_i_can_see_the_advisers_for_each_trading_name
   end
 
+  scenario 'The principal has not added any advisers yet' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_have_a_firm_with_trading_names_and_no_advisers
+    and_i_am_logged_in
+    when_i_am_on_the_principal_dashboard_advisers_page
+    then_the_parent_firm_section_shows_a_prompt_to_add_an_adviser
+    then_each_trading_name_section_shows_a_prompt_to_add_an_adviser
+  end
+
   def given_i_am_a_fully_registered_principal_user
     @principal = FactoryGirl.create(:principal)
     @user = FactoryGirl.create(:user, principal: @principal)
   end
 
-  def and_i_have_a_firm_with_trading_names_and_advisers
+  def and_i_have_a_firm_with_trading_names_and_no_advisers
     firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: @principal.fca_number)
     @principal.firm.update_attributes(firm_attrs)
+  end
+
+  def and_i_have_a_firm_with_trading_names_and_advisers
+    and_i_have_a_firm_with_trading_names_and_no_advisers
+
     @principal.firm.update(advisers: FactoryGirl.create_list(:adviser, 3))
     @principal.firm.trading_names.each do |trading_name|
       trading_name.update(advisers: FactoryGirl.create_list(:adviser, 3))
@@ -41,6 +55,24 @@ RSpec.feature 'The dashboard adviser list page' do
     @principal.firm.trading_names.each.with_index do |trading_name, index|
       trading_name_table = advisers_index_page.trading_names[index]
       expect_table_to_match_advisers(trading_name_table, trading_name.advisers)
+    end
+  end
+
+  def then_the_parent_firm_section_shows_a_prompt_to_add_an_adviser
+    expect(advisers_index_page).to have_parent_firm
+    expect(advisers_index_page.parent_firm).to have_no_advisers_message(
+      text: I18n.t('dashboard.advisers_index.no_advisers_message'))
+    expect(advisers_index_page.parent_firm).to have_add_adviser_link
+  end
+
+  def then_each_trading_name_section_shows_a_prompt_to_add_an_adviser
+    expect(advisers_index_page).to have_trading_names(
+      count: @principal.firm.trading_names.count)
+
+    advisers_index_page.trading_names.each do |trading_name_section|
+      expect(trading_name_section).to have_no_advisers_message(
+        text: I18n.t('dashboard.advisers_index.no_advisers_message'))
+      expect(trading_name_section).to have_add_adviser_link
     end
   end
 

--- a/spec/support/dashboard/advisers_table_section.rb
+++ b/spec/support/dashboard/advisers_table_section.rb
@@ -2,6 +2,8 @@ module Dashboard
   class AdvisersTableSection < SitePrism::Section
     sections :advisers, AdvisersTableRowSection, '.t-advisers-table-row'
 
+    element :add_adviser_link, '.t-add-adviser-link'
     element :edit_link, '.t-edit-link'
+    element :no_advisers_message, '.t-no-advisers-message'
   end
 end


### PR DESCRIPTION
Adds a helpful message to the table of advisers for each firm, when no advisers have been added yet.

![screen shot 2015-06-15 at 14 14 32](https://cloud.githubusercontent.com/assets/306583/8160599/e5e89138-1368-11e5-841a-4b0f308a19c4.png)

## Testing locally

1. Follow the RAD set up instructions in the README.
2. Fire up a Rails console
3. Run the following to create a user/principal who has a firm with trading names but hasn't added any advisers yet:

```ruby
principal = FactoryGirl.create(:principal, fca_number: 999901)
user = FactoryGirl.create(:user, principal: principal)
firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: principal.fca_number)
principal.firm.update_attributes(firm_attrs)
```

The username is whatever is in `user.email` and the test password (from the Factory) is `Password1!`.

4. Fire up the local Rails development server 
5. Navigate to [http://localhost:3000/dashboard/advisers](http://localhost:3000/dashboard/advisers)
