### PR TITLE
Add new conditional flow for remote & face to face advice method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.63'
+gem 'mas-rad_core', '0.0.64'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.63)
+    mas-rad_core (0.0.64)
       active_model_serializers
       geocoder
       httpclient
@@ -322,7 +322,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.63)
+  mas-rad_core (= 0.0.64)
   oga
   pg
   poltergeist

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,4 +8,5 @@ require(['jquery', 'componentLoader', 'eventsWithPromises'], function ($, compon
 require(['jquery'], function ($) {
   require(['AdviserAjaxCall']);
   require(['DataTransform']);
+  require(['RemoteAndFaceToFaceOptions']);
 });

--- a/app/assets/javascripts/modules/FieldToggleVisibility.js
+++ b/app/assets/javascripts/modules/FieldToggleVisibility.js
@@ -24,7 +24,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   function FieldToggleVisibility($el, config) {
     FieldToggleVisibility.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.$triggers = this.$el.find('[data-dough-field-trigger]');
+    this.$triggers = this.$el.find('[data-dough-field-show],[data-dough-field-hide]');
     this.$targets = this.$el.find('[data-dough-field-target]');
 
     this.hideRelevantTargets();
@@ -53,10 +53,11 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     self.$triggers.on('change', function(i, o) {
       var $trigger = $(this),
-          triggerTarget = $trigger.attr('data-dough-field-trigger'),
-          triggerAction = $trigger.attr('data-dough-field-trigger-type');
+          actions = self.getActionsFromTrigger($trigger);
 
-      self.onChange.call(self, $trigger, triggerTarget, triggerAction);
+      $.each(actions, function(i, action) {
+        self.onChange.call(self, $trigger, action.target, action.action);
+      });
     });
 
     this._initialisedSuccess(initialised);
@@ -67,9 +68,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   FieldToggleVisibilityProto.hideRelevantTargets = function() {
     var self = this;
 
-    this.$triggers.filter('[data-dough-field-trigger-type="show"]:not(:checked)').each(function() {
+    this.$triggers.filter('[data-dough-field-show]:not(:checked)').each(function() {
       var $trigger = $(this),
-        target = $trigger.attr('data-dough-field-trigger'),
+        target = $trigger.attr('data-dough-field-show'),
         $target = self.$targets.filter('[data-dough-field-target="' + target + '"]');
 
         $target.addClass('is-hidden');
@@ -83,6 +84,20 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     $target[triggerAction === 'show' ? 'removeClass' : 'addClass']('is-hidden');
 
     return this;
+  };
+
+  FieldToggleVisibilityProto.getActionsFromTrigger = function($trigger) {
+    var actions = [];
+
+    if ($trigger.is('[data-dough-field-show]')) {
+      actions.push({action: 'show', target: $trigger.attr('data-dough-field-show')});
+    }
+
+    if ($trigger.is('[data-dough-field-hide]')) {
+      actions.push({action: 'hide', target: $trigger.attr('data-dough-field-hide')});
+    }
+
+    return actions;
   };
 
   return FieldToggleVisibility;

--- a/app/assets/javascripts/modules/RemoteAndFaceToFaceOptions.js
+++ b/app/assets/javascripts/modules/RemoteAndFaceToFaceOptions.js
@@ -1,0 +1,13 @@
+define(['jquery'], function($) {
+  'use strict';
+
+  var $picker = $('[data-remote-and-face-to-face-picker]'),
+      $fieldset = $('[data-remote-and-face-to-face-conditional-fieldset]');
+
+  if($picker.find(':checked').length === 0) {
+    $fieldset.hide();
+    $picker.change(function() {
+      $fieldset.show();
+    });
+  }
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -3,6 +3,7 @@
 //= depend_on_asset modules/FieldToggleVisibility
 //= depend_on_asset modules/AdviserAjaxCall
 //= depend_on_asset modules/DataTransform
+//= depend_on_asset modules/RemoteAndFaceToFaceOptions
 //= depend_on_asset modules/MultiTableFilter
 //= depend_on_asset modules/ConfirmableForm
 
@@ -20,6 +21,7 @@
       FieldToggleVisibility: requirejs_path('modules/FieldToggleVisibility'),
       AdviserAjaxCall: requirejs_path('modules/AdviserAjaxCall'),
       DataTransform: requirejs_path('modules/DataTransform'),
+      RemoteAndFaceToFaceOptions: requirejs_path('modules/RemoteAndFaceToFaceOptions'),
       MultiTableFilter: requirejs_path('modules/MultiTableFilter'),
       ConfirmableForm: requirejs_path('modules/ConfirmableForm'),
       componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -45,6 +45,7 @@ class QuestionnairesController < PrincipalsBaseController
     :equity_release_flag,
     :inheritance_tax_and_estate_planning_flag,
     :wills_and_probate_flag,
+    :remote_or_local_advice,
     in_person_advice_method_ids: [],
     other_advice_method_ids: [],
     initial_advice_fee_structure_ids: [],

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -45,7 +45,7 @@ class QuestionnairesController < PrincipalsBaseController
     :equity_release_flag,
     :inheritance_tax_and_estate_planning_flag,
     :wills_and_probate_flag,
-    :remote_or_local_advice,
+    :primary_advice_method,
     in_person_advice_method_ids: [],
     other_advice_method_ids: [],
     initial_advice_fee_structure_ids: [],

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -40,6 +40,7 @@ module SelfService
       :equity_release_flag,
       :inheritance_tax_and_estate_planning_flag,
       :wills_and_probate_flag,
+      :remote_or_local_advice,
       in_person_advice_method_ids: [],
       other_advice_method_ids: [],
       initial_advice_fee_structure_ids: [],

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -40,7 +40,7 @@ module SelfService
       :equity_release_flag,
       :inheritance_tax_and_estate_planning_flag,
       :wills_and_probate_flag,
-      :remote_or_local_advice,
+      :primary_advice_method,
       in_person_advice_method_ids: [],
       other_advice_method_ids: [],
       initial_advice_fee_structure_ids: [],

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -54,14 +54,14 @@
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_trigger_type: 'hide', dough_field_trigger: '1'  } %>
+                <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_hide: '1'  } %>
                 <%= t('registration.status_question.answer_one') %>
               </label>
             </div>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_trigger_type: 'show', dough_field_trigger: '1' } %>
+                <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_show: '1' } %>
                 <%= t('registration.status_question.answer_two') %>
                 <span class="visually-hidden"><%= t('registration.notice') %></span>
               </label>
@@ -76,7 +76,7 @@
 
               <div class="form__group-item">
                 <label>
-                  <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_trigger_type: 'show', dough_field_trigger: '2'  } %>
+                  <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_show: '2'  } %>
                   <%= t('registration.answer_yes') %>
                   <span class="visually-hidden"><%= t('registration.notice') %></span>
                 </label>
@@ -84,7 +84,7 @@
 
               <div class="form__group-item">
                 <label>
-                  <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_trigger_type: 'hide', dough_field_trigger: '2'  } %>
+                  <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_hide: '2'  } %>
                   <%= t('registration.answer_no') %>
                 </label>
               </div>

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -99,23 +99,32 @@
 
       <hr>
 
-      <section>
+      <section data-dough-component="FieldToggleVisibility">
         <%= heading_tag(t('questionnaire.providing_your_services.heading'), level: 2, class: 'heading-small') %>
         <p class="l-questionnaire__section-description"><%= t('questionnaire.providing_your_services.description') %></p>
 
-        <fieldset class="form__group">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
 
-          <%= f.form_row :in_person_advice_methods do %>
-            <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
-              <div class="form__group-item">
-                <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
-              </div>
-            <% end %>
+        <fieldset class="form__group">
+          <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
+
+          <%= f.form_row :remote_or_local_advice do %>
+            <div class="form__group-item">
+              <label>
+                <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: '1', dough_field_hide: '2'  } %>
+                <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
+              </label>
+            </div>
+
+            <div class="form__group-item">
+              <label>
+                <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: '2', dough_field_hide: '1' } %>
+                <%= t('questionnaire.remote_or_local_advice.answer_local') %>
+              </label>
+            </div>
           <% end %>
         </fieldset>
 
