### PR TITLE
Configure / to redirect to the self_service root when a user is signed-in

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,15 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
   devise_for :users
-  root 'principals#pre_qualification_form'
+
+  unauthenticated do
+    root 'principals#pre_qualification_form'
+  end
+
+  authenticated do
+    # This root is given an explicit name to prevent a root route name collision
+    root to: redirect('/self_service/'), as: :authenticated_root
+  end
 
   get 'error', to: 'pages#error'
 

--- a/spec/features/root_routing_spec.rb
+++ b/spec/features/root_routing_spec.rb
@@ -1,0 +1,26 @@
+#
+# A routing test implemented as a feature. This is necessary so we can fake
+# logins.
+# See: https://github.com/plataformatec/devise/issues/1670#issuecomment-4060164
+#
+
+RSpec.describe 'GET /', type: :feature do
+  context 'when not logged in' do
+    it 'routes to the root_path' do
+      visit '/'
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context 'when logged in to the self_service area' do
+    let(:user) { FactoryGirl.create(:user, principal: principal) }
+    let(:principal) { FactoryGirl.create(:principal) }
+
+    before { login_as(user, scope: :user) }
+
+    it 'redirects to /self_service/firms' do
+      visit '/'
+      expect(current_path).to eq(self_service_firms_path)
+    end
+  end
+end


### PR DESCRIPTION
Had to implement the test as a feature and use Capybara so that sign-in could be faked. See comment in spec header.