### PR TITLE
Allow Admin users to sign-in/behave like Principals

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,8 @@
+class Admin::UsersController < Admin::ApplicationController
+  def switch_user
+    user = User.find params[:user_id]
+    sign_in(:user, user)
+    flash[:notice] = "You are now signed in as #{user.principal.full_name}"
+    redirect_to self_service_root_path
+  end
+end

--- a/app/helpers/admin/firms_helper.rb
+++ b/app/helpers/admin/firms_helper.rb
@@ -16,6 +16,10 @@ module Admin::FirmsHelper
     end
   end
 
+  def user_for(principal)
+    User.find_by_principal_token principal.token
+  end
+
   private
 
   def render_literal_or_fee_or_percentage(value, attribute_name)

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -48,6 +48,9 @@
   </div>
 </div>
 
+
+<%= render 'admin/shared/sign_in_as_principal', principal: @firm.principal %>
+
 <% if @firm.subsidiary? %>
   <h2>Parent Firm</h2>
   <p>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -25,3 +25,5 @@
     </p>
   </div>
 </div>
+
+<%= render 'admin/shared/sign_in_as_principal', principal: @principal %>

--- a/app/views/admin/shared/_sign_in_as_principal.html.erb
+++ b/app/views/admin/shared/_sign_in_as_principal.html.erb
@@ -1,0 +1,8 @@
+<% if user_for(principal).present? %>
+  <h2>Edit</h2>
+
+  <%= form_tag(admin_users_sign_in_path) do %>
+    <%= hidden_field_tag(:user_id, user_for(principal).id) %>
+    <%= submit_tag "Sign in as #{principal.full_name}", class: 't-sign-in-as-principal' %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'pages#home'
+
+    post '/users/sign_in', to: 'users#switch_user'
+
     resources :advisers, only: [:index, :show, :edit, :update, :destroy]
 
     resources :firms, only: [:index, :show] do

--- a/spec/features/admin/move_advisers_spec.rb
+++ b/spec/features/admin/move_advisers_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature 'Move advisers between firms' do
   let(:confirm_page) { Admin::MoveAdvisers::ConfirmPage.new }
   let(:move_page) { Admin::MoveAdvisers::MovePage.new }
 
+  before do
+    create :user, principal: from_firm.principal
+  end
+
   scenario 'Moving an adviser from one firm to another' do
     given_i_want_to_move_an_adviser_from_firm(from_firm)
     and_i_want_to_move_adviser(adviser)

--- a/spec/features/admin/sign_in_as_principal_spec.rb
+++ b/spec/features/admin/sign_in_as_principal_spec.rb
@@ -1,0 +1,54 @@
+RSpec.feature 'Move advisers between firms' do
+  let(:admin_firm_page) { Admin::FirmPage.new }
+  let(:firms_index_page) { SelfService::FirmsIndexPage.new }
+  let(:updated_postcode) { 'EH11 2AB' }
+
+  scenario 'admin signs in as principal' do
+    given_there_is_a_fully_registered_principal_user
+    and_i_am_logged_in_as_an_admin_user
+    and_i_am_on_the_admin_firm_page
+    when_i_sign_in_as_principal
+    then_i_see "You are now signed in as #{@principal.full_name}"
+    and_i_am_on_the_self_service_firm_page
+  end
+
+  scenario 'admin visits page of firm with a principal without a user record' do
+    # i.e. when the invite rake task hasn't been run
+    given_there_is_a_principal
+    and_i_am_logged_in_as_an_admin_user
+    and_i_am_on_the_admin_firm_page
+    then_it_doesnt_blow_up
+  end
+
+  def given_there_is_a_fully_registered_principal_user
+    @user = FactoryGirl.create(:user)
+    @principal = @user.principal
+  end
+
+  def and_i_am_logged_in_as_an_admin_user
+  end
+
+  def and_i_am_on_the_admin_firm_page
+    admin_firm_page.load(firm_id: @principal.firm.id)
+  end
+
+  def when_i_sign_in_as_principal
+    admin_firm_page.sign_in_as_principal.click
+  end
+
+  def then_i_see(message)
+    expect(page.text).to include(message)
+  end
+
+  def and_i_am_on_the_self_service_firm_page
+    expect(firms_index_page).to be_displayed
+  end
+
+  def given_there_is_a_principal
+    @principal = FactoryGirl.create(:principal)
+  end
+
+  def then_it_doesnt_blow_up
+    expect(admin_firm_page).to_not have_text('NoMethodError')
+  end
+end

--- a/spec/support/admin/firm_page.rb
+++ b/spec/support/admin/firm_page.rb
@@ -3,4 +3,5 @@ class Admin::FirmPage < SitePrism::Page
   set_url_matcher %r{/admin/firms/[0-9]+}
 
   element :move_advisers, '.t-move-advisers'
+  element :sign_in_as_principal, '.t-sign-in-as-principal'
 end


### PR DESCRIPTION
To provide good customer service, 
Admin users need to be able to perform any operation within Self-Service that principals can.

This PR provides a button in the admin area of RAD to 'Sign in as <principal>' to allow the admin to edit the principals firm details, without having knowledge of the principals password.

This functionality is only accessible in the admin area of the site.