-        <fieldset class="form__group">
+        <fieldset class="form__group" data-dough-field-target="1">
           <legend class="l-questionnaire__legend"><%= t('questionnaire.other_advice_methods.heading') %></legend>
 
           <%= f.form_row :other_advice_methods do %>
@@ -123,6 +132,18 @@
             <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
               <div class="form__group-item">
                 <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
+              </div>
+            <% end %>
+          <% end %>
+        </fieldset>
+
+        <fieldset class="form__group" data-dough-field-target="2">
+          <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
+
+          <%= f.form_row :in_person_advice_methods do %>
+            <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
+              <div class="form__group-item">
+                <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -104,46 +104,47 @@
         <p class="l-questionnaire__section-description"><%= t('questionnaire.providing_your_services.description') %></p>
 
 
-        <fieldset class="form__group">
+        <fieldset class="form__group" data-remote-and-face-to-face-picker>
           <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
 
           <%= f.form_row :remote_or_local_advice do %>
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: '1', dough_field_hide: '2'  } %>
+                <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person' } %>
                 <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
               </label>
             </div>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: '2', dough_field_hide: '1' } %>
+                <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
                 <%= t('questionnaire.remote_or_local_advice.answer_local') %>
               </label>
             </div>
           <% end %>
         </fieldset>
 
-        <fieldset class="form__group" data-dough-field-target="1">
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.other_advice_methods.heading') %></legend>
-
-          <%= f.form_row :other_advice_methods do %>
-            <%= f.errors_for :other_advice_methods %>
-            <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
-              <div class="form__group-item">
-                <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
-              </div>
-            <% end %>
-          <% end %>
-        </fieldset>
-
-        <fieldset class="form__group" data-dough-field-target="2">
+        <fieldset class="form__group" data-dough-field-target="in_person">
           <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
 
           <%= f.form_row :in_person_advice_methods do %>
             <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
               <div class="form__group-item">
                 <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
