### PR TITLE
Make 'types of advice' require at least one checked

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.62'
+gem 'mas-rad_core', '0.0.63'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.62)
+    mas-rad_core (0.0.63)
       active_model_serializers
       geocoder
       httpclient
@@ -322,7 +322,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.62)
+  mas-rad_core (= 0.0.63)
   oga
   pg
   poltergeist

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -45,7 +45,6 @@ class QuestionnairesController < PrincipalsBaseController
     :equity_release_flag,
     :inheritance_tax_and_estate_planning_flag,
     :wills_and_probate_flag,
-    :other_flag,
     in_person_advice_method_ids: [],
     other_advice_method_ids: [],
     initial_advice_fee_structure_ids: [],

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -40,7 +40,6 @@ module SelfService
       :equity_release_flag,
       :inheritance_tax_and_estate_planning_flag,
       :wills_and_probate_flag,
-      :other_flag,
       in_person_advice_method_ids: [],
       other_advice_method_ids: [],
       initial_advice_fee_structure_ids: [],

--- a/app/views/self_service/firms/_form.html.erb
+++ b/app/views/self_service/firms/_form.html.erb
@@ -45,11 +45,6 @@
   </div>
 </section>
 
-<section class="form-section">
-  <%= render partial: 'self_service/firms/questionnaire/supplementary_information', locals: {f: f} %>
-</section>
-
-
 <div class="l-self-service-action-row">
   <%= link_to t('self_service.cancel_button'), self_service_firms_path, class: 'l-self-service-action-row__cancel' %>
   <%= f.submit t('self_service.save_button'), class: 'button button--primary t-save-button' %>

--- a/app/views/self_service/firms/questionnaire/_business_split.html.erb
+++ b/app/views/self_service/firms/questionnaire/_business_split.html.erb
@@ -1,8 +1,8 @@
 <fieldset class="form__group">
   <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.business_split.subheading') %></legend>
 
-  <%= f.form_row :business_offering do %>
-  <%= f.errors_for :business_offering %>
+  <%= f.form_row :advice_types do %>
+  <%= f.errors_for :advice_types %>
     <% t('questionnaire.retirement_advice.business_split.advice_options').each do |attribute, heading| %>
       <div class="form__group-item">
         <label>

--- a/app/views/self_service/firms/questionnaire/_business_split.html.erb
+++ b/app/views/self_service/firms/questionnaire/_business_split.html.erb
@@ -1,12 +1,15 @@
 <fieldset class="form__group">
   <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.business_split.subheading') %></legend>
 
-  <% t('questionnaire.retirement_advice.business_split.advice_options').each do |attribute, heading| %>
-    <div class="form__group-item">
-      <label>
-        <%= f.check_box attribute, class: "form__input t-#{attribute.to_s.dasherize}", aria_labelledby: "form-label-#{attribute} input-label-#{attribute}-b".dasherize %>
-        <%= raw heading %>
-      </label>
-    </div>
+  <%= f.form_row :business_offering do %>
+  <%= f.errors_for :business_offering %>
+    <% t('questionnaire.retirement_advice.business_split.advice_options').each do |attribute, heading| %>
+      <div class="form__group-item">
+        <label>
+          <%= f.check_box attribute, class: "form__input t-#{attribute.to_s.dasherize}", aria_labelledby: "form-label-#{attribute} input-label-#{attribute}-b".dasherize %>
+          <%= raw heading %>
+        </label>
+      </div>
+    <% end %>
   <% end %>
 </fieldset>

--- a/app/views/self_service/firms/questionnaire/_supplementary_information.html.erb
+++ b/app/views/self_service/firms/questionnaire/_supplementary_information.html.erb
@@ -1,2 +1,0 @@
-<%= heading_tag(t('questionnaire.retirement_advice.business_split.footnotes.heading'), level: 3, class: 'form-section__heading') %>
-<p id="other_description" class="footnote"><%= t('questionnaire.retirement_advice.business_split.footnotes.other_html') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
       firm:
         fca_number: FRN
         registered_name: Registered name
-        business_offering: Types of advice provided
+        advice_types: Types of advice provided
       user:
         login: Firm Reference Number
     errors:
@@ -56,7 +56,7 @@ en:
               too_short: "- please select at least one"
             investment_sizes:
               too_short: "- please select at least one"
-            business_offering:
+            advice_types:
               invalid: "- please select at least one"
             website_address:
               invalid: " is invalid. The address must be in the format: http://www.example.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
       firm:
         fca_number: FRN
         registered_name: Registered name
+        business_offering: Types of advice provided
       user:
         login: Firm Reference Number
     errors:
