### PR TITLE
Adaptive self_service/firms/index

### DIFF
--- a/app/controllers/self_service/firms_controller.rb
+++ b/app/controllers/self_service/firms_controller.rb
@@ -6,6 +6,8 @@ module SelfService
       @lookup_names = Lookup::Subsidiary.where(fca_number: @firm.fca_number).reject do |lookup_name|
         @trading_names.map(&:registered_name).include? lookup_name.name
       end
+
+      @presenter = FirmsIndexPresenter.new(@firm, @trading_names, @lookup_names)
     end
   end
 end

--- a/app/controllers/self_service/firms_controller.rb
+++ b/app/controllers/self_service/firms_controller.rb
@@ -1,13 +1,13 @@
 module SelfService
   class FirmsController < AbstractFirmsController
     def index
-      @firm = principal.firm
-      @trading_names = @firm.trading_names.registered
-      @lookup_names = Lookup::Subsidiary.where(fca_number: @firm.fca_number).reject do |lookup_name|
-        @trading_names.map(&:registered_name).include? lookup_name.name
+      firm = principal.firm
+      trading_names = firm.trading_names.registered
+      lookup_names = Lookup::Subsidiary.where(fca_number: firm.fca_number).reject do |lookup_name|
+        trading_names.map(&:registered_name).include? lookup_name.name
       end
 
-      @presenter = FirmsIndexPresenter.new(@firm, @trading_names, @lookup_names)
+      @presenter = FirmsIndexPresenter.new(firm, trading_names, lookup_names)
     end
   end
 end

--- a/app/presenters/self_service/firms_index_presenter.rb
+++ b/app/presenters/self_service/firms_index_presenter.rb
@@ -1,0 +1,19 @@
+module SelfService
+  FirmsIndexPresenter = Struct.new(:firm, :trading_names, :lookup_names) do
+    def firm_has_trading_names?
+      trading_names.present? || lookup_names.present?
+    end
+
+    def total_firms
+      1 + trading_names.count + lookup_names.count
+    end
+
+    def no_trading_names_have_been_added?
+      trading_names.empty?
+    end
+
+    def trading_names_are_available_to_add?
+      lookup_names.present?
+    end
+  end
+end

--- a/app/views/self_service/firms/_table_available_trading_names.html.erb
+++ b/app/views/self_service/firms/_table_available_trading_names.html.erb
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody data-dough-filter-rows>
-      <% @lookup_names.each do |lookup_name| %>
+      <% @presenter.lookup_names.each do |lookup_name| %>
         <tr class="t-available-trading-name-table-row">
           <td class="t-firm-name" data-dough-filterable>
             <%= lookup_name.name %>

--- a/app/views/self_service/firms/_table_parent_firm.html.erb
+++ b/app/views/self_service/firms/_table_parent_firm.html.erb
@@ -16,12 +16,12 @@
     <tbody>
       <tr class="t-parent-firm-table-row">
         <td class="t-firm-name">
-          <%= link_to edit_self_service_firm_path(@firm), class: 't-edit-link' do %>
-            <%= @firm.registered_name %>
+          <%= link_to edit_self_service_firm_path(@presenter.firm), class: 't-edit-link' do %>
+            <%= @presenter.firm.registered_name %>
           <% end %>
         </td>
-        <td class="t-frn"><%= @firm.fca_number %></td>
-        <td class="t-principal-name"><%= @firm.principal.full_name %></td>
+        <td class="t-frn"><%= @presenter.firm.fca_number %></td>
+        <td class="t-principal-name"><%= @presenter.firm.principal.full_name %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/self_service/firms/_table_trading_names.html.erb
+++ b/app/views/self_service/firms/_table_trading_names.html.erb
@@ -17,7 +17,7 @@
       </tr>
     </thead>
     <tbody data-dough-filter-rows>
-      <% @trading_names.sorted_by_registered_name.each do |trading_name| %>
+      <% @presenter.trading_names.sorted_by_registered_name.each do |trading_name| %>
         <tr class="t-trading-name-table-row">
           <td class="t-firm-name" data-dough-filterable>
             <%= link_to edit_self_service_trading_name_path(trading_name), class: 't-edit-link' do %>

--- a/app/views/self_service/firms/index.html.erb
+++ b/app/views/self_service/firms/index.html.erb
@@ -1,7 +1,14 @@
 <%= render_breadcrumbs(breadcrumbs_root) %>
 
 <div class="l-self-service">
-  <h2><%= t('self_service.firms_index.firm_heading') %></h2>
+  <h1 class="t-page-title">
+    <%= t('self_service.firms_index.title', count: (1 + @trading_names.count + @lookup_names.count)) %>
+  </h1>
+
+  <% if @trading_names.present? || @lookup_names.present? %>
+    <h2 class="t-parent-firm-heading"><%= t('self_service.firms_index.firm_heading') %></h2>
+  <% end %>
+
   <%= render 'table_parent_firm' %>
 
   <% if @trading_names.present? || @lookup_names.present? %>