+              </div>
+            <% end %>
+          <% end %>
+        </fieldset>
+
+        <fieldset class="form__group" data-remote-and-face-to-face-conditional-fieldset>
+          <legend class="l-questionnaire__legend" data-dough-field-target="remote"><%= t('questionnaire.other_advice_methods.heading') %></legend>
+          <legend class="l-questionnaire__legend" data-dough-field-target="in_person"><%= t('questionnaire.other_advice_methods.alternative_heading') %></legend>
+
+          <%= f.form_row :other_advice_methods do %>
+            <%= f.errors_for :other_advice_methods %>
+            <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
+              <div class="form__group-item">
+                <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -105,20 +105,20 @@
 
 
         <fieldset class="form__group" data-remote-and-face-to-face-picker>
-          <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
+          <legend class="l-questionnaire__legend"><%= t('questionnaire.primary_advice_method.heading') %></legend>
 
-          <%= f.form_row :remote_or_local_advice do %>
+          <%= f.form_row :primary_advice_method do %>
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person' } %>
-                <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
+                <%= f.radio_button :primary_advice_method, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person' } %>
+                <%= t('questionnaire.primary_advice_method.answer_remote') %>
               </label>
             </div>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
-                <%= t('questionnaire.remote_or_local_advice.answer_local') %>
+                <%= f.radio_button :primary_advice_method, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
+                <%= t('questionnaire.primary_advice_method.answer_local') %>
               </label>
             </div>
           <% end %>

--- a/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
@@ -24,7 +24,7 @@
 
     <%= f.form_row :other_advice_methods do %>
       <%= f.errors_for :other_advice_methods %>
-      <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
+      <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :friendly_name) do |b| %>
         <div class="form__group-item">
           <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
         </div>
@@ -36,7 +36,7 @@
     <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
 
     <%= f.form_row :in_person_advice_methods do %>
-      <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
+      <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :friendly_name) do |b| %>
         <div class="form__group-item">
           <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
         </div>

--- a/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
@@ -1,44 +1,45 @@
 <div data-dough-component="FieldToggleVisibility">
-  <fieldset class="form__group">
+  <fieldset class="form__group" data-dough-field-show="show_options">
     <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
 
     <%= f.form_row :remote_or_local_advice do %>
       <div class="form__group-item">
         <label>
-          <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: '1', dough_field_hide: '2'  } %>
+          <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person'  } %>
           <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
         </label>
       </div>
 
       <div class="form__group-item">
         <label>
-          <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: '2', dough_field_hide: '1' } %>
+          <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
           <%= t('questionnaire.remote_or_local_advice.answer_local') %>
         </label>
       </div>
     <% end %>
   </fieldset>
 
-  <fieldset class="form__group" data-dough-field-target="1">
-    <legend class="l-questionnaire__legend"><%= t('questionnaire.other_advice_methods.heading') %></legend>
-
-    <%= f.form_row :other_advice_methods do %>
-      <%= f.errors_for :other_advice_methods %>
-      <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :friendly_name) do |b| %>
-        <div class="form__group-item">
-          <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
-        </div>
-      <% end %>
-    <% end %>
-  </fieldset>
-
-  <fieldset class="form__group" data-dough-field-target="2">
+  <fieldset class="form__group" data-dough-field-target="in_person">
     <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
 
     <%= f.form_row :in_person_advice_methods do %>
       <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :friendly_name) do |b| %>
         <div class="form__group-item">
           <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
+        </div>
+      <% end %>
+    <% end %>
+  </fieldset>
+
+  <fieldset class="form__group" data-dough-field-target="show_options">
+    <legend class="l-questionnaire__legend" data-dough-field-target="remote"><%= t('questionnaire.other_advice_methods.heading') %></legend>
+    <legend class="l-questionnaire__legend" data-dough-field-target="in_person"><%= t('questionnaire.other_advice_methods.alternative_heading') %></legend>
+
+    <%= f.form_row :other_advice_methods do %>
+      <%= f.errors_for :other_advice_methods %>
+      <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :friendly_name) do |b| %>
+        <div class="form__group-item">
+          <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
@@ -1,5 +1,5 @@
 <div data-dough-component="FieldToggleVisibility">
-  <fieldset class="form__group" data-dough-field-show="show_options">
+  <fieldset class="form__group" data-remote-and-face-to-face-picker>
     <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
 
     <%= f.form_row :remote_or_local_advice do %>
@@ -31,7 +31,7 @@
     <% end %>
   </fieldset>
 
-  <fieldset class="form__group" data-dough-field-target="show_options">
+  <fieldset class="form__group" data-remote-and-face-to-face-conditional-fieldset>
     <legend class="l-questionnaire__legend" data-dough-field-target="remote"><%= t('questionnaire.other_advice_methods.heading') %></legend>
     <legend class="l-questionnaire__legend" data-dough-field-target="in_person"><%= t('questionnaire.other_advice_methods.alternative_heading') %></legend>
 

--- a/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
@@ -1,19 +1,19 @@
 <div data-dough-component="FieldToggleVisibility">
   <fieldset class="form__group" data-remote-and-face-to-face-picker>
