### PR TITLE
scoping firms and trading names to the current user within self-service

### DIFF
--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -2,20 +2,6 @@ module SelfService
   class AbstractFirmsController < ApplicationController
     before_action :authenticate_user!
 
-    def edit
-      @firm = Firm.find(params[:id])
-    end
-
-    def update
-      @firm = Firm.find(params[:id])
-      if @firm.update(firm_params)
-        flash[:notice] = I18n.t('self_service.firm_edit.saved')
-        redirect_to_edit
-      else
-        render :edit
-      end
-    end
-
     protected
 
     def principal

--- a/app/controllers/self_service/firms_controller.rb
+++ b/app/controllers/self_service/firms_controller.rb
@@ -7,6 +7,20 @@ module SelfService
       @presenter = FirmsIndexPresenter.new(firm, trading_names, available_trading_names(firm: firm))
     end
 
+    def edit
+      @firm = principal.firm
+    end
+
+    def update
+      @firm = principal.firm
+      if @firm.update(firm_params)
+        flash[:notice] = I18n.t('self_service.firm_edit.saved')
+        redirect_to_edit
+      else
+        render :edit
+      end
+    end
+
     private
 
     def available_trading_names(firm:)

--- a/app/controllers/self_service/trading_names_controller.rb
+++ b/app/controllers/self_service/trading_names_controller.rb
@@ -15,6 +15,20 @@ module SelfService
       end
     end
 
+    def edit
+      @firm = principal.firm.trading_names.find(params[:id])
+    end
+
+    def update
+      @firm = principal.firm.trading_names.find(params[:id])
+      if @firm.update(firm_params)
+        flash[:notice] = I18n.t('self_service.firm_edit.saved')
+        redirect_to_edit
+      else
+        render :edit
+      end
+    end
+
     def destroy
       trading_name = principal.firm.trading_names.registered.find(params[:id])
       trading_name.destroy
@@ -27,7 +41,7 @@ module SelfService
 
     def initialize_firm_from_lookup_trading_name(id)
       lookup_name = Lookup::Subsidiary.find_by!(id: id, fca_number: principal.fca_number)
