### PR TITLE
Simplify breadcrumb titles + tidy ups

### DIFF
--- a/app/helpers/self_service/breadcrumbs_helper.rb
+++ b/app/helpers/self_service/breadcrumbs_helper.rb
@@ -30,7 +30,7 @@ module SelfService
 
     def crumb_trading_name_edit
       {
-        name: t('self_service.trading_name_edit.title', firm_name: @firm.registered_name),
+        name: t('self_service.trading_name_edit.breadcrumb', firm_name: @firm.registered_name),
         url: edit_self_service_trading_name_path(@firm)
       }
     end
@@ -39,32 +39,28 @@ module SelfService
       return crumb_trading_name_edit if @firm.trading_name?
 
       {
-        name: t('self_service.firm_edit.title', firm_name: @firm.registered_name),
+        name: t('self_service.firm_edit.breadcrumb', firm_name: @firm.registered_name),
         url: edit_self_service_firm_path(@firm)
       }
     end
 
     def crumb_firm_advisers
       {
-        name: t('self_service.advisers_index.title', firm_name: @firm.registered_name),
+        name: t('self_service.advisers_index.breadcrumb'),
         url: self_service_firm_advisers_path(@firm)
       }
     end
 
     def crumb_firm_adviser_edit
-      {
-        name: t('self_service.adviser_edit.title',
-                adviser_name: @adviser.name,
-                adviser_reference_number: @adviser.reference_number)
-      }
+      { name: t('self_service.adviser_edit.breadcrumb', adviser_name: @adviser.name) }
     end
 
     def crumb_firm_adviser_new
-      { name: t('self_service.adviser_new.title', firm_name: @firm.registered_name) }
+      { name: t('self_service.adviser_new.breadcrumb') }
     end
 
     def crumb_trading_name_new
-      { name: t('self_service.trading_name_new.title', firm_name: @firm.registered_name) }
+      { name: t('self_service.trading_name_new.breadcrumb', firm_name: @firm.registered_name) }
     end
   end
 end

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -2,9 +2,7 @@
 
 <div class="l-constrained">
   <h1 class="t-firm-name">
-    <%= t('self_service.adviser_edit.title',
-          adviser_name: @adviser.name,
-          adviser_reference_number: @adviser.reference_number) %>
+    <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name) %>
   </h1>
 
   <%= form_for @adviser,

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render_breadcrumbs(breadcrumbs_firm_adviser_edit) %>
 
 <div class="l-constrained">
-  <h1 class="t-firm-name">
+  <h1>
     <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name) %>
   </h1>
 

--- a/app/views/self_service/advisers/index.html.erb
+++ b/app/views/self_service/advisers/index.html.erb
@@ -2,9 +2,9 @@
 
 <div class="l-constrained" data-dough-component="MultiTableFilter">
   <div class="l-heading-with-button">
-    <h2 class="t-firm-name">
+    <h1 class="t-firm-name">
       <%= t('self_service.advisers_index.title', firm_name: @firm.registered_name) %>
-    </h2>
+    </h1>
     <%= add_adviser_button(firm: @firm) %>
   </div>
 

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="l-constrained">
 
-  <h1 class="t-firm-name">
+  <h1>
     <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>
   </h1>
 

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -7,6 +7,7 @@ en:
     save_button: Save
 
     advisers_index:
+      breadcrumb: Advisers
       title: "%{firm_name} Advisers"
       adviser_names_filter_label: "Filter adviser names:"
       adviser_names_filter_placeholder: e.g. adviser name
@@ -17,11 +18,13 @@ en:
       no_advisers_message: You have not added any advisers to this firm.
 
     adviser_new:
+      breadcrumb: Add an adviser
       title: "Add an adviser to %{firm_name}"
       submit_button: Add adviser
 
     adviser_edit:
-      title: "Edit adviser: %{adviser_name} (%{adviser_reference_number})"
+      breadcrumb: "%{adviser_name}"
+      title: "Edit adviser: %{adviser_name}"
       submit_button: Save adviser
       saved: Saved successfully
 
@@ -40,6 +43,7 @@ en:
       new_trading_name_link: Add to directory
 
     firm_edit:
+      breadcrumb: "%{firm_name}"
       title: "Edit: %{firm_name}"
       saved: Saved successfully
       trading_name_heading: Trading name
@@ -51,9 +55,11 @@ en:
       questionnaire_heading: Questionnaire Responses
 
     trading_name_new:
+      breadcrumb: "Add to directory: %{firm_name}"
       title: "Add to directory: %{firm_name}"
 
     trading_name_edit:
+      breadcrumb: "%{firm_name}"
       title: "Edit: %{firm_name}"
       saved: Saved successfully
 


### PR DESCRIPTION
* Normalise all page title to h1
* Simplify the breadcrumb titles (see example screenshots below)

## Before:

![screen shot 2015-06-26 at 10 39 32](https://cloud.githubusercontent.com/assets/306583/8374728/c369d722-1bef-11e5-83d2-a5325e112f2d.png)

## After:

![screen shot 2015-06-26 at 10 39 03](https://cloud.githubusercontent.com/assets/306583/8374734/cabf2fd6-1bef-11e5-9ff2-dc20e33a1b30.png)