### PR TITLE
change rake task to produce csv list of principals to invite

### DIFF
--- a/lib/tasks/existing_firms_sign_up_task.rb
+++ b/lib/tasks/existing_firms_sign_up_task.rb
@@ -1,22 +1,32 @@
 module Tasks
   class ExistingFirmsSignUpTask
-    def self.notify
+    def self.notify(inviter, output = STDOUT)
       valid_registered_parent_firms.each do |firm|
         principal = firm.principal
         user = User.find_by_principal_token principal.token
+        next if user.present?
 
-        if user.nil?
-          invite principal
-        elsif user.invited_to_sign_up? && !user.invitation_accepted?
-          user.invite!
-        end
+        user = invite principal
+        output << CSV.generate_line(build_csv_data(inviter, user, firm))
       end
+    end
+
+    def self.build_csv_data(inviter, user, firm)
+      result = []
+      result << firm.fca_number
+      result << firm.registered_name
+      result << user.principal.full_name
+      result << user.principal.email_address
+      result << inviter.invitation_url(user)
+      result
     end
 
     def self.invite(principal)
       User.invite!(
         principal_token: principal.token,
-        email: principal.email_address
+        email: principal.email_address,
+        skip_invitation: true,
+        invitation_sent_at: DateTime.current
       )
     end
 

--- a/lib/tasks/export_existing_firms_without_accounts.rake
+++ b/lib/tasks/export_existing_firms_without_accounts.rake
@@ -1,0 +1,6 @@
+namespace :principals do
+  desc 'existing firms needing notified to sign up'
+  task generate_invitations_csv: :environment do
+    Tasks::ExistingFirmsSignUpTask.notify(Tasks::UserInvitationHelper.new)
+  end
+end

--- a/lib/tasks/notify_existing_firms_without_accounts.rake
+++ b/lib/tasks/notify_existing_firms_without_accounts.rake
@@ -1,7 +1,0 @@
-
-namespace :notify do
-  desc 'existing firms need notified to sign up'
-  task existing_firms_to_sign_up: :environment do
-    Tasks::ExistingFirmsSignUpTask.notify
-  end
-end

--- a/lib/tasks/user_invitation_helper.rb
+++ b/lib/tasks/user_invitation_helper.rb
@@ -1,0 +1,9 @@
+module Tasks
+  class UserInvitationHelper
+    def invitation_url(user)
+      app = Rails.application
+      host = app.config.action_mailer.default_url_options[:host]
+      app.routes.url_helpers.accept_user_invitation_url(invitation_token: user.raw_invitation_token, host: host)
+    end
+  end
+end

--- a/spec/lib/tasks/user_invitation_helper_spec.rb
+++ b/spec/lib/tasks/user_invitation_helper_spec.rb
@@ -1,0 +1,15 @@
+module Tasks
+  RSpec.describe UserInvitationHelper do
+    describe '#invitation_url' do
+      it 'generates the invitation_url' do
+        user = User.new
+
+        Rails.application.config.action_mailer.default_url_options[:host] = 'example.com'
+        allow(user).to receive(:raw_invitation_token).and_return('my_raw_invite_token')
+
+        expected_url = 'http://example.com/users/invitation/accept?invitation_token=my_raw_invite_token'
+        expect(subject.invitation_url(user)).to eq(expected_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is to update/replace the existing rake task which would previously invite firms without an account in RAD to create one.

This process is changing so that MailChimp (or similar service) can be used for sending and tracking the invitations. 

The PR is to change the rake task so that it now returns CSV output that can easily be used with MailChimp.