@@ -55,6 +56,8 @@ en:
               too_short: "- please select at least one"
             investment_sizes:
               too_short: "- please select at least one"
+            business_offering:
+              invalid: "- please select at least one"
             website_address:
               invalid: " is invalid. The address must be in the format: http://www.example.com"
         adviser:
@@ -322,7 +325,7 @@ en:
 
       business_split:
         heading: Describe your firm's business split as it relates to ‘at’ or ‘post’ retirement advice
-        subheading: "Types of advice provided"
+        subheading: "Types of advice provided *"
 
         advice_options:
           retirement_income_products_flag: Conversion of pension pot/other liquid savings into retirement income

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,7 +334,6 @@ en:
           equity_release_flag: Equity release
           inheritance_tax_and_estate_planning_flag: Inheritance Tax and Estate Planning
           wills_and_probate_flag: Wills & Probate
-          other_flag: Other <a href="#other_description">&#185;</a>
 
         footnotes:
           heading: Supplementary Information

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -72,7 +72,6 @@ namespace :export do
           firm.equity_release_flag,
           firm.inheritance_tax_and_estate_planning_flag,
           firm.wills_and_probate_flag,
-          firm.other_flag,
           firm.investment_sizes.map(&:name).join(', ')
         ]
       end

--- a/spec/features/principal_completes_firm_questionnaire_spec.rb
+++ b/spec/features/principal_completes_firm_questionnaire_spec.rb
@@ -84,7 +84,6 @@ RSpec.feature 'Principal completes the firm questionnaire' do
     page.equity_release_flag.set true
     page.inheritance_tax_and_estate_planning_flag.set true
     page.wills_and_probate_flag.set true
-    page.other_flag.set true
   end
 
   def when_i_complete_all_mandatory_questions

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature 'The self service firm edit page' do
                       long_term_care_flag: true,
                       equity_release_flag: false,
                       inheritance_tax_and_estate_planning_flag: true,
-                      wills_and_probate_flag: false,
-                      other_flag: true)
+                      wills_and_probate_flag: false)
   end
 
   scenario 'The principal can edit their firm' do
@@ -138,7 +137,6 @@ RSpec.feature 'The self service firm edit page' do
       p.equity_release_flag.set firm_changes.equity_release_flag
       p.inheritance_tax_and_estate_planning_flag.set firm_changes.inheritance_tax_and_estate_planning_flag
       p.wills_and_probate_flag.set firm_changes.wills_and_probate_flag
-      p.other_flag.set firm_changes.other_flag
       p.minimum_fee.set firm_changes.minimum_fixed_fee
     end
   end
@@ -151,7 +149,6 @@ RSpec.feature 'The self service firm edit page' do
       expect(p.equity_release_flag?).to eq firm_changes.equity_release_flag
       expect(p.inheritance_tax_and_estate_planning_flag?).to eq firm_changes.inheritance_tax_and_estate_planning_flag
       expect(p.wills_and_probate_flag?).to eq firm_changes.wills_and_probate_flag
-      expect(p.other_flag?).to eq firm_changes.other_flag
       expect(p.minimum_fee.value).to eq firm_changes.minimum_fixed_fee.to_s
     end
   end

--- a/spec/support/questionnaire_page.rb
+++ b/spec/support/questionnaire_page.rb
@@ -28,7 +28,6 @@ class QuestionnairePage < SitePrism::Page
   element :equity_release_flag, '#firm_equity_release_flag'
   element :inheritance_tax_and_estate_planning_flag, '#firm_inheritance_tax_and_estate_planning_flag'
   element :wills_and_probate_flag, '#firm_wills_and_probate_flag'
-  element :other_flag, '#firm_other_flag'
 
   elements :investment_sizes, '.t-questionnaire__firm-investment-size-id'
 

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -34,7 +34,6 @@ module SelfService
     element :equity_release_flag, '.t-equity-release-flag'
     element :inheritance_tax_and_estate_planning_flag, '.t-inheritance-tax-and-estate-planning-flag'
     element :wills_and_probate_flag, '.t-wills-and-probate-flag'
-    element :other_flag, '.t-other-flag'
 
     elements :investment_sizes, '.t-questionnaire__firm-investment-size-id'
 
@@ -70,10 +69,6 @@ module SelfService
 
     def wills_and_probate_flag?
       !!wills_and_probate_flag.checked?
-    end
-
-    def other_flag?
-      !!other_flag.checked?
     end
   end
 end


### PR DESCRIPTION
See https://github.com/moneyadviceservice/mas-rad_core/pull/79

Also:

* Rename 'business split' to 'advice types'.
* Remove the 'other' type of advice.
* Remove 'supplementary advice' text that is no longer required after removing 'other'