### PR TITLE
Bug fix: order the advisers on the self_service advisers index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.59'
+gem 'mas-rad_core', '0.0.60'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.59)
+    mas-rad_core (0.0.60)
       active_model_serializers
       geocoder
       httpclient
@@ -322,7 +322,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.59)
+  mas-rad_core (= 0.0.60)
   oga
   pg
   poltergeist

--- a/app/views/self_service/advisers/_advisers_table.html.erb
+++ b/app/views/self_service/advisers/_advisers_table.html.erb
@@ -15,7 +15,7 @@
       </tr>
     </thead>
     <tbody data-dough-filter-rows>
-      <% advisers.each do |adviser| %>
+      <% advisers.sorted_by_name.each do |adviser| %>
         <tr class="t-advisers-table-row">
           <td class="t-adviser-name" data-dough-filterable>
             <%= link_to adviser.name, edit_self_service_firm_adviser_path(adviser.firm, adviser), class: 't-edit-link' %>

--- a/spec/features/self_service/advisers_index_spec.rb
+++ b/spec/features/self_service/advisers_index_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature 'The self service adviser list page' do
     expect(advisers_index_page).to have_firm_name
     expect(advisers_index_page.firm_name).to have_text(firm.registered_name)
     expect(firm.advisers).not_to be_empty
-    expect_table_to_match_advisers(advisers_index_page, firm.advisers)
+    expect_table_to_match_advisers(advisers_index_page, firm.advisers.sorted_by_name)
   end
 
   def then_there_is_a_prompt_to_add_an_adviser


### PR DESCRIPTION
Running RSpec with random seed 53592 flushed this out.

<strike>So, this fix is inconsistent (which is why I have put in the TODO). The ordering should be pushed back into `mas-rad_core` as scope. This is what we've done for the other models. My rationale for doing this quick and dirty fix is:</strike>

<strike>1. I'd prefer the fix to get in sooner rather than later because it causes random test fails. This was avoids the lead time of making a new mas-rad_core release now.</strike>
<strike>2. Other updates are scheduled for mas-rad_core and adding a relevant scope can be batched with these.</strike>

<strike>Do you agree?</strike>

UPDATE: this has now been redone post-update to mas-rad_core.