--- a/app/views/self_service/firms/index.html.erb
+++ b/app/views/self_service/firms/index.html.erb
@@ -2,20 +2,20 @@
 
 <div class="l-self-service">
   <h1 class="t-page-title">
-    <%= t('self_service.firms_index.title', count: (1 + @trading_names.count + @lookup_names.count)) %>
+    <%= t('self_service.firms_index.title', count: @presenter.total_firms) %>
   </h1>
 
-  <% if @trading_names.present? || @lookup_names.present? %>
+  <% if @presenter.firm_has_trading_names? %>
     <h2 class="t-parent-firm-heading"><%= t('self_service.firms_index.firm_heading') %></h2>
   <% end %>
 
   <%= render 'table_parent_firm' %>
 
-  <% if @trading_names.present? || @lookup_names.present? %>
+  <% if @presenter.firm_has_trading_names? %>
     <div id="firm-list" class="t-trading-names-block" data-dough-component="MultiTableFilter">
       <h2><%= t('self_service.firms_index.trading_names_heading') %></h2>
 
-      <% if @trading_names.empty? %>
+      <% if @presenter.no_trading_names_have_been_added? %>
         <p class="t-add-trading-names-prompt">
           <%= t('self_service.firms_index.add_trading_names_prompt') %>
         </p>
@@ -26,7 +26,7 @@
     </div>
   <% end %>
 
-  <% if @lookup_names.present? %>
+  <% if @presenter.trading_names_are_available_to_add? %>
     <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="MultiTableFilter">
       <h2><%= t('self_service.firms_index.available_trading_names_heading') %></h2>
 

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -34,6 +34,9 @@ en:
       deleted: "%{name} has been successfully removed."
 
     firms_index:
+      title:
+        one: Firm
+        other: Firms
       firm_heading: Parent Firm
       trading_names_heading: Trading Names
       add_trading_names_prompt: >-

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -28,7 +28,7 @@ module SelfService
       context 'when all trading names are registered' do
         it 'assigns all trading names' do
           get :index
-          expect(assigns(:trading_names).count).to eq 3
+          expect(assigns(:presenter).trading_names.count).to eq 3
         end
       end
 
@@ -41,7 +41,7 @@ module SelfService
 
         it 'assigns only registered trading names' do
           get :index
-          expect(assigns(:trading_names).count).to eq 2
+          expect(assigns(:presenter).trading_names.count).to eq 2
         end
       end
     end

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -20,6 +20,11 @@ module SelfService
     end
 
     describe 'GET #index' do
+      it 'creates and assigns the presenter' do
+        get :index
+        expect(assigns(:presenter)).to be_a SelfService::FirmsIndexPresenter
+      end
+
       context 'when all trading names are registered' do
         it 'assigns all trading names' do
           get :index

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -28,7 +28,7 @@ module SelfService
       context 'when all trading names are registered' do
         it 'assigns all trading names' do
           get :index
-          expect(assigns(:presenter).trading_names.count).to eq 3
+          expect(assigns(:presenter)).to have(3).trading_names
         end
       end
 
@@ -41,7 +41,7 @@ module SelfService
 
         it 'assigns only registered trading names' do
           get :index
-          expect(assigns(:presenter).trading_names.count).to eq 2
+          expect(assigns(:presenter)).to have(2).trading_names
         end
       end
     end

--- a/spec/features/self_service/firms_index_spec.rb
+++ b/spec/features/self_service/firms_index_spec.rb
@@ -9,6 +9,8 @@ RSpec.feature 'The self service firm list page' do
     then_i_can_see_the_parent_firm_i_am_associated_with
     and_i_can_see_the_list_of_trading_names_i_am_associated_with
     and_i_can_see_the_list_of_available_trading_names
+    and_the_page_title_indicates_a_plural
+    and_the_parent_firm_section_heading_is_visible
   end
 
   scenario 'When there are no added or available trading names' do
@@ -19,6 +21,8 @@ RSpec.feature 'The self service firm list page' do
     then_i_can_see_the_parent_firm_i_am_associated_with
     and_the_trading_names_block_is_not_shown
     and_the_available_trading_names_block_is_not_shown
+    and_the_page_title_indicates_a_singular
+    and_the_parent_firm_section_heading_is_not_visible
   end
 
   scenario 'When there are available trading names but none have been added' do
