### PR TITLE
Amend 'Add trading name' forms to handle pre-existing record.

### DIFF
--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -19,5 +19,10 @@ module SelfService
         concat content_tag(:span, sr_label, class: 'visually-hidden')
       end
     end
+
+    def create_or_update_self_service_trading_names_path(firm)
+      return self_service_trading_name_path(firm) if firm.persisted?
+      self_service_trading_names_path
+    end
   end
 end

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -7,7 +7,7 @@
   </h1>
 
   <%= form_for @firm,
-               url: self_service_trading_names_path(@firm),
+               url: create_or_update_self_service_trading_names_path(@firm),
                builder: Dough::Forms::Builders::Validation,
                html: { class: 'form' } do |f| %>
 

--- a/spec/helpers/self_service/self_service_helper_spec.rb
+++ b/spec/helpers/self_service/self_service_helper_spec.rb
@@ -1,0 +1,23 @@
+module SelfService
+  RSpec.describe SelfServiceHelper, type: :helper do
+    describe '#add_or_edit_self_service_trading_names_path' do
+      subject { helper.create_or_update_self_service_trading_names_path(trading_name) }
+
+      context 'the trading name is an existing record' do
+        let(:trading_name) { FactoryGirl.create(:trading_name) }
+
+        it 'returns the create path' do
+          expect(subject).to eq self_service_trading_name_path(trading_name)
+        end
+      end
+
+      context 'the trading name is an existing record' do
+        let(:trading_name) { FactoryGirl.build(:trading_name) }
+
+        it 'returns the create path' do
+          expect(subject).to eq self_service_trading_names_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've got a situation where there are a number of incomplete records in the database. This causes a number of interesting phenomena. In this instance, we look to see if there's an incomplete copy of our requested firm first and use it if it's there. Otherwise we'd need to delete it, because we'd have a dupe.

Our forms weren't written to expect this, so when the 'new' form was passed an existing record it created an unusual URL. To avoid this, we point the form to the edit action if the record is persisted, and the create action if it's new.