-    <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
+    <legend class="l-questionnaire__legend"><%= t('questionnaire.primary_advice_method.heading') %></legend>
 
-    <%= f.form_row :remote_or_local_advice do %>
+    <%= f.form_row :primary_advice_method do %>
       <div class="form__group-item">
         <label>
-          <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person'  } %>
-          <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
+          <%= f.radio_button :primary_advice_method, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: 'remote', dough_field_hide: 'in_person'  } %>
+          <%= t('questionnaire.primary_advice_method.answer_remote') %>
         </label>
       </div>
 
       <div class="form__group-item">
         <label>
-          <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
-          <%= t('questionnaire.remote_or_local_advice.answer_local') %>
+          <%= f.radio_button :primary_advice_method, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: 'in_person', dough_field_hide: 'remote' } %>
+          <%= t('questionnaire.primary_advice_method.answer_local') %>
         </label>
       </div>
     <% end %>

--- a/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
+++ b/app/views/self_service/firms/questionnaire/_advice_methods.html.erb
@@ -1,24 +1,46 @@
-<fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
+<div data-dough-component="FieldToggleVisibility">
+  <fieldset class="form__group">
+    <legend class="l-questionnaire__legend"><%= t('questionnaire.remote_or_local_advice.heading') %></legend>
 
-  <%= f.form_row :in_person_advice_methods do %>
-    <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
+    <%= f.form_row :remote_or_local_advice do %>
       <div class="form__group-item">
-        <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
+        <label>
+          <%= f.radio_button :remote_or_local_advice, :remote, class: 'form__group-input js-radio-button', data: { dough_field_show: '1', dough_field_hide: '2'  } %>
+          <%= t('questionnaire.remote_or_local_advice.answer_remote') %>
+        </label>
+      </div>
+
+      <div class="form__group-item">
+        <label>
+          <%= f.radio_button :remote_or_local_advice, :local, class: 'form__group-input js-radio-button', data: { dough_field_show: '2', dough_field_hide: '1' } %>
+          <%= t('questionnaire.remote_or_local_advice.answer_local') %>
+        </label>
       </div>
     <% end %>
-  <% end %>
-</fieldset>
+  </fieldset>
 
-<fieldset class="form__group">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.other_advice_methods.heading') %></legend>
+  <fieldset class="form__group" data-dough-field-target="1">
+    <legend class="l-questionnaire__legend"><%= t('questionnaire.other_advice_methods.heading') %></legend>
 
-  <%= f.form_row :other_advice_methods do %>
-    <%= f.errors_for :other_advice_methods %>
-    <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
-      <div class="form__group-item">
-        <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
-      </div>
+    <%= f.form_row :other_advice_methods do %>
+      <%= f.errors_for :other_advice_methods %>
+      <%= f.collection_check_boxes(:other_advice_method_ids, OtherAdviceMethod.all, :id, :name) do |b| %>
+        <div class="form__group-item">
+          <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__other-advice-method-id') + b.text } %>
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
-</fieldset>
+  </fieldset>
+
+  <fieldset class="form__group" data-dough-field-target="2">
+    <legend class="l-questionnaire__legend"><%= t('questionnaire.in_person_advice_methods.heading') %></legend>
+
+    <%= f.form_row :in_person_advice_methods do %>
+      <%= f.collection_check_boxes(:in_person_advice_method_ids, InPersonAdviceMethod.all, :id, :name) do |b| %>
+        <div class="form__group-item">
+          <%= b.label { b.check_box(class: 'form__group-input t-questionnaire__in-person-advice-method-id') + b.text } %>
+        </div>
+      <% end %>
+    <% end %>
+  </fieldset>
+</div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
     modules/ConfirmableForm.js
     modules/FieldToggleVisibility.js
     modules/DataTransform.js
+    modules/RemoteAndFaceToFaceOptions.js
     modules/AdviserAjaxCall.js
   )
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
       label_four: County *
       label_five: Post code *
 
-    remote_or_local_advice:
+    primary_advice_method:
       heading: How does your firm primarily offer advice through to transaction? *
       answer_remote: Remotely (e.g. telephone, video conferencing, automated advice)
       answer_local: Face-to-face

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,6 +297,7 @@ en:
 
     other_advice_methods:
       heading: How can customers receive remote advice? *
+      alternative_heading: What other ways can customers receive advice?
 
     free_initial_meeting:
       heading: Does your firm offer a free initial meeting? *

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,11 +283,16 @@ en:
       label_four: County *
       label_five: Post code *
 
+    remote_or_local_advice:
+      heading: How does your firm primarily offer advice through to transaction? *
+      answer_remote: Remotely (e.g. telephone, video conferencing, automated advice)
+      answer_local: Face-to-face
+
     in_person_advice_methods:
-      heading: Does your firm offer advice (through to transaction) in person?
+      heading: How can customers receive face-to-face advice? *
 
     other_advice_methods:
-      heading: Does your firm offer advice by other methods through to transaction?
+      heading: How can customers receive remote advice? *
 
     free_initial_meeting:
       heading: Does your firm offer a free initial meeting? *

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -360,3 +360,14 @@ en:
       pension_pot:
         heading: Total pension pot / investment size *
         description: Please tell us what size pension pot(s) you are willing to provide advice on. Check all that apply.
