### PR TITLE
Add breadcrumbs and titles consistently

### DIFF
--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,10 +1,15 @@
+<% content_for(:page_title) do
+     t('self_service.adviser_edit.title',
+       adviser_name: @adviser.name,
+       adviser_reference_number: @adviser.reference_number)
+   end %>
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.advisers', url: self_service_advisers_path },
-                        { name: t('self_service.adviser_edit.title', adviser_name: @adviser.name, adviser_reference_number: @adviser.reference_number) }] %>
+                        { name: content_for(:page_title) }] %>
 
 <div class="l-constrained">
   <h1 class="t-firm-name">
-    <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name, adviser_reference_number: @adviser.reference_number) %>
+    <%= content_for(:page_title) %>
   </h1>
 
   <%= form_for @adviser,

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="l-constrained">
   <h1 class="t-firm-name">
-    <%= t('self_service.adviser_edit.edit_adviser_heading') %>
+    <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name, adviser_reference_number: @adviser.reference_number) %>
   </h1>
 
   <%= form_for @adviser,

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,3 +1,7 @@
+<%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
+                        { locale_key: 'self_service.navigation.advisers', url: self_service_advisers_path },
+                        { name: t('self_service.adviser_edit.title', adviser_name: @adviser.name, adviser_reference_number: @adviser.reference_number) }] %>
+
 <div class="l-constrained">
   <h1 class="t-firm-name">
     <%= t('self_service.adviser_edit.edit_adviser_heading') %>

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -5,7 +5,7 @@
 <div class="l-constrained">
 
   <h1 class="t-firm-name">
-    <%= t('self_service.adviser_new.new_adviser_heading') %>
+    <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>
   </h1>
 
   <%= form_for @adviser,

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -1,3 +1,7 @@
+<%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
+                        { locale_key: 'self_service.navigation.advisers', url: self_service_advisers_path },
+                        { name: t('self_service.adviser_new.title', firm_name: @firm.registered_name) }] %>
+
 <div class="l-constrained">
 
   <h1 class="t-firm-name">

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -1,11 +1,12 @@
+<% content_for(:page_title) { t('self_service.adviser_new.title', firm_name: @firm.registered_name) } %>
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.advisers', url: self_service_advisers_path },
-                        { name: t('self_service.adviser_new.title', firm_name: @firm.registered_name) }] %>
+                        { name: content_for(:page_title) }] %>
 
 <div class="l-constrained">
 
   <h1 class="t-firm-name">
-    <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>
+    <%= content_for(:page_title) %>
   </h1>
 
   <%= form_for @adviser,

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -5,11 +5,10 @@
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">
     <h1 class="t-firm-name">
-      <%= @firm.registered_name %>
+      <%= t('self_service.firm_edit.title', firm_name: @firm.registered_name) %>
     </h1>
     <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
   </div>
-
 
   <%= form_for @firm,
                url: self_service_firm_path(@firm),

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -1,11 +1,12 @@
+<% content_for(:page_title) { t('self_service.firm_edit.title', firm_name: @firm.registered_name) } %>
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
-                        { name: t('self_service.firm_edit.title', firm_name: @firm.registered_name) }] %>
+                        { name: content_for(:page_title) }] %>
 
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">
     <h1 class="t-firm-name">
-      <%= t('self_service.firm_edit.title', firm_name: @firm.registered_name) %>
+      <%= content_for(:page_title) %>
     </h1>
     <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
   </div>

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
-                        { name: @firm.registered_name }] %>
+                        { name: t('self_service.firm_edit.title', firm_name: @firm.registered_name) }] %>
 
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">
     <h1 class="t-firm-name">
-      <%= @firm.registered_name %>
+      <%= t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) %>
     </h1>
     <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
   </div>

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -1,11 +1,12 @@
+<% content_for(:page_title) { t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) } %>
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
-                        { name: t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) }] %>
+                        { name: content_for(:page_title) }] %>
 
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">
     <h1 class="t-firm-name">
-      <%= t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) %>
+      <%= content_for(:page_title) %>
     </h1>
     <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
   </div>

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -1,3 +1,7 @@
+<%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
+                        { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
+                        { name: t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) }] %>
+
 <div class="l-constrained">
   <div class="l-heading-with-inline-links">
     <h1 class="t-firm-name">

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -5,7 +5,7 @@
 <div class="l-constrained">
 
   <h1 class="t-firm-name">
-    <%= @firm.registered_name %>
+    <%= t('self_service.trading_name_new.title', firm_name: @firm.registered_name) %>
   </h1>
 
   <%= form_for @firm,

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -1,3 +1,7 @@
+<%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
+                        { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
+                        { name: t('self_service.trading_name_new.title', firm_name: @firm.registered_name) }] %>
+
 <div class="l-constrained">
 
   <h1 class="t-firm-name">

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -1,11 +1,12 @@
+<% content_for(:page_title) { t('self_service.trading_name_new.title', firm_name: @firm.registered_name) } %>
 <%= render_breadcrumbs [{ locale_key: 'self_service.navigation.root', url: self_service_root_path },
                         { locale_key: 'self_service.navigation.firms', url: self_service_firms_path },
-                        { name: t('self_service.trading_name_new.title', firm_name: @firm.registered_name) }] %>
+                        { name: content_for(:page_title) }] %>
 
 <div class="l-constrained">
 
   <h1 class="t-firm-name">
-    <%= t('self_service.trading_name_new.title', firm_name: @firm.registered_name) %>
+    <%= content_for(:page_title) %>
   </h1>
 
   <%= form_for @firm,

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -16,10 +16,12 @@ en:
       no_advisers_message: You have not added any advisers to this firm.
 
     adviser_new:
+      title: "Add an adviser to %{firm_name}"
       new_adviser_heading: Add an adviser
       submit_button: Add adviser
 
     adviser_edit:
+      title: "Edit adviser: %{adviser_name} (%{adviser_reference_number})"
       edit_adviser_heading: Edit adviser
       submit_button: Save adviser
       saved: Saved successfully
@@ -39,6 +41,7 @@ en:
       new_trading_name_link: Add to directory
 
     firm_edit:
+      title: "Edit: %{firm_name}"
       saved: Saved successfully
       trading_name_heading: Trading name
       firm_heading: Firm
@@ -48,7 +51,11 @@ en:
       address_heading: Address
       questionnaire_heading: Questionnaire Responses
 
+    trading_name_new:
+      title: "Add to directory: %{firm_name}"
+
     trading_name_edit:
+      title: "Edit: %{firm_name}"
       saved: Saved successfully
 
     navigation: # name according to route name

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -17,12 +17,10 @@ en:
 
     adviser_new:
       title: "Add an adviser to %{firm_name}"
-      new_adviser_heading: Add an adviser
       submit_button: Add adviser
 
     adviser_edit:
       title: "Edit adviser: %{adviser_name} (%{adviser_reference_number})"
-      edit_adviser_heading: Edit adviser
       submit_button: Save adviser
       saved: Saved successfully
 


### PR DESCRIPTION
Some pages were missing breadcrumbs.

Also updated on-page titles to match the final crumb name.