### PR TITLE
Update seed data and provide a way to migrate live data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,5 +67,7 @@ end
   'Certified Financial Planner',
   'Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent',
   'Equity release qualifications i.e. holder of Certificate in Equity Release or equivalent',
-  'Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent'
+  'Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent',
+  'Holder of Trust and Estate Practitioner qualification (TEP) i.e. full member of STEP',
+  'Fellow of the Chartered Insurance Institute (FCII)'
 ].each.with_index(1) { |item, index| Qualification.find_or_create_by(name: item, order: index) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,10 +62,10 @@ end
 
 [
   'Level 4 (DipPFS, DipFA® or equivalent)',
-  'Level 6 Diploma in Financial Advice (Adv DipFA®)',
+  'Level 6 (APFS, Adv DipFA®)',
   'Chartered Financial Planner',
   'Certified Financial Planner',
-  'Pension transfer qualifications - holder of G60, AF3 or equivalent',
+  'Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent',
   'Equity release qualifications i.e. holder of Certificate in Equity Release or equivalent',
-  'Long term care planning qualifications i.e. holder of CF8 or equivalent'
+  'Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent'
 ].each.with_index(1) { |item, index| Qualification.find_or_create_by(name: item, order: index) }

--- a/lib/tasks/update_qualifications.rake
+++ b/lib/tasks/update_qualifications.rake
@@ -1,0 +1,43 @@
+namespace :data do
+  namespace :migrate do
+    def change_type(record)
+      if record.new_record?
+        '+ Adding   '
+      elsif record.name_changed?
+        '! Changing '
+      else
+        '  No change'
+      end
+    end
+
+    desc 'Migrate qualifications data in an existing database'
+    task qualifications: :environment do
+      # This is a snapshot of the seed data at the time this task was written
+      seed_data_snapshot = {
+        # We lookup each by the 'order' attribute rather than id, as this field
+        # is guaranteed to be consistent because it is used to map to translations
+        # in rad_consumer
+        1 => 'Level 4 (DipPFS, DipFA® or equivalent)',
+        2 => 'Level 6 (APFS, Adv DipFA®)',
+        3 => 'Chartered Financial Planner',
+        4 => 'Certified Financial Planner',
+        5 => 'Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent',
+        6 => 'Equity release qualifications i.e. holder of Certificate in Equity Release or equivalent',
+        7 => 'Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent',
+        8 => 'Holder of Trust and Estate Practitioner qualification (TEP) i.e. full member of STEP',
+        9 => 'Fellow of the Chartered Insurance Institute (FCII)'
+      }
+
+      Qualification.transaction do
+        seed_data_snapshot.each do |ordinal, name|
+          q = Qualification.find_or_initialize_by(order: ordinal)
+          q.name = name
+          puts "#{change_type(q)} #{ordinal} => #{name}"
+          q.save!
+        end
+      end
+
+      puts 'Done.'
+    end
+  end
+end


### PR DESCRIPTION
The qualifications are stored in the database. We need to update and add to these which calls for an update to the seed data and an update to the data already live in production.

A (possibly) temporary rake task has been created to migrate the live data. For comfort it will show which records have been changed or added, because this will be run on production. E.g.

```
$ bundle exec rake data:migrate:qualifications
  No change 1 => Level 4 (DipPFS, DipFA® or equivalent)
! Changing  2 => Level 6 (APFS, Adv DipFA®)
  No change 3 => Chartered Financial Planner
  No change 4 => Certified Financial Planner
! Changing  5 => Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent
  No change 6 => Equity release qualifications i.e. holder of Certificate in Equity Release or equivalent
! Changing  7 => Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent
+ Adding    8 => Holder of Trust and Estate Practitioner qualification (TEP) i.e. full member of STEP
+ Adding    9 => Fellow of the Chartered Insurance Institute (FCII)
Done.
```

```
$ bundle exec rake data:migrate:qualifications
  No change 1 => Level 4 (DipPFS, DipFA® or equivalent)
  No change 2 => Level 6 (APFS, Adv DipFA®)
  No change 3 => Chartered Financial Planner
  No change 4 => Certified Financial Planner
  No change 5 => Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent
  No change 6 => Equity release qualifications i.e. holder of Certificate in Equity Release or equivalent
  No change 7 => Long term care planning qualifications i.e. holder of CF8, CeLTCI®. or equivalent
  No change 8 => Holder of Trust and Estate Practitioner qualification (TEP) i.e. full member of STEP
  No change 9 => Fellow of the Chartered Insurance Institute (FCII)
Done.
```