### PR TITLE
Fix double flash message

### DIFF
--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -8,8 +8,12 @@ module SelfService
 
     def update
       @firm = Firm.find(params[:id])
-      @firm.update(firm_params) && flash[:notice] = I18n.t('self_service.firm_edit.saved')
-      render :edit
+      if @firm.update(firm_params)
+        flash[:notice] = I18n.t('self_service.firm_edit.saved')
+        redirect_to_edit
+      else
+        render :edit
+      end
     end
 
     protected
@@ -46,6 +50,14 @@ module SelfService
 
     def firm_params
       params.require(:firm).permit(*FIRM_PARAMS)
+    end
+
+    def redirect_to_edit(firm_id: params[:firm_id])
+      redirect_to(
+        controller: params[:controller],
+        action: :edit,
+        firm_id: firm_id
+      )
     end
   end
 end

--- a/app/controllers/self_service/advisers_controller.rb
+++ b/app/controllers/self_service/advisers_controller.rb
@@ -19,7 +19,7 @@ module SelfService
       # work across mas-rad_core and this codebase.
       if @adviser.save
         flash[:notice] = I18n.t('self_service.adviser_edit.saved')
-        render :edit
+        redirect_to edit_self_service_firm_adviser_path(@firm, @adviser)
       else
         render :new
       end

--- a/app/controllers/self_service/advisers_controller.rb
+++ b/app/controllers/self_service/advisers_controller.rb
@@ -31,9 +31,12 @@ module SelfService
 
     def update
       @adviser = @firm.advisers.find(params[:id])
-      @adviser.update(adviser_params) && flash[:notice] = I18n.t('self_service.adviser_edit.saved')
-
-      render :edit
+      if @adviser.update(adviser_params)
+        flash[:notice] = I18n.t('self_service.adviser_edit.saved')
+        redirect_to edit_self_service_firm_adviser_path(@firm, @adviser)
+      else
+        render :edit
+      end
     end
 
     private

--- a/app/controllers/self_service/trading_names_controller.rb
+++ b/app/controllers/self_service/trading_names_controller.rb
@@ -9,7 +9,7 @@ module SelfService
       @firm.assign_attributes(firm_params)
       if @firm.save
         flash[:notice] = I18n.t('self_service.trading_name_edit.saved')
-        render :edit
+        redirect_to edit_self_service_trading_name_path(@firm)
       else
         render :new
       end

--- a/spec/controllers/selfservice/advisers_controller/create_spec.rb
+++ b/spec/controllers/selfservice/advisers_controller/create_spec.rb
@@ -17,8 +17,9 @@ module SelfService
           expect(assigns(:adviser)).to be_an Adviser
         end
 
-        it 'renders the adviser edit page' do
-          expect(response).to render_template :edit
+        it 'redirects to the adviser edit page' do
+          redirect_path = edit_self_service_firm_adviser_path(firm, assigns(:adviser).id)
+          expect(response).to redirect_to redirect_path
         end
 
         it 'adds a success flash message' do

--- a/spec/controllers/selfservice/advisers_controller/update_spec.rb
+++ b/spec/controllers/selfservice/advisers_controller/update_spec.rb
@@ -17,16 +17,13 @@ module SelfService
         let(:adviser_params) { { postcode: 'AB1 2GH' } }
         before { patch :update, firm_id: firm.id, id: adviser.id, adviser: adviser_params }
 
-        it 'provides the firm to the view' do
-          expect(assigns(:firm)).to eq(firm)
-        end
-
-        it 'provides the adviser to the view' do
-          expect(assigns(:adviser)).to eq(adviser)
-        end
-
         it 'adds a success message after successfully updating the adviser' do
           expect(flash[:notice]).to eq('Saved successfully')
+        end
+
+        it 'redirects to the edit page' do
+          redirect_path = edit_self_service_firm_adviser_path(assigns(:firm), assigns(:adviser))
+          expect(response).to redirect_to redirect_path
         end
       end
     end

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -65,8 +65,9 @@ module SelfService
           expect(firm.reload.email_address).to eq firm_params[:email_address]
         end
 
-        it 'renders the edit page' do
-          expect(response).to render_template 'self_service/firms/edit'
+        it 'redirects to the edit page' do
+          redirect_path = edit_self_service_firm_path(assigns(:firm))
+          expect(response).to redirect_to redirect_path
         end
       end
 

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -58,11 +58,12 @@ module SelfService
         before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
 
         it 'creates the firm' do
-          expect(firm.trading_names.max_by(&:id).email_address).to eq firm_params[:email_address]
+          expect(assigns(:firm).persisted?).to be_truthy
+          expect(assigns(:firm).email_address).to eq firm_params[:email_address]
         end
 
         it 'assigns the firm to the principal’s firm' do
-          expect(firm.trading_names.max_by(&:id).parent_id).to eq firm.id
+          expect(assigns(:firm).parent_id).to eq firm.id
         end
 
         it 'redirects to the edit page' do

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -65,8 +65,9 @@ module SelfService
           expect(firm.trading_names.max_by(&:id).parent_id).to eq firm.id
         end
 
-        it 'renders the edit page' do
-          expect(response).to render_template 'self_service/trading_names/edit'
+        it 'redirects to the edit page' do
+          redirect_path = edit_self_service_trading_name_path(assigns(:firm))
+          expect(response).to redirect_to redirect_path
         end
       end
 


### PR DESCRIPTION
@paulanthonywilson pointed out what I should probably have known — if you set a flash message and then render a view, that flash message will appear twice (first on the page you're rendering, then on the next page when it'll be cleared).

Since we currently render the edit page when we update or create records, we were encountering this. Likewise, if the user hit `#create`, which rendered `:edit`, then hit refresh, unexpected things might happen.

This PR changes some of those renders to redirects, and some of them to use `flash.now`