-      @firm = principal.firm.subsidiaries.find_or_initialize_by(
+      @firm = principal.firm.trading_names.find_or_initialize_by(
         registered_name: lookup_name.name,
         fca_number: lookup_name.fca_number
       )

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -1,91 +1,153 @@
-module SelfService
-  RSpec.describe SelfService::TradingNamesController, type: :controller do
-    let(:principal) { FactoryGirl.create(:principal) }
-    let(:firm) do
-      firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
-      principal.firm.update_attributes(firm_attrs)
-      principal.firm
-    end
-    let(:user) { FactoryGirl.create :user, principal: firm.principal }
-    let(:lookup_subsidiary) { FactoryGirl.create(:lookup_subsidiary, fca_number: principal.fca_number) }
-    before { sign_in(user) }
+RSpec.describe SelfService::TradingNamesController, type: :controller do
+  let(:principal) { FactoryGirl.create(:principal) }
+  let(:firm) do
+    firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
+    principal.firm.update_attributes(firm_attrs)
+    principal.firm
+  end
+  let(:user) { FactoryGirl.create :user, principal: firm.principal }
+  let(:lookup_subsidiary) { FactoryGirl.create(:lookup_subsidiary, fca_number: principal.fca_number) }
+  before { sign_in(user) }
 
-    def build_firm_params(params = {})
-      firm = FactoryGirl.build(:firm)
-      firm_params = firm.attributes
-      firm_params.symbolize_keys!
-      firm_params[:initial_advice_fee_structure_ids] = firm.initial_advice_fee_structure_ids
-      firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
-      firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
-      firm_params[:investment_size_ids] = firm.investment_size_ids
-      firm_params[:primary_advice_method] = firm.primary_advice_method
-      firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
-      firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
-      firm_params.merge(params)
-    end
+  def build_firm_params(params = {})
+    firm = params[:firm] || FactoryGirl.build(:firm)
+    firm_params = firm.attributes
+    firm_params.symbolize_keys!
+    firm_params[:initial_advice_fee_structure_ids] = firm.initial_advice_fee_structure_ids
+    firm_params[:ongoing_advice_fee_structure_ids] = firm.ongoing_advice_fee_structure_ids
+    firm_params[:allowed_payment_method_ids] = firm.allowed_payment_method_ids
+    firm_params[:investment_size_ids] = firm.investment_size_ids
+    firm_params[:primary_advice_method] = firm.primary_advice_method
+    firm_params[:other_advice_method_ids] = firm.other_advice_method_ids
+    firm_params[:in_person_advice_method_ids] = firm.in_person_advice_method_ids
+    firm_params.merge(params)
+  end
 
-    describe 'GET #new' do
-      context 'when not passed a lookup_id' do
-        it 'raises a 404' do
-          expect { get :new }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-
-      context 'when not passed a non-existent lookup_id' do
-        it 'raises a 404' do
-          expect { get :new, lookup_id: '9999999' }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-
-      context 'when passed a lookup_id' do
-        before { get :new, lookup_id: lookup_subsidiary.id }
-
-        it 'assigns a new firm with the name & fca number of the lookup firm' do
-          expect(assigns(:firm).registered_name).to eq lookup_subsidiary.name
-          expect(assigns(:firm).fca_number).to eq lookup_subsidiary.fca_number
-        end
-
-        it 'assigns a new firm with the parent id of the principal’s firm' do
-          expect(assigns(:firm).parent_id).to eq firm.id
-        end
-
-        it 'renders the new page' do
-          expect(subject).to render_template 'self_service/trading_names/new'
-        end
+  describe 'GET #new' do
+    context 'when not passed a lookup_id' do
+      it 'raises a 404' do
+        expect { get :new }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
-    describe 'POST #create' do
-      context 'when passed valid details' do
-        let(:firm_params) { build_firm_params }
-        before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
+    context 'when not passed a non-existent lookup_id' do
+      it 'raises a 404' do
+        expect { get :new, lookup_id: '9999999' }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
 
-        it 'creates the firm' do
-          expect(assigns(:firm).persisted?).to be_truthy
-          expect(assigns(:firm).email_address).to eq firm_params[:email_address]
-        end
+    context 'when passed a lookup_id' do
+      before { get :new, lookup_id: lookup_subsidiary.id }
 
-        it 'assigns the firm to the principal’s firm' do
-          expect(assigns(:firm).parent_id).to eq firm.id
-        end
-
-        it 'redirects to the edit page' do
-          redirect_path = edit_self_service_trading_name_path(assigns(:firm))
-          expect(response).to redirect_to redirect_path
-        end
+      it 'assigns a new firm with the name & fca number of the lookup firm' do
+        expect(assigns(:firm).registered_name).to eq lookup_subsidiary.name
+        expect(assigns(:firm).fca_number).to eq lookup_subsidiary.fca_number
       end
 
-      context 'when passed invalid details' do
-        let(:firm_params) { build_firm_params(email_address: 'not_valid') }
-        before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
+      it 'assigns a new firm with the parent id of the principal’s firm' do
+        expect(assigns(:firm).parent_id).to eq firm.id
+      end
 
-        it 'does not create the firm' do
-          expect(firm.trading_names).to be_empty
-        end
+      it 'renders the new page' do
+        expect(subject).to render_template 'self_service/trading_names/new'
+      end
+    end
+  end
 
-        it 'renders the new page' do
-          expect(response).to render_template 'self_service/trading_names/new'
-        end
+  describe 'POST #create' do
+    context 'when passed valid details' do
+      let(:firm_params) { build_firm_params }
+      before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
+
+      it 'creates the firm' do
+        expect(assigns(:firm).persisted?).to be_truthy
+        expect(assigns(:firm).email_address).to eq firm_params[:email_address]
+      end
+
+      it 'assigns the firm to the principal’s firm' do
+        expect(assigns(:firm).parent_id).to eq firm.id
+      end
+
+      it 'redirects to the edit page' do
+        redirect_path = edit_self_service_trading_name_path(assigns(:firm))
+        expect(response).to redirect_to redirect_path
+      end
+    end
+
+    context 'when passed invalid details' do
+      let(:firm_params) { build_firm_params(email_address: 'not_valid') }
+      before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
+
+      it 'does not create the firm' do
+        expect(firm.trading_names).to be_empty
+      end
+
+      it 'renders the new page' do
+        expect(response).to render_template 'self_service/trading_names/new'
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let!(:trading_name) { create :firm, parent: firm }
+    context 'when accessing current users firm' do
+      before { get :edit, id: trading_name.id }
+
+      it 'assigns the trading name' do
+        expect(assigns(:firm)).to eq trading_name
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template 'self_service/trading_names/edit'
+      end
+    end
+
+    context 'when trying to access another users trading_name' do
+      let!(:other_principal) { create :principal }
+
+      it 'does not assign the other principals trading names' do
+        other_trading_name = create :firm, parent: other_principal.firm
+        expect { get :edit, id: other_trading_name.id }.to raise_error
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:trading_name) { create :firm, parent: firm }
+    let(:trading_name_params) { build_firm_params(firm: trading_name, email_address: 'valid@example.com') }
+    context 'when passed valid details' do
+      before { patch :update, id: trading_name.id, firm: trading_name_params }
+
+      it 'updates the trading_name' do
+        expect(trading_name.reload.email_address).to eq trading_name_params[:email_address]
+      end
+
+      it 'redirects to the edit page' do
+        redirect_path = edit_self_service_trading_name_path(id: trading_name.id)
+        expect(response).to redirect_to redirect_path
+      end
+    end
+
+    context 'when trying to access another users trading_name' do
+      let!(:other_principal) { create :principal }
+      let(:trading_name_params) { build_firm_params(firm: trading_name, email_address: 'valid@example.com') }
+
+      it 'fails to respond successfully' do
+        other_trading_name = create :firm, parent: other_principal.firm
+        expect { patch :update, id: other_trading_name.id, firm: firm_params }.to raise_error
+      end
+    end
+
+    context 'when passed invalid details' do
+      let(:firm_params) { build_firm_params(firm: trading_name, email_address: 'not_valid') }
+      before { patch :update, id: trading_name.id, firm: firm_params }
+
+      it 'does not update the firm' do
+        expect(trading_name.reload.email_address).not_to eq firm_params[:email_address]
+      end
+
+      it 'renders the edit page' do
+        expect(response).to render_template 'self_service/trading_names/edit'
       end
     end
   end


### PR DESCRIPTION
Original implementation allow signed in self service users to tweak urls to edit other users firms and trading_names.

To solve this we've scoped everything from the `current_user.principal.firm`