### PR TITLE
Allow log-in by FRN only.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,20 +14,15 @@ class User < ActiveRecord::Base
 
   def self.find_for_database_authentication(warden_conditions)
     conditions = warden_conditions.dup
-    email_or_frn = conditions.delete(:login)
-    return nil unless email_or_frn.present?
+    fca_number = conditions.delete(:login)
+    return nil unless fca_number.present?
 
-    find_user_by_email_or_frn(conditions, email_or_frn: email_or_frn)
+    find_user_by_fca_number(conditions, fca_number: fca_number)
   end
 
-  def self.find_user_by_email_or_frn(conditions, email_or_frn:)
+  def self.find_user_by_fca_number(conditions, fca_number:)
     where(conditions.to_hash)
       .joins(:principal)
-      .find_by(
-        [
-          '(lower(users.email) = :email OR principals.fca_number = :fca_number)',
-          { email: email_or_frn.downcase, fca_number: email_or_frn.to_i }
-        ]
-      )
+      .find_by(['principals.fca_number = :fca_number', { fca_number: fca_number.to_i }])
   end
 end

--- a/config/locales/authentication.en.yml
+++ b/config/locales/authentication.en.yml
@@ -38,7 +38,7 @@ en:
         register_html: "Get more from your money by <a href=\"%{url}\">registering with the Money Advice Service</a>."
       field_help_texts:
         email: "Enter your email used on registration"
-        login: "Enter your firm reference number or email used on registration"
+        login: "Enter your firm reference number"
         password: "Enter your password used on registration"
       forgot_password: "Forgot your password?"
     reset_password_page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
         registered_name: Registered name
         percent_total: Percentage total
       user:
-        login: Email or FRN
+        login: Firm Reference Number
     errors:
       models:
         firm:

--- a/spec/features/principal_reset_password_spec.rb
+++ b/spec/features/principal_reset_password_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Principal can reset their password' do
 
   def and_sign_in_with_new_details
     visit new_user_session_path
-    sign_in_page.login_field.set @user.email
+    sign_in_page.login_field.set @user.principal.fca_number
     sign_in_page.password_field.set 'new_Password1!'
     sign_in_page.submit_button.click
   end

--- a/spec/features/principal_sign_in_spec.rb
+++ b/spec/features/principal_sign_in_spec.rb
@@ -2,18 +2,19 @@ RSpec.feature 'Principal can sign in' do
   let(:sign_in_page) { SignInPage.new }
   let(:firms_index_page) { SelfService::FirmsIndexPage.new }
 
-  scenario 'Principal can sign in with email and password' do
-    given_the_principal_user_exists
-    when_they_sign_in_with_email_and_password
-    they_see_the_firms_index_page
-    they_have_logged_in
-  end
-
   scenario 'Principal can sign in with FRN and password' do
     given_the_principal_user_exists
     when_they_sign_in_with_frn_and_password
     they_see_the_firms_index_page
     they_have_logged_in
+  end
+
+  scenario 'Principal cannot sign in with email' do
+    given_the_principal_user_exists
+    when_they_sign_in_with_email_and_password
+    they_have_not_logged_in
+    they_see_the_sign_in_page
+    and_they_see_a_notice_that_their_details_were_incorrect
   end
 
   scenario 'Principal cannot sign in with incorrect details' do


### PR DESCRIPTION
Email is no longer allowed, under the logic that the email might change, but the FRN is constant.