+
+  in_person_advice_method:
+    ordinal:
+      '1': At a customer's home
+      '2': At your offices
+      '3': At an agreed location
+
+  other_advice_method:
+    ordinal:
+      '1': 'By telephone'
+      '2': 'By video conferencing'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,10 @@ en:
               too_short: "- please select at least one"
             advice_types:
               invalid: "- please select at least one"
+            other_advice_methods:
+              blank: "- please select at least one"
+            in_person_advice_methods:
+              blank: "- please select at least one"
             website_address:
               invalid: " is invalid. The address must be in the format: http://www.example.com"
         adviser:

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SelfService::FirmsController, type: :controller do
     firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
     firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
     firm_params[:investment_size_ids] = firm.investment_size_ids
-    firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
+    firm_params[:primary_advice_method] = firm.primary_advice_method
     firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
     firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
     firm_params.merge(params)
@@ -111,7 +111,7 @@ RSpec.describe SelfService::FirmsController, type: :controller do
     context 'when the advice type is changed from local to remote' do
       let(:other_advice_method_ids) { create_list(:other_advice_method, rand(1..3)).map(&:id) }
       let(:firm_params) do
-        extract_firm_params(firm, remote_or_local_advice: :remote,
+        extract_firm_params(firm, primary_advice_method: :remote,
                                   other_advice_method_ids: other_advice_method_ids)
       end
       before { patch :update, id: firm.id, firm: firm_params }

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -16,6 +16,9 @@ module SelfService
       firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
       firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
       firm_params[:investment_size_ids] = firm.investment_size_ids
+      firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
+      firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
+      firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
       firm_params.merge(params)
     end
 
@@ -103,6 +106,23 @@ module SelfService
 
         it 'renders the edit page' do
           expect(response).to render_template 'self_service/firms/edit'
+        end
+      end
+
+      context 'when the advice type is changed from local to remote' do
+        let(:other_advice_method_ids) { create_list(:other_advice_method, rand(1..3)).map(&:id) }
+        let(:firm_params) do
+          extract_firm_params(firm, remote_or_local_advice: :remote,
+                                    other_advice_method_ids: other_advice_method_ids)
+        end
+        before { patch :update, id: firm.id, firm: firm_params }
+
+        it 'clears the local advice types' do
+          expect(firm.reload.in_person_advice_methods).to be_empty
+        end
+
+        it 'sets the remote advice types' do
+          expect(firm.reload.other_advice_method_ids).to eq other_advice_method_ids
         end
       end
     end

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -1,77 +1,106 @@
-module SelfService
-  RSpec.describe SelfService::FirmsController, type: :controller do
-    let(:principal) { FactoryGirl.create(:principal) }
-    let(:firm) do
-      firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: principal.fca_number)
-      principal.firm.update_attributes(firm_attrs)
-      principal.firm
-    end
-    let(:user) { FactoryGirl.create :user, principal: firm.principal }
-    before { sign_in(user) }
+RSpec.describe SelfService::FirmsController, type: :controller do
+  let(:principal) { FactoryGirl.create(:principal) }
+  let(:firm) do
+    firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: principal.fca_number)
+    principal.firm.update_attributes(firm_attrs)
+    principal.firm
+  end
+  let(:user) { FactoryGirl.create :user, principal: firm.principal }
+  before { sign_in(user) }
 
-    def extract_firm_params(firm, params = {})
-      firm_params = firm.attributes
-      firm_params.symbolize_keys!
-      firm_params[:initial_advice_fee_structure_ids] = firm.initial_advice_fee_structure_ids
-      firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
-      firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
-      firm_params[:investment_size_ids] = firm.investment_size_ids
-      firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
-      firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
-      firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
-      firm_params.merge(params)
+  def extract_firm_params(firm, params = {})
+    firm_params = firm.attributes
+    firm_params.symbolize_keys!
+    firm_params[:initial_advice_fee_structure_ids] = firm.initial_advice_fee_structure_ids
+    firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
+    firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
+    firm_params[:investment_size_ids] = firm.investment_size_ids
+    firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
+    firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
+    firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
+    firm_params.merge(params)
+  end
+
+  describe 'GET #index' do
+    it 'creates and assigns the presenter' do
+      get :index
+      expect(assigns(:presenter)).to be_a SelfService::FirmsIndexPresenter
     end
 
-    describe 'GET #index' do
-      it 'creates and assigns the presenter' do
+    context 'when all trading names are registered' do
+      it 'assigns all trading names' do
         get :index
