### PR TITLE
Style tweaks

### DIFF
--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -1,6 +1,6 @@
 .navigation {
   @extend .unstyled-list;
-  text-align: right;
+  float: right;
   margin-top: 22px;
   padding-right: 0.5em;
 }

--- a/app/assets/stylesheets/layouts/_heading_with_action.scss
+++ b/app/assets/stylesheets/layouts/_heading_with_action.scss
@@ -1,22 +1,38 @@
 %heading-with-action {
   @include clearfix();
   @extend %heading-medium;
+  position: relative;
   font-size: inherit;
   font-weight: inherit;
+
 
   h1,
   h2,
   h3 {
-    float: left;
     margin: 0;
+    margin-bottom: $baseline-unit*2;
+
+    @include respond-to($mq-m) {
+      margin-bottom: 0;
+      float: left;
+    }
   }
 }
 
 .l-heading-with-button {
   @extend %heading-with-action;
 
-  .button {
-    float: right;
+  @include respond-to($mq-m) {
+    h1,
+    h2,
+    h3 {
+        padding-right: 5em;
+    }
+
+    .button {
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
   }
 }
-

--- a/app/assets/stylesheets/layouts/heading_with_inline_links.scss
+++ b/app/assets/stylesheets/layouts/heading_with_inline_links.scss
@@ -2,12 +2,22 @@
   // Only supports h1 ~ ul
   @extend %heading-with-action;
 
+  h1,
+  h2,
+  h3 {
+    @include respond-to($mq-m) {
+      margin-right: 0.5em;
+    }
+  }
+
   ul {
     @extend .unstyled-list;
-    display: inline-block;
-    padding-top: 18px;
-    margin-bottom: 0;
-    margin-left: 1em;
+
+    @include respond-to($mq-m) {
+      display: inline-block;
+      padding-top: 18px;
+      margin-bottom: 0;
+    }
 
     li {
       font-size: 1.25rem;


### PR DESCRIPTION
'Floats' commit fixes this bug in Safari: 

![image](https://cloud.githubusercontent.com/assets/1007202/8525356/44a21d26-23f8-11e5-9777-6139a669f68c.png)

---

'Headings' commit fixes this situation:

![image](https://cloud.githubusercontent.com/assets/1007202/8525397/84de3686-23f8-11e5-9f4f-680a2bb4e512.png)

After:

![image](https://cloud.githubusercontent.com/assets/1007202/8525406/93b94376-23f8-11e5-9ed8-fa67ffebc31f.png)

@spencer mentioned a way of doing this using table css, but I couldn't find a way that didn't introduce lots of wrapping divs that I'd rather avoid. This solution assumes buttons are narrower than a certain width (5em in title font) though, so alternative opinions encouraged here.