@@ -29,6 +33,8 @@ RSpec.feature 'The self service firm list page' do
     then_i_can_see_the_parent_firm_i_am_associated_with
     and_the_trading_names_section_is_showing_a_prompt_to_add_a_trading_name
     and_i_can_see_the_list_of_available_trading_names
+    and_the_page_title_indicates_a_plural
+    and_the_parent_firm_section_heading_is_visible
   end
 
   scenario 'The principal can delete trading names' do
@@ -140,6 +146,25 @@ RSpec.feature 'The self service firm list page' do
   def and_i_cannot_see_the_deleted_trading_name
     firms = firms_index_page.trading_names
     expect(firms.any? { |a| a.name.text == @trading_name_registered_name_to_delete }).to be_falsey
+  end
+
+  def and_the_page_title_indicates_a_plural
+    plural_form = I18n.t!('self_service.firms_index.title', count: 2)
+    expect(firms_index_page.page_title).to have_text(/^#{plural_form}$/)
+  end
+
+  def and_the_page_title_indicates_a_singular
+    singular_form = I18n.t!('self_service.firms_index.title', count: 1)
+    expect(firms_index_page.page_title).to have_text(/^#{singular_form}$/)
+  end
+
+  def and_the_parent_firm_section_heading_is_visible
+    expect(firms_index_page.parent_firm_heading)
+      .to have_text(I18n.t!('self_service.firms_index.firm_heading'))
+  end
+
+  def and_the_parent_firm_section_heading_is_not_visible
+    expect(firms_index_page).not_to have_parent_firm_heading
   end
 
   private

--- a/spec/presenters/self_service/firms_index_presenter_spec.rb
+++ b/spec/presenters/self_service/firms_index_presenter_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe SelfService::FirmsIndexPresenter do
+  let(:trading_names) { [] }
+  let(:lookup_names) { [] }
+
+  describe '#firm_has_trading_names?' do
+    subject { described_class.new(nil, trading_names, lookup_names).firm_has_trading_names? }
+
+    context 'when both `trading_names` and `lookup_names` are empty' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when both `trading_names` and `lookup_names` are not empty' do
+      let(:trading_names) { [:thing] }
+      let(:lookup_names) { [:thing] }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when `trading_names` is not empty and `lookup_names` is empty' do
+      let(:trading_names) { [:thing] }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when `trading_names` is empty and `lookup_names` is not empty' do
+      let(:lookup_names) { [:thing] }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#total_firms' do
+    subject { described_class.new(nil, trading_names, lookup_names).total_firms }
+
+    context 'when both `trading_names` and `lookup_names` are empty' do
+      it { is_expected.to eq(1) }
+    end
+
+    context 'when `trading_names` and `lookup_names` contain one element each' do
+      let(:trading_names) { [:thing] }
+      let(:lookup_names) { [:thing] }
+      it { is_expected.to eq(3) }
+    end
+
+    context 'when `trading_names` contains one element and `lookup_names` is empty' do
+      let(:trading_names) { [:thing] }
+      it { is_expected.to eq(2) }
+    end
+
+    context 'when `trading_names` is empty and `lookup_names` contains one element' do
+      let(:lookup_names) { [:thing] }
+      it { is_expected.to eq(2) }
+    end
+  end
+
+  describe '#no_trading_names_have_been_added?' do
+    subject { described_class.new(nil, trading_names, lookup_names).no_trading_names_have_been_added? }
+    context 'when `trading_names` is empty' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when `trading_names` is not empty' do
+      let(:trading_names) { [:thing] }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#trading_names_are_available_to_add?' do
+    subject { described_class.new(nil, trading_names, lookup_names).trading_names_are_available_to_add? }
+    context 'when `lookup_names` is empty' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when `lookup_names` is not empty' do
+      let(:lookup_names) { [:thing] }
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/support/self_service/firms_index_page.rb
+++ b/spec/support/self_service/firms_index_page.rb
@@ -4,6 +4,8 @@ module SelfService
     set_url_matcher %r{/self_service/firms}
 
     element :flash_message, '.t-flash-message'
+    element :page_title, '.t-page-title'
+    element :parent_firm_heading, '.t-parent-firm-heading'
     section :parent_firm, FirmTableRowSection, '.t-parent-firm-table-row'
     element :trading_names_block, '.t-trading-names-block'
     element :add_trading_names_prompt, '.t-add-trading-names-prompt'


### PR DESCRIPTION
* Makes the self_service/firm/index adapt depending on whether there are trading names or not
* Factors out some logic into a presenter

Below left is the page when there are trading names, on the right there are none so the additional headings disappear and the page title becomes 'Firm' singular.

![screen shot 2015-06-26 at 14 44 55](https://cloud.githubusercontent.com/assets/306583/8406248/70c4733c-1e52-11e5-91bd-4cf71c9c6a05.png)
