### PR TITLE
Enable `pg_stat_statements` in schema.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20150630143001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false


### PR DESCRIPTION
Something has been adding this for ages, and since it's default on heroku and doesn't seem to have any negative effects let's check it in.