### PR TITLE
[DEV APPROVED] Update dough from 5.1.0 -> 5.7.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'devise_security_extension'
 gem 'dough-ruby',
     github: 'moneyadviceservice/dough',
     require: 'dough',
-    ref: 'cf08913'
+    ref: '77dc86f'
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: git://github.com/moneyadviceservice/dough.git
-  revision: cf089138b49435ee2e5f3f10a477500e93edd951
-  ref: cf08913
+  revision: 77dc86fbef0c0cf7137b5129bd2b2e4e1f8da259
+  ref: 77dc86f
   specs:
-    dough-ruby (5.1.0)
+    dough-ruby (5.7.3)
       activesupport
       rails (>= 3.2)
       sass-rails (~> 4.0.0)

--- a/app/assets/javascripts/modules/FieldToggleVisibility.js
+++ b/app/assets/javascripts/modules/FieldToggleVisibility.js
@@ -36,6 +36,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @private
    */
   DoughBaseComponent.extend(FieldToggleVisibility);
+  FieldToggleVisibility.componentName = 'FieldToggleVisibility';
   FieldToggleVisibilityProto = FieldToggleVisibility.prototype;
 
   /**

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -25,6 +25,7 @@
       MultiTableFilter: requirejs_path('modules/MultiTableFilter'),
       ConfirmableForm: requirejs_path('modules/ConfirmableForm'),
       componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
+      utilities: requirejs_path('dough/assets/js/lib/utilities'),
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
       FieldHelpText: requirejs_path('dough/assets/js/components/FieldHelpText'),
       eventsWithPromises: requirejs_path('eventsWithPromises/src/eventsWithPromises'),

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -1,5 +1,13 @@
 //= depend_on_asset jquery/dist/jquery
 //= depend_on_asset jquery-fastlivefilter/jquery.fastLiveFilter
+
+//= depend_on_asset dough/assets/js/lib/componentLoader
+//= depend_on_asset dough/assets/js/lib/utilities
+//= depend_on_asset dough/assets/js/components/DoughBaseComponent
+//= depend_on_asset dough/assets/js/components/FieldHelpText
+//= depend_on_asset eventsWithPromises/src/eventsWithPromises
+//= depend_on_asset rsvp/rsvp
+
 //= depend_on_asset modules/FieldToggleVisibility
 //= depend_on_asset modules/AdviserAjaxCall
 //= depend_on_asset modules/DataTransform

--- a/app/views/layouts/_mas_head.html.erb
+++ b/app/views/layouts/_mas_head.html.erb
@@ -1,14 +1,14 @@
-<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/basic-ea7670b1f707d74ea3995dc089465c3a.css" media="screen" rel="stylesheet" />
+<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/basic-e7b486ea05952e6a617d1e9b8e24c0aa.css" media="screen" rel="stylesheet" />
 
 <!--[if ( gte IE 7 ) & ( lte IE 8 ) & (!IEMobile) ]>
-<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_files-ff703b1d1494bc230ea71275731abdde.css" media="screen" rel="stylesheet" />
-<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_fixed-ec3120ee9d7ff3a43394b5e68669525f.css" media="all" rel="stylesheet" />
-<script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/html5shiv/dist/html5shiv-fee07e49a2d47f6e8f4f18d64a93ed5e.js"></script>
-<script>var responsiveStyle = false;</script>
+  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_files-442dafc21ff87a79e5ff0cb0979691b4.css" media="screen" rel="stylesheet" />
+  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_fixed-a94a5184a6cf84af5ff5705cd3e4bcd5.css" media="all" rel="stylesheet" />
+  <script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/html5shiv/dist/html5shiv-7e00c9993fc9d04c278d8c8041edbc62.js"></script>
+  <script>var responsiveStyle = false;</script>
 <![endif]-->
 
 <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
-<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_responsive-b06b59642cc009662e29331e12b6a2a1.css" media="only all" rel="stylesheet" />
+<link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_responsive-eed1f17afec8152707db50a11d36bb5d.css" media="only all" rel="stylesheet" />
 <script>var responsiveStyle = true;</script>
 <!--<![endif]-->
 
@@ -26,7 +26,7 @@ var require = {
 
       appendFile = function(tag, src, content) {
         var position = d.getElementsByTagName('script')[0],
-        file = d.createElement(tag);
+            file = d.createElement(tag);
         if (tag === 'script') {
           file.async = true;
           file.type = "text/javascript";
@@ -46,7 +46,7 @@ var require = {
       };
 
       fonts = {
-        url: 'https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_base64-348ce9151db29f9a692d5d63f1b30b36.css',
+        url: 'https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_base64-390ace12989d92c6dacf27ed27d8d7ed.css',
         cacheName: 'MAS.fonts',
         loadClass: 'wf-museosans-n4-active fontsLoaded',
         localstorage: undefined,

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -29,6 +29,7 @@ require.config({
     FieldToggleVisibility: 'app/assets/javascripts/modules/FieldToggleVisibility',
     MultiTableFilter: 'app/assets/javascripts/modules/MultiTableFilter',
     ConfirmableForm: 'app/assets/javascripts/modules/ConfirmableForm',
+    utilities: 'vendor/assets/bower_components/dough/assets/js/lib/utilities',
     List: 'vendor/assets/bower_components/list.js/dist/list'
   },
 


### PR DESCRIPTION
RAD pulls in this stuff in a bit of a funny way. Two points.

1. We're calling it from github, not the gem server, so that we don't need VPN access.
2. We also pull in frontend's styles by calling through to a newish version on the CDN.

Questions on this welcome.