### PR TITLE
Ensure MultiTableFilter works with multiple tables

### DIFF
--- a/app/assets/javascripts/modules/MultiTableFilter.js
+++ b/app/assets/javascripts/modules/MultiTableFilter.js
@@ -61,7 +61,7 @@ define(['jquery', 'jqueryFastLiveFilter', 'DoughBaseComponent'],
   MultiTableFilterProto.toggleFilterGroups = function() {
     var self = this;
 
-    $(self.config.filterGroupSelector).each(function(_index, filterGroup) {
+    self.$find(self.config.filterGroupSelector).each(function(_index, filterGroup) {
       self.toggleFilterGroup(filterGroup);
     });
   };
@@ -71,7 +71,7 @@ define(['jquery', 'jqueryFastLiveFilter', 'DoughBaseComponent'],
    * @param {HTMLElement} filterGroup Element for table group wrapper
    */
   MultiTableFilterProto.toggleFilterGroup = function(filterGroup) {
-    var $filterGroup = $(filterGroup),
+    var $filterGroup = this.$find(filterGroup),
         $list = $filterGroup.find(this.config.filterListSelector),
         $rows = $list.first().find('tr'),
         hiddenRows;
@@ -96,14 +96,19 @@ define(['jquery', 'jqueryFastLiveFilter', 'DoughBaseComponent'],
    * Binds filter library to text field and table groups
    */
   MultiTableFilterProto.bindFilterToElements = function() {
-    var self = this;
+    var self = this,
+        $filterLists = self.$find(self.config.filterListSelector);
 
-    $(self.config.filterFieldSelector).fastLiveFilter(self.config.filterListSelector, {
+    self.$find(self.config.filterFieldSelector).fastLiveFilter($filterLists, {
       selector: self.config.filterTargetSelector,
       callback: function(total) {
         self.toggleFilterGroups();
       }
     });
+  };
+
+  MultiTableFilterProto.$find = function(selector) {
+    return this.$el.find(selector);
   };
 
   return MultiTableFilter;

--- a/spec/javascripts/fixtures/MultiTableFilter.html
+++ b/spec/javascripts/fixtures/MultiTableFilter.html
@@ -5,11 +5,27 @@
       <thead>
         <tr>
           <th>ID</th>
+        </tr>
+      </thead>
+      <tbody data-dough-filter-rows>
+        <tr>
+          <td data-dough-filterable>1</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="t-group" data-dough-component="MultiTableFilter" data-dough-filter-group>
+    <input class="t-input-field" type="text" data-dough-filter-input>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
           <th>Name</th>
           <th>City</th>
         </tr>
       </thead>
-      <tbody data-dough-filter-rows>
+      <tbody class="t-rows" data-dough-filter-rows>
         <tr>
           <td>1</td>
           <td data-dough-filterable>Alex</td>

--- a/spec/javascripts/tests/MultiTableFilter_spec.js
+++ b/spec/javascripts/tests/MultiTableFilter_spec.js
@@ -2,12 +2,11 @@ describe('filter table based on text field criteria', function () {
   'use strict';
 
   function visibleRows() {
-    return $('[data-dough-filter-rows]').find('tr:visible');
+    return $('.t-rows').find('tr:visible');
   }
 
   function setFilterText(text) {
-    $('[data-dough-filter-input]').val(text);
-    $('[data-dough-filter-input]').change();
+    $('.t-input-field').val(text).change();
   }
 
   describe('on a table', function() {
@@ -16,7 +15,7 @@ describe('filter table based on text field criteria', function () {
 
       requirejs(['jquery', 'MultiTableFilter'], function ($, MultiTableFilter) {
         self.$html = $(window.__html__['spec/javascripts/fixtures/MultiTableFilter.html']).appendTo('body');
-        self.component = self.$html.find('[data-dough-component="MultiTableFilter"]');
+        self.component = self.$html.find('.t-group');
         self.MultiTableFilter = new MultiTableFilter(self.component).init();
 
         done();


### PR DESCRIPTION
Previously we used jQuery to search across the whole document. But we want to restrict our searches to the component — so we're doing that now.

Also changes the specs to test against this scenario by default.