### PR TITLE
Fix layout bug in legend tags in IE

### DIFF
--- a/app/assets/stylesheets/layouts/_questionnaire.scss
+++ b/app/assets/stylesheets/layouts/_questionnaire.scss
@@ -42,6 +42,7 @@
   @include body(18,24);
   font-weight: 700;
   color: $color-green-secondary;
+  width: 100%;
 
   + p {
     // CSS bug fix


### PR DESCRIPTION
The legend tags overflowed their containers and ran amok. This handy width property sorts it all out.

Legend tags seem to have unexpected behaviour in IE (even 11). We might use them with care in future.

Before:
![image](https://cloud.githubusercontent.com/assets/1007202/8699821/2a7ae734-2b00-11e5-975f-2bd5c921feb0.png)


After:
![image](https://cloud.githubusercontent.com/assets/1007202/8699812/1b579496-2b00-11e5-9519-7f53891837b4.png)