-        expect(assigns(:presenter)).to be_a SelfService::FirmsIndexPresenter
-      end
-
-      context 'when all trading names are registered' do
-        it 'assigns all trading names' do
-          get :index
-          expect(assigns(:presenter)).to have(3).trading_names
-        end
-      end
-
-      context 'when some trading names are registered' do
-        before do
-          trading_name = firm.trading_names.first
-          trading_name.email_address = nil
-          trading_name.save(validate: false)
-        end
-
-        it 'assigns only registered trading names' do
-          get :index
-          expect(assigns(:presenter)).to have(2).trading_names
-        end
-      end
-
-      context 'when there are lookup names' do
-        before { FactoryGirl.create_list(:lookup_subsidiary, 8, fca_number: firm.fca_number) }
-
-        it 'assigns lookup names' do
-          get :index
-          expect(assigns(:presenter)).to have(8).lookup_names
-        end
-
-        it 'sorts lookup names by lowercase name (alpha ascending)' do
-          get :index
-          assigned_names = assigns(:presenter).lookup_names.map(&:name)
-          sorted_names = assigned_names.sort_by(&:downcase)
-
-          expect(assigned_names).to eq sorted_names
-        end
+        expect(assigns(:presenter)).to have(3).trading_names
       end
     end
 
-    describe 'GET #edit' do
-      let(:trading_name) { FactoryGirl.create(:firm, parent_id: firm.id) }
-      before { get :edit, id: firm.id }
+    context 'when some trading names are registered' do
+      before do
+        trading_name = firm.trading_names.first
+        trading_name.email_address = nil
+        trading_name.save(validate: false)
+      end
 
-      it 'assigns the firm' do
-        expect(assigns(:firm)).to eq firm
+      it 'assigns only registered trading names' do
+        get :index
+        expect(assigns(:presenter)).to have(2).trading_names
+      end
+    end
+
+    context 'when there are lookup names' do
+      before { FactoryGirl.create_list(:lookup_subsidiary, 8, fca_number: firm.fca_number) }
+
+      it 'assigns lookup names' do
+        get :index
+        expect(assigns(:presenter)).to have(8).lookup_names
+      end
+
+      it 'sorts lookup names by lowercase name (alpha ascending)' do
+        get :index
+        assigned_names = assigns(:presenter).lookup_names.map(&:name)
+        sorted_names = assigned_names.sort_by(&:downcase)
+
+        expect(assigned_names).to eq sorted_names
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:trading_name) { FactoryGirl.create(:firm, parent_id: firm.id) }
+    before { get :edit, id: firm.id }
+
+    it 'assigns the firm' do
+      expect(assigns(:firm)).to eq firm
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template 'self_service/firms/edit'
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:firm) { FactoryGirl.create(:firm) }
+
+    context 'when passed valid details' do
+      let(:firm_params) { extract_firm_params(firm, email_address: 'valid@example.com') }
+      before { patch :update, id: firm.id, firm: firm_params }
+
+      it 'updates the firm' do
+        expect(firm.reload.email_address).to eq firm_params[:email_address]
+      end
+
+      it 'redirects to the edit page' do
+        redirect_path = edit_self_service_firm_path(assigns(:firm))
+        expect(response).to redirect_to redirect_path
+      end
+    end
+
+    context 'when passed invalid details' do
+      let(:firm_params) { extract_firm_params(firm, email_address: 'not_valid') }
+      before { patch :update, id: firm.id, firm: firm_params }
+
+      it 'does not update the firm' do
+        expect(firm.reload.email_address).not_to eq firm_params[:email_address]
       end
 
       it 'renders the edit page' do
@@ -79,51 +108,20 @@ module SelfService
       end
     end
 
-    describe 'PATCH #update' do
-      let(:firm) { FactoryGirl.create(:firm) }
+    context 'when the advice type is changed from local to remote' do
+      let(:other_advice_method_ids) { create_list(:other_advice_method, rand(1..3)).map(&:id) }
+      let(:firm_params) do
+        extract_firm_params(firm, remote_or_local_advice: :remote,
+                                  other_advice_method_ids: other_advice_method_ids)
+      end
+      before { patch :update, id: firm.id, firm: firm_params }
 
-      context 'when passed valid details' do
-        let(:firm_params) { extract_firm_params(firm, email_address: 'valid@example.com') }
-        before { patch :update, id: firm.id, firm: firm_params }
-
-        it 'updates the firm' do
-          expect(firm.reload.email_address).to eq firm_params[:email_address]
-        end
-
-        it 'redirects to the edit page' do
-          redirect_path = edit_self_service_firm_path(assigns(:firm))
-          expect(response).to redirect_to redirect_path
-        end
+      it 'clears the local advice types' do
+        expect(firm.reload.in_person_advice_methods).to be_empty
       end
 
-      context 'when passed invalid details' do
-        let(:firm_params) { extract_firm_params(firm, email_address: 'not_valid') }
-        before { patch :update, id: firm.id, firm: firm_params }
-
-        it 'does not update the firm' do
-          expect(firm.reload.email_address).not_to eq firm_params[:email_address]
-        end
-
-        it 'renders the edit page' do
-          expect(response).to render_template 'self_service/firms/edit'
-        end
-      end
-
-      context 'when the advice type is changed from local to remote' do
-        let(:other_advice_method_ids) { create_list(:other_advice_method, rand(1..3)).map(&:id) }
-        let(:firm_params) do
-          extract_firm_params(firm, remote_or_local_advice: :remote,
-                                    other_advice_method_ids: other_advice_method_ids)
-        end
-        before { patch :update, id: firm.id, firm: firm_params }
-
-        it 'clears the local advice types' do
-          expect(firm.reload.in_person_advice_methods).to be_empty
-        end
-
-        it 'sets the remote advice types' do
-          expect(firm.reload.other_advice_method_ids).to eq other_advice_method_ids
-        end
+      it 'sets the remote advice types' do
+        expect(firm.reload.other_advice_method_ids).to eq other_advice_method_ids
       end
     end
   end

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -18,6 +18,9 @@ module SelfService
       firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
       firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
       firm_params[:investment_size_ids] = firm.investment_size_ids
