### PR TITLE
Let users log in with FRN or email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,15 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(user)
     stored_location_for(user) || dashboard_root_path
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_in) do |u|
+      u.permit(:login, :password, :remember_me)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,33 @@
 class User < ActiveRecord::Base
   devise :invitable, :database_authenticatable, :recoverable,
          :recoverable, :rememberable, :trackable, :registerable,
-         :secure_validatable, :password_archivable, :password_expirable
+         :secure_validatable, :password_archivable, :password_expirable,
+         authentication_keys: [:login]
 
   validates :email, email: { validate_mx: false, allow_idn: false }
 
   belongs_to :principal, foreign_key: :principal_token
 
   accepts_nested_attributes_for :principal
+
+  attr_accessor :login
+
+  def self.find_for_database_authentication(warden_conditions)
+    conditions = warden_conditions.dup
+    email_or_frn = conditions.delete(:login)
+    return nil unless email_or_frn.present?
+
+    find_user_by_email_or_frn(conditions, email_or_frn: email_or_frn)
+  end
+
+  def self.find_user_by_email_or_frn(conditions, email_or_frn:)
+    where(conditions.to_hash)
+      .joins(:principal)
+      .find_by(
+        [
+          '(lower(users.email) = :email OR principals.fca_number = :fca_number)',
+          { email: email_or_frn.downcase, fca_number: email_or_frn.to_i }
+        ]
+      )
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,17 +9,17 @@
 
   <div class="registration__row">
     <div class="registration__field">
-      <%= f.form_row :email do %>
-        <%= f.errors_for :email %>
-        <%= f.label :email, class: "form__label-heading" %>
-        <%= f.email_field :email, class: 't-email-field', autofocus: true, "aria-describedby" => "tooltip_email" %>
+      <%= f.form_row :login do %>
+        <%= f.errors_for :login %>
+        <%= f.label :login, class: "form__label-heading" %>
+        <%= f.email_field :login, class: 't-login-field', autofocus: true, "aria-describedby" => "tooltip_login" %>
       <% end %>
     </div>
 
     <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_email" data-dough-component="FieldHelpText">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_login" data-dough-component="FieldHelpText">
         <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.email") %></p>
+          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.login") %></p>
         </div>
       </div>
     </div>

--- a/config/locales/authentication.en.yml
+++ b/config/locales/authentication.en.yml
@@ -38,6 +38,7 @@ en:
         register_html: "Get more from your money by <a href=\"%{url}\">registering with the Money Advice Service</a>."
       field_help_texts:
         email: "Enter your email used on registration"
+        login: "Enter your firm reference number or email used on registration"
         password: "Enter your password used on registration"
       forgot_password: "Forgot your password?"
     reset_password_page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
         fca_number: FRN
         registered_name: Registered name
         percent_total: Percentage total
+      user:
+        login: Email or FRN
     errors:
       models:
         firm:

--- a/spec/features/principal_reset_password_spec.rb
+++ b/spec/features/principal_reset_password_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Principal can reset their password' do
 
   def and_sign_in_with_new_details
     visit new_user_session_path
-    sign_in_page.email_field.set @user.email
+    sign_in_page.login_field.set @user.email
     sign_in_page.password_field.set 'new_Password1!'
     sign_in_page.submit_button.click
   end

--- a/spec/features/principal_sign_in_spec.rb
+++ b/spec/features/principal_sign_in_spec.rb
@@ -2,9 +2,16 @@ RSpec.feature 'Principal can sign in' do
   let(:sign_in_page) { SignInPage.new }
   let(:dashboard_page) { Dashboard::DashboardPage.new }
 
-  scenario 'Principal can sign in with correct details' do
+  scenario 'Principal can sign in with email and password' do
     given_the_principal_user_exists
-    when_they_sign_in_with_correct_details
+    when_they_sign_in_with_email_and_password
+    they_see_the_dashboard_page
+    they_have_logged_in
+  end
+
+  scenario 'Principal can sign in with FRN and password' do
+    given_the_principal_user_exists
+    when_they_sign_in_with_frn_and_password
     they_see_the_dashboard_page
     they_have_logged_in
   end
@@ -21,16 +28,23 @@ RSpec.feature 'Principal can sign in' do
     @user = FactoryGirl.create(:user)
   end
 
-  def when_they_sign_in_with_correct_details
+  def when_they_sign_in_with_email_and_password
     sign_in_page.load
-    sign_in_page.email_field.set @user.email
+    sign_in_page.login_field.set @user.email
+    sign_in_page.password_field.set 'Password1!'
+    sign_in_page.submit_button.click
+  end
+
+  def when_they_sign_in_with_frn_and_password
+    sign_in_page.load
+    sign_in_page.login_field.set @user.principal.fca_number
     sign_in_page.password_field.set 'Password1!'
     sign_in_page.submit_button.click
   end
 
   def when_they_sign_in_with_incorrect_details
     sign_in_page.load
-    sign_in_page.email_field.set @user.email
+    sign_in_page.login_field.set @user.email
     sign_in_page.password_field.set 'not_a_password'
     sign_in_page.submit_button.click
   end
@@ -55,6 +69,6 @@ RSpec.feature 'Principal can sign in' do
 
   def and_they_see_a_notice_that_their_details_were_incorrect
     expect(sign_in_page.devise_form_errors).to have_text(
-      I18n.t('devise.failure.invalid', authentication_keys: 'email'))
+      I18n.t('devise.failure.invalid', authentication_keys: 'login'))
   end
 end

--- a/spec/support/sign_in_page.rb
+++ b/spec/support/sign_in_page.rb
@@ -2,7 +2,7 @@ class SignInPage < SitePrism::Page
   set_url '/users/sign_in'
   set_url_matcher %r{/users/sign_in}
 
-  element :email_field, '.t-email-field'
+  element :login_field, '.t-login-field'
   element :password_field, '.t-password-field'
   element :submit_button, '.t-submit-button'
   element :forgot_password_link, '.t-forgot-password'


### PR DESCRIPTION
Sometimes firm principals want to log in with their email, some with their firm reference number.

That's fine, we can do that.