### PR TITLE
updating advisers filter label and placeholder text

### DIFF
--- a/app/views/dashboard/advisers/index.html.erb
+++ b/app/views/dashboard/advisers/index.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="t-parent-firm">
-    <%= filter_field :trading_names, locale_prefix: 'dashboard.firms_index.trading_names_filter' %>
+    <%= filter_field :trading_names, locale_prefix: 'dashboard.advisers_index.adviser_names_filter' %>
 
     <div data-dough-filter-group>
       <%= render 'dashboard/advisers/advisers_table', firm: @firm %>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -11,6 +11,8 @@ en:
     view_all_firms_link: View all firms
 
     advisers_index:
+      adviser_names_filter_label: "Filter adviser names:"
+      adviser_names_filter_placeholder: e.g. adviser name
       trading_names_heading: "Trading Name: %{trading_name}"
       add_adviser_button: Add an adviser
       add_adviser_button_full: Add an adviser to %{firm_name}


### PR DESCRIPTION
The label and placeholder text were previously pointing to the same label and placeholder text of the trading_names filter.