+      firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
+      firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
+      firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
       firm_params.merge(params)
     end
 

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -18,7 +18,7 @@ module SelfService
       firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
       firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
       firm_params[:investment_size_ids] = firm.investment_size_ids
-      firm_params[:remote_or_local_advice] = firm.remote_or_local_advice
+      firm_params[:primary_advice_method] = firm.primary_advice_method
       firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
       firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
       firm_params.merge(params)

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -155,8 +155,10 @@ RSpec.feature 'The self service firm edit page' do
 
   def complete_part_3
     firm_edit_page.tap do |p|
-      set_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods)
-      set_checkbox_group_state(p, OtherAdviceMethod.all, firm_changes.other_advice_methods)
+      set_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods,
+                               label: :friendly_name)
+      set_checkbox_group_state(p, OtherAdviceMethod.all, firm_changes.other_advice_methods,
+                               label: :friendly_name)
       p.offers_free_initial_meeting = firm_changes.free_initial_meeting
       p.choose(firm_changes.initial_meeting_duration.name)
       set_checkbox_group_state(p, InitialAdviceFeeStructure.all, firm_changes.initial_advice_fee_structures)
@@ -167,8 +169,10 @@ RSpec.feature 'The self service firm edit page' do
 
   def validate_part_3
     firm_edit_page.tap do |p|
-      expect_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods)
-      expect_checkbox_group_state(p, OtherAdviceMethod.all, firm_changes.other_advice_methods)
+      expect_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods,
+                                  label: :friendly_name)
+      expect_checkbox_group_state(p, OtherAdviceMethod.all, firm_changes.other_advice_methods,
+                                  label: :friendly_name)
       expect(p.offers_free_initial_meeting?).to eq(firm_changes.free_initial_meeting)
       expect(p).to have_checked_field(firm_changes.initial_meeting_duration.name)
       expect_checkbox_group_state(p, InitialAdviceFeeStructure.all, firm_changes.initial_advice_fee_structures)

--- a/spec/javascripts/fixtures/FieldToggleVisibility.html
+++ b/spec/javascripts/fixtures/FieldToggleVisibility.html
@@ -4,14 +4,14 @@
       <legend>Test heading</legend>
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="hide" checked />
+          <input type="radio" data-dough-field-hide="1" checked />
           Test radio button
         </label>
       </div>
 
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="show" />
+          <input type="radio" data-dough-field-show="1" />
           Test radio button
         </label>
       </div>

--- a/spec/javascripts/fixtures/FieldToggleVisibilityMultiple.html
+++ b/spec/javascripts/fixtures/FieldToggleVisibilityMultiple.html
@@ -4,14 +4,14 @@
       <legend>Test heading</legend>
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="hide" />
+          <input type="radio" data-dough-field-hide="1" />
           Test radio button
         </label>
       </div>
 
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="show" />
+          <input type="radio" data-dough-field-show="1" />
           Test radio button
         </label>
       </div>
@@ -33,14 +33,14 @@
       <legend>Test heading</legend>
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="2" data-dough-field-trigger-type="hide" />
+          <input type="radio" data-dough-field-hide="2" />
           Test radio button
         </label>
       </div>
 
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="2" data-dough-field-trigger-type="show" />
+          <input type="radio" data-dough-field-show="2" />
           Test radio button
         </label>
       </div>

--- a/spec/javascripts/fixtures/FieldToggleVisibilityShown.html
+++ b/spec/javascripts/fixtures/FieldToggleVisibilityShown.html
@@ -4,14 +4,14 @@
       <legend>Test heading</legend>
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="hide" />
+          <input type="radio" data-dough-field-hide="1" />
           Test radio button
         </label>
       </div>
 
       <div>
         <label>
-          <input type="radio" data-dough-field-trigger="1" data-dough-field-trigger-type="show" checked />
+          <input type="radio" data-dough-field-show="1" checked />
           Test radio button
         </label>
       </div>

