### PR TITLE
Show '* Indicates required fields' on the self_service forms

### DIFF
--- a/app/views/self_service/advisers/_form.html.erb
+++ b/app/views/self_service/advisers/_form.html.erb
@@ -1,3 +1,5 @@
+<p><%= t('self_service.required_fields_message') %></p>
+
 <div class="t-validation-summary">
   <%= f.validation_summary %>
 </div>

--- a/app/views/self_service/firms/_form.html.erb
+++ b/app/views/self_service/firms/_form.html.erb
@@ -1,3 +1,5 @@
+<p><%= t('self_service.required_fields_message') %></p>
+
 <% if @firm.errors.any? %>
   <div class="t-validation-summary">
     <%= f.validation_summary %>

--- a/app/views/self_service/principals/_form.html.erb
+++ b/app/views/self_service/principals/_form.html.erb
@@ -1,4 +1,6 @@
 <div class="l-half-width">
+  <p><%= t('self_service.required_fields_message') %></p>
+
   <% if f.object.errors.any? %>
     <div class="t-validation-summary">
       <%= f.validation_summary %>

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -5,6 +5,7 @@ en:
     add_trading_name_button: Add a trading name
     cancel_button: Cancel
     save_button: Save
+    required_fields_message: "* Indicates required fields"
 
     advisers_index:
       breadcrumb: Advisers


### PR DESCRIPTION
Based on the example in the [MAS style guide](https://www.moneyadviceservice.org.uk/en/styleguide/forms).

E.g.

![screen shot 2015-07-01 at 17 25 13](https://cloud.githubusercontent.com/assets/306583/8459594/4f586238-2016-11e5-8850-d69184737442.png)
