### PR TITLE
Fix self-service navigation.

### DIFF
--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -2,26 +2,22 @@
   @extend .unstyled-list;
   text-align: right;
   margin-top: 22px;
+  padding-right: 0.5em;
 }
 
 %navigation-item {
   @include inline-block;
   line-height: 1;
-  border-right: 1px solid $color-primary-nav;
-  padding: 0 $baseline-unit*1.5 0 $baseline-unit*0.7;
+  border-left: 1px solid $color-primary-nav;
+  padding: 0 .25em 0 .5em;
 }
 
 .navigation__item {
   @extend %navigation-item;
 }
 
-.navigation__item--last {
-  @extend %navigation-item;
-  border-right: 0;
-
-  @include respond-to($mq-m) {
-    border-right: 1px solid $color-primary-nav;
-  }
+.navigation__item:first-child {
+  border-left: 0;
 }
 
 .navigation__item--desktop-only {
@@ -31,15 +27,6 @@
   @include respond-to($mq-m) {
     @include inline-block;
   }
-}
-
-.navigation__item--desktop-only--last {
-  @extend .navigation__item--desktop-only;
-  border-right: 0;
-}
-
-.navigation__item-divider {
-  margin: 0 $baseline-unit;
 }
 
 .navigation__link,

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -4,17 +4,17 @@
       <li class='navigation__item'>
         <%= link_to t('authentication_sign_in'), new_user_session_path, class: 'navigation__link t-sign-in' %>
       </li>
-      <li class='navigation__item--last'>
+      <li class='navigation__item'>
         <%= link_to t('authentication_sign_up'), register_path, class: 'navigation__link' %>
       </li>
     <% else %>
       <li class='navigation__item'>
         <%= link_to t('self_service.navigation.firms'), self_service_firms_path, class: 'navigation__link t-navigation-link' %>
       </li>
-      <li class='navigation__item--last'>
+      <li class='navigation__item'>
         <%= link_to t('authentication_sign_out'), destroy_user_session_path, class: 'navigation__link t-sign-out' %>
       </li>
-      <li class='navigation__item--desktop-only--last'>
+      <li class='navigation__item--desktop-only'>
         <%= link_to t('authentication_change_password'), edit_user_registration_path(current_user), class: 'navigation__link' %>
       </li>
     <% end %>


### PR DESCRIPTION
I accidentally forgot to check signed out desktop and so it looked odd.
This is cleaner anyway, but does rely on you not needing to hide the
first navigation item.

Perfect solution would be JS or some sort of future CSS but this will do.