--- a/spec/javascripts/tests/FieldToggleVisibility_spec.js
+++ b/spec/javascripts/tests/FieldToggleVisibility_spec.js
@@ -34,7 +34,7 @@ describe('show content block on click of radio button', function () {
 
     it('shows the target element when radio button is checked', function () {
       var fieldToggleVisibility = new this.FieldToggleVisibility(this.component).init(),
-          $showTrigger = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="show"]'),
+          $showTrigger = fieldToggleVisibility.$triggers.filter('[data-dough-field-show]'),
           triggerTarget = $showTrigger.attr('data-dough-field-trigger'),
           $target = fieldToggleVisibility.$el.find('[data-dough-field-target="' + triggerTarget + '"]');
 
@@ -45,8 +45,8 @@ describe('show content block on click of radio button', function () {
 
     it('hides the target element when radio button is checked', function () {
       var fieldToggleVisibility = new this.FieldToggleVisibility(this.component).init(),
-          $hideTrigger = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="hide"]'),
-          triggerTarget = $hideTrigger.attr('data-dough-field-trigger'),
+          $hideTrigger = fieldToggleVisibility.$triggers.filter('[data-dough-field-hide]'),
+          triggerTarget = $hideTrigger.attr('data-dough-field-hide'),
           $target = fieldToggleVisibility.$el.find('[data-dough-field-target="' + triggerTarget + '"]');
 
       $hideTrigger.trigger('click');
@@ -82,8 +82,8 @@ describe('show content block on click of radio button', function () {
 
     it('shows the correct target', function() {
       var fieldToggleVisibility = new this.FieldToggleVisibility(this.component).init(),
-          $showTrigger1 = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="show"]').filter('[data-dough-field-trigger="1"]'),
-          $showTrigger2 = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="show"]').filter('[data-dough-field-trigger="2"]'),
+          $showTrigger1 = fieldToggleVisibility.$triggers.filter('[data-dough-field-show="1"]'),
+          $showTrigger2 = fieldToggleVisibility.$triggers.filter('[data-dough-field-show="2"]'),
           $target1 = fieldToggleVisibility.$el.find('[data-dough-field-target="1"]'),
           $target2 = fieldToggleVisibility.$el.find('[data-dough-field-target="2"]');
 
@@ -95,8 +95,8 @@ describe('show content block on click of radio button', function () {
 
     it('hides the correct target', function() {
       var fieldToggleVisibility = new this.FieldToggleVisibility(this.component).init(),
-          $hideTrigger1 = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="hide"]').filter('[data-dough-field-trigger="1"]'),
-          $hideTrigger2 = fieldToggleVisibility.$triggers.filter('[data-dough-field-trigger-type="hide"]').filter('[data-dough-field-trigger="2"]'),
+          $hideTrigger1 = fieldToggleVisibility.$triggers.filter('[data-dough-field-hide="1"]'),
+          $hideTrigger2 = fieldToggleVisibility.$triggers.filter('[data-dough-field-hide="2"]'),
           $target1 = fieldToggleVisibility.$el.find('[data-dough-field-target="1"]'),
           $target2 = fieldToggleVisibility.$el.find('[data-dough-field-target="2"]');
 

--- a/spec/support/checkbox_group_helpers.rb
+++ b/spec/support/checkbox_group_helpers.rb
@@ -5,20 +5,20 @@ module CheckboxGroupHelpers
     end
   end
 
-  def set_checkbox_group_state(page_object, all_options, checked_options)
+  def set_checkbox_group_state(page_object, all_options, checked_options, label: :name)
     checkbox_states = get_option_group_state(all_options,
                                              checked_options)
     checkbox_states.each do |state, advice_method|
-      page_object.find_field(advice_method.name).set(state)
+      page_object.find_field(advice_method.send label).set(state)
     end
   end
 
-  def expect_checkbox_group_state(page_object, all_options, checked_options)
+  def expect_checkbox_group_state(page_object, all_options, checked_options, label: :name)
     checkbox_states = get_option_group_state(all_options,
                                              checked_options)
     checkbox_states.each do |selected, advice_method|
-      expect(page_object).to have_checked_field(advice_method.name) if selected
-      expect(page_object).to have_unchecked_field(advice_method.name) unless selected
+      expect(page_object).to have_checked_field(advice_method.send label) if selected
+      expect(page_object).to have_unchecked_field(advice_method.send label) unless selected
     end
   end
 end


### PR DESCRIPTION
There's a fair amount of code changed here — apologies! The commits should make sense at least (I hope).

## Before

![image](https://cloud.githubusercontent.com/assets/1007202/8831042/9ada41d6-3097-11e5-8d2d-ff7c7a81d13e.png)

Two sets of checkboxes, one for face to face advice, one for remote advice. Firms could select any combination.

## After

![](http://g.recordit.co/gfhQIP9dLD.gif)

One set of radio buttons to pick a primary advice type, then:

If they pick remote, then they see

* A set of checkboxes to select remote advice methods.

If they pick face-to-face, they see:

* A set of checkboxes to select face-to-face advice methods.
* Another set of checkboxes to select remote advice methods (optional).

---

In terms of the JS, I decided to extend the existing FieldToggleVisibility component to be a bit more robust about letting me show and hide different things. This went pretty well until I needed to handle the situation when neither radio button was selected, and then it didn't work anymore. I added a little bit of extra jQuery to handle that situation — it's not nice but I'm hoping it's adequate. Do you think so?

We'll be working with this page a fair bit in coming months, so maybe I'll get to add in a data binding library for these slightly more involved scenarios. 