### PR TITLE
Add `required_asterisk` method to add nbsp and * to required fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,8 @@ module ApplicationHelper
   def register_path
     prequalify_principals_path
   end
+
+  def required_asterisk(string)
+    string + "\u00a0*" # \u00a0 is a non breaking space
+  end
 end

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -129,7 +129,7 @@
         </fieldset>
 
         <fieldset class="form__group form__group--inline">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.free_initial_meeting.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.free_initial_meeting.heading') %></legend>
 
           <%= f.form_row :free_initial_meeting do %>
             <%= f.errors_for :free_initial_meeting %>
@@ -174,7 +174,7 @@
         <p class="l-questionnaire__section-description"><%= t('questionnaire.service_charges.hint') %></p>
 
         <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_advice_fee.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.initial_advice_fee.heading') %></legend>
 
           <%= f.form_row :initial_advice_fee_structures do %>
             <%= f.errors_for :initial_advice_fee_structures %>
@@ -187,7 +187,7 @@
         </fieldset>
 
         <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.ongoing_advice_fee.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.ongoing_advice_fee.heading') %></legend>
 
           <%= f.form_row :ongoing_advice_fee_structures do %>
             <%= f.errors_for :ongoing_advice_fee_structures %>
@@ -200,7 +200,7 @@
         </fieldset>
 
         <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.allowed_payment_methods.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.allowed_payment_methods.heading') %></legend>
 
           <%= f.form_row :allowed_payment_methods do %>
             <%= f.errors_for :allowed_payment_methods %>
@@ -233,7 +233,7 @@
         <%= heading_tag(t('questionnaire.retirement_advice.business_split.heading'), level: 2, class: 'heading-small') %>
 
         <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.business_split.subheading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.retirement_advice.business_split.subheading') %></legend>
 
           <div class="l-questionnaire__row">
             <div class="l-questionnaire__field">
@@ -267,7 +267,7 @@
         <p class="l-questionnaire__section-description"><%= t('questionnaire.retirement_advice.typical_customer.description') %></p>
 
         <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.pension_pot.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.retirement_advice.pension_pot.heading') %></legend>
           <p><%= t('questionnaire.retirement_advice.pension_pot.description') %></p>
           <%= f.form_row :investment_sizes do %>
             <%= f.errors_for :investment_sizes %>

--- a/app/views/self_service/firms/questionnaire/_business_split.html.erb
+++ b/app/views/self_service/firms/questionnaire/_business_split.html.erb
@@ -1,9 +1,9 @@
 <fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.business_split.subheading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.retirement_advice.business_split.subheading') %></legend>
 
   <%= f.form_row :advice_types do %>
     <%= f.errors_for :advice_types %>
-    
+
     <% t('questionnaire.retirement_advice.business_split.advice_options').each do |attribute, heading| %>
       <div class="form__group-item">
         <label>

--- a/app/views/self_service/firms/questionnaire/_initial_advice.html.erb
+++ b/app/views/self_service/firms/questionnaire/_initial_advice.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_advice_fee.heading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.initial_advice_fee.heading') %></legend>
 
   <%= f.form_row :initial_advice_fee_structures do %>
     <%= f.errors_for :initial_advice_fee_structures %>

--- a/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
+++ b/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="form__group form__group--inline">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.free_initial_meeting.heading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.free_initial_meeting.heading') %></legend>
 
   <%= f.form_row :free_initial_meeting do %>
     <%= f.errors_for :free_initial_meeting %>

--- a/app/views/self_service/firms/questionnaire/_investment_sizes.html.erb
+++ b/app/views/self_service/firms/questionnaire/_investment_sizes.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.retirement_advice.pension_pot.heading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.retirement_advice.pension_pot.heading') %></legend>
   <p><%= t('questionnaire.retirement_advice.pension_pot.description') %></p>
   <%= f.form_row :investment_sizes do %>
     <%= f.errors_for :investment_sizes %>

--- a/app/views/self_service/firms/questionnaire/_ongoing_advice.html.erb
+++ b/app/views/self_service/firms/questionnaire/_ongoing_advice.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.ongoing_advice_fee.heading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.ongoing_advice_fee.heading') %></legend>
 
   <%= f.form_row :ongoing_advice_fee_structures do %>
     <%= f.errors_for :ongoing_advice_fee_structures %>

--- a/app/views/self_service/firms/questionnaire/_payment_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_payment_methods.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.allowed_payment_methods.heading') %></legend>
+  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.allowed_payment_methods.heading') %></legend>
 
   <%= f.form_row :allowed_payment_methods do %>
     <%= f.errors_for :allowed_payment_methods %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,7 +290,7 @@ en:
       heading: Does your firm offer advice by other methods through to transaction?
 
     free_initial_meeting:
-      heading: Does your firm offer a free initial meeting? *
+      heading: Does your firm offer a free initial meeting?
       answer_yes: "Yes"
       answer_no: "No"
 
@@ -299,13 +299,13 @@ en:
       duration_unit: minutes
 
     initial_advice_fee:
-      heading: Initial advice *
+      heading: Initial advice
 
     ongoing_advice_fee:
-      heading: Ongoing advice *
+      heading: Ongoing advice
 
     allowed_payment_methods:
-      heading: Do you allow customers to pay for advice? *
+      heading: Do you allow customers to pay for advice?
 
     minimum_fixed_fee:
       heading: Do you have a minimum fee?
@@ -325,7 +325,7 @@ en:
 
       business_split:
         heading: Describe your firm's business split as it relates to ‘at’ or ‘post’ retirement advice
-        subheading: "Types of advice provided *"
+        subheading: "Types of advice provided"
 
         advice_options:
           retirement_income_products_flag: Conversion of pension pot/other liquid savings into retirement income
@@ -349,5 +349,5 @@ en:
         description: Customers searching for advice on converting their pension pot into retirement income and/or advice on pension transfers will be asked to provide the size of pension pot they wish to invest and/or transfer.
 
       pension_pot:
-        heading: Total pension pot / investment size *
+        heading: Total pension pot / investment size
         description: Please tell us what size pension pot(s) you are willing to provide advice on. Check all that apply.


### PR DESCRIPTION
Why not use `&nbsp;` you ask? Because I'd have to `#html_safe` the whole string and I prefer to avoid that if possible – even though at the moment there's no interpolation.