### PR TITLE
Add email to devise parameter sanitizer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_in) do |u|
-      u.permit(:login, :password, :remember_me)
+      u.permit(:login, :email, :password, :remember_me)
     end
   end
 end


### PR DESCRIPTION
We need this so changing it on the 'change password' page works correctly. We didn't think we needed it because our login form submits the `login` parameter, not `email`.