### PR TITLE
Add a login panel to the RAD homepage

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -7,6 +7,7 @@
 
 @import 'states/hidden';
 
+@import 'layouts/2col';
 @import 'layouts/constrained';
 @import 'layouts/self_service';
 @import 'layouts/firm';

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -34,6 +34,7 @@
 @import 'components/notice/all';
 @import 'components/form_section';
 @import 'components/inline_list_with_separator';
+@import 'components/sign_in_panel';
 
 // Shame
 

--- a/app/assets/stylesheets/components/_sign_in_panel.scss
+++ b/app/assets/stylesheets/components/_sign_in_panel.scss
@@ -1,0 +1,16 @@
+.sign-in-panel__heading {
+  margin: 0 0 $baseline-unit 0;
+}
+
+.sign-in-panel__actions {
+  @extend %clearfix;
+}
+
+.sign-in-panel__actions__link {
+  display: inline-block;
+  padding: 12px 0;
+}
+
+.sign-in-panel__actions__submit {
+  float: right;
+}

--- a/app/assets/stylesheets/layouts/_2col.scss
+++ b/app/assets/stylesheets/layouts/_2col.scss
@@ -1,0 +1,3 @@
+.l-2col-side--pull-right {
+  float: right;
+}

--- a/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
+++ b/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
@@ -1,6 +1,9 @@
 .l-pre-qualification {
-  @include column(12);
   margin-bottom: $baseline-unit*8;
+}
+
+.l-pre-qualification--restricted-width {
+  @include column(12);
 
   @include respond-to($mq-m) {
     @include column(9);
@@ -9,10 +12,6 @@
   @include respond-to($mq-l) {
     @include column(7);
   }
-}
-
-.l-pre-qualification__intro-text {
-  margin-bottom: $baseline-unit*8;
 }
 
 .l-pre-qualification__question {

--- a/app/helpers/sign_in_panel_helper.rb
+++ b/app/helpers/sign_in_panel_helper.rb
@@ -1,0 +1,10 @@
+module SignInPanelHelper
+  def sign_in_resource_name
+    # This must match the value passed to `devise_for` in routes.rb
+    :user
+  end
+
+  def sign_in_resource
+    @sign_in_resource ||= Devise.mappings[sign_in_resource_name].to.new
+  end
+end

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -5,6 +5,10 @@
   </div>
 
   <div class="l-2col">
+    <section class="l-2col-side l-2col-side--pull-right">
+      <%= render 'shared/sign_in_panel' %>
+    </section>
+
     <section class="l-2col-main">
       <%= heading_tag(t('registration.sub_heading'), level: 2) %>
       <p><%= t('registration.eligibility_explanation') %></p>
@@ -120,10 +124,6 @@
 
         <button class="button button--primary t-submit-button"><%= t('registration.submit_button') %></button>
       <% end %>
-    </section>
-
-    <section class="l-2col-side">
-      <%= render 'shared/sign_in_panel' %>
     </section>
   </div>
 </div>

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -118,7 +118,7 @@
           </div>
         </div>
 
-        <button class="button button--primary t-button-next"><%= t('registration.button_next') %></button>
+        <button class="button button--primary t-submit-button"><%= t('registration.submit_button') %></button>
       <% end %>
     </section>
 

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -1,119 +1,129 @@
-<div class="l-constrained">
-  <section class="l-pre-qualification">
+<div class="l-constrained l-pre-qualification">
+  <div class="l-1col">
     <%= heading_tag(t('registration.heading'), level: 1) %>
-    <p class="l-pre-qualification__intro-text"><%= t('registration.introduction') %></p>
+    <p class="intro"><%= t('registration.introduction') %></p>
+  </div>
 
-    <%= form_for @prequalification, url: prequalify_principals_path, html: { class: 'form' } do |f| %>
-      <%= f.form_row :active_question do %>
-        <fieldset class="form__group form__group--inline t-active-question">
-          <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.active_question.heading') %></legend>
-          <p><%= t('registration.active_question.description') %></p>
-
-          <div class="form__group-item">
-            <label>
-              <%= f.radio_button :active_question, 1, class: 'form__group-input' %>
-              <%= t('registration.answer_yes') %>
-            </label>
-          </div>
-
-          <div class="form__group-item">
-            <label>
-              <%= f.radio_button :active_question, 0, class: 'form__group-input' %>
-              <%= t('registration.answer_no') %>
-            </label>
-          </div>
-        </fieldset>
-      <% end %>
-
-      <%= f.form_row :business_model_question do %>
-        <fieldset class="form__group form__group--inline t-business-model-question">
-          <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.business_model_question.heading') %></legend>
-          <p><%= t('registration.business_model_question.description') %></p>
-
-          <div class="form__group-item">
-            <label>
-              <%= f.radio_button :business_model_question, 1, class: 'form__group-input' %>
-              <%= t('registration.answer_yes') %>
-            </label>
-          </div>
-
-          <div class="form__group-item">
-            <label>
-              <%= f.radio_button :business_model_question, 0, class: 'form__group-input' %>
-              <%= t('registration.answer_no') %>
-            </label>
-          </div>
-        </fieldset>
-      <% end %>
-
-      <div data-dough-component="FieldToggleVisibility">
-        <%= f.form_row :status_question do %>
-          <fieldset class="form__group form__group--inline t-status-question">
-            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.status_question.heading') %></legend>
-            <p><%= t('registration.status_question.description') %></p>
+  <div class="l-2col">
+    <section class="l-2col-main">
+      <%= heading_tag(t('registration.sub_heading'), level: 2) %>
+      <p><%= t('registration.eligibility_explanation') %></p>
+      <%= form_for @prequalification, url: prequalify_principals_path, html: { class: 'form' } do |f| %>
+        <%= f.form_row :active_question do %>
+          <fieldset class="form__group form__group--inline t-active-question">
+            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.active_question.heading') %></legend>
+            <p><%= t('registration.active_question.description') %></p>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_hide: '1'  } %>
-                <%= t('registration.status_question.answer_one') %>
+                <%= f.radio_button :active_question, 1, class: 'form__group-input' %>
+                <%= t('registration.answer_yes') %>
               </label>
             </div>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_show: '1' } %>
-                <%= t('registration.status_question.answer_two') %>
-                <span class="visually-hidden"><%= t('registration.notice') %></span>
+                <%= f.radio_button :active_question, 0, class: 'form__group-input' %>
+                <%= t('registration.answer_no') %>
               </label>
             </div>
           </fieldset>
         <% end %>
 
-        <div data-dough-field-target="1">
-          <%= f.form_row :particular_market_question do %>
-            <fieldset class="form__group form__group--inline t-particular-market-question">
-              <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.particular_market_question.heading') %></legend>
+        <%= f.form_row :business_model_question do %>
+          <fieldset class="form__group form__group--inline t-business-model-question">
+            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.business_model_question.heading') %></legend>
+            <p><%= t('registration.business_model_question.description') %></p>
+
+            <div class="form__group-item">
+              <label>
+                <%= f.radio_button :business_model_question, 1, class: 'form__group-input' %>
+                <%= t('registration.answer_yes') %>
+              </label>
+            </div>
+
+            <div class="form__group-item">
+              <label>
+                <%= f.radio_button :business_model_question, 0, class: 'form__group-input' %>
+                <%= t('registration.answer_no') %>
+              </label>
+            </div>
+          </fieldset>
+        <% end %>
+
+        <div data-dough-component="FieldToggleVisibility">
+          <%= f.form_row :status_question do %>
+            <fieldset class="form__group form__group--inline t-status-question">
+              <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.status_question.heading') %></legend>
+              <p><%= t('registration.status_question.description') %></p>
 
               <div class="form__group-item">
                 <label>
-                  <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_show: '2'  } %>
-                  <%= t('registration.answer_yes') %>
+                  <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_hide: '1'  } %>
+                  <%= t('registration.status_question.answer_one') %>
+                </label>
+              </div>
+
+              <div class="form__group-item">
+                <label>
+                  <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_show: '1' } %>
+                  <%= t('registration.status_question.answer_two') %>
                   <span class="visually-hidden"><%= t('registration.notice') %></span>
                 </label>
               </div>
-
-              <div class="form__group-item">
-                <label>
-                  <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_hide: '2'  } %>
-                  <%= t('registration.answer_no') %>
-                </label>
-              </div>
             </fieldset>
           <% end %>
 
-          <%= f.form_row :consider_available_providers_question do %>
-            <fieldset class="form__group form__group--inline t-consider-available-providers-question" data-dough-field-target="2">
-              <legend class="l-pre-qualification__question"><%= t('registration.consider_available_providers_question.heading') %></legend>
+          <div data-dough-field-target="1">
+            <%= f.form_row :particular_market_question do %>
+              <fieldset class="form__group form__group--inline t-particular-market-question">
+                <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.particular_market_question.heading') %></legend>
 
-              <div class="form__group-item">
-                <label>
-                  <%= f.radio_button :consider_available_providers_question, 1, class: 'form__group-input' %>
-                  <%= t('registration.answer_yes') %>
-                </label>
-              </div>
+                <div class="form__group-item">
+                  <label>
+                    <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_show: '2'  } %>
+                    <%= t('registration.answer_yes') %>
+                    <span class="visually-hidden"><%= t('registration.notice') %></span>
+                  </label>
+                </div>
 
-              <div class="form__group-item">
-                <label>
-                  <%= f.radio_button :consider_available_providers_question, 0, class: 'form__group-input' %>
-                  <%= t('registration.answer_no') %>
-                </label>
-              </div>
-            </fieldset>
-          <% end %>
+                <div class="form__group-item">
+                  <label>
+                    <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_hide: '2'  } %>
+                    <%= t('registration.answer_no') %>
+                  </label>
+                </div>
+              </fieldset>
+            <% end %>
+
+            <%= f.form_row :consider_available_providers_question do %>
+              <fieldset class="form__group form__group--inline t-consider-available-providers-question" data-dough-field-target="2">
+                <legend class="l-pre-qualification__question"><%= t('registration.consider_available_providers_question.heading') %></legend>
+
+                <div class="form__group-item">
+                  <label>
+                    <%= f.radio_button :consider_available_providers_question, 1, class: 'form__group-input' %>
+                    <%= t('registration.answer_yes') %>
+                  </label>
+                </div>
+
+                <div class="form__group-item">
+                  <label>
+                    <%= f.radio_button :consider_available_providers_question, 0, class: 'form__group-input' %>
+                    <%= t('registration.answer_no') %>
+                  </label>
+                </div>
+              </fieldset>
+            <% end %>
+          </div>
         </div>
-      </div>
 
-      <%= button_primary t('registration.button_next') %>
-    <% end %>
-  </section>
+        <%= button_primary t('registration.button_next') %>
+      <% end %>
+    </section>
+
+    <section class="l-2col-side">
+      <%= render 'shared/sign_in_panel' %>
+    </section>
+  </div>
 </div>

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -118,7 +118,7 @@
           </div>
         </div>
 
-        <%= button_primary t('registration.button_next') %>
+        <button class="button button--primary t-button-next"><%= t('registration.button_next') %></button>
       <% end %>
     </section>
 

--- a/app/views/principals/rejection_form.html.erb
+++ b/app/views/principals/rejection_form.html.erb
@@ -1,5 +1,5 @@
 <div class="l-constrained">
-  <%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification' },
+  <%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification l-pre-qualification--restricted-width' },
     builder: Dough::Forms::Builders::Validation do |f| %>
     <%= f.validation_summary %>
     <%= heading_tag(t('rejection.heading'), level: 1) %>
@@ -19,7 +19,7 @@
       <label class="form__label-heading"><%= t('rejection.email_address') %></label>
       <%= f.email_field :email, class: 't-email' %>
     <% end %>
-    
+
     <%= f.form_row :message do %>
       <%= f.errors_for :message %>
       <label class="form__label-heading"><%= t('rejection.message') %></label>

--- a/app/views/shared/_sign_in_panel.html.erb
+++ b/app/views/shared/_sign_in_panel.html.erb
@@ -1,4 +1,4 @@
-<div class="panel">
+<div class="panel t-sign-in-panel">
   <%= heading_tag(t('sign_in_panel.heading'), level: 2, class: 'sign-in-panel__heading') %>
   <p><%= t('sign_in_panel.description') %></p>
 
@@ -29,8 +29,8 @@
 
     <div class="registration__row">
       <div class="registration__field sign-in-panel__actions">
-        <%= link_to t('authentication.sign_in_page.forgot_password'), new_password_path(sign_in_resource_name), class: 'sign-in-panel__actions__link' %>
-        <%= f.submit t('authentication.sign_in_page.label'), class: 'button button--primary sign-in-panel__actions__submit' %>
+        <%= link_to t('authentication.sign_in_page.forgot_password'), new_password_path(sign_in_resource_name), class: 'sign-in-panel__actions__link t-forgot-password' %>
+        <%= f.submit t('authentication.sign_in_page.label'), class: 'button button--primary sign-in-panel__actions__submit t-sign-in-button' %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_sign_in_panel.html.erb
+++ b/app/views/shared/_sign_in_panel.html.erb
@@ -1,0 +1,37 @@
+<div class="panel">
+  <%= heading_tag(t('sign_in_panel.heading'), level: 2, class: 'sign-in-panel__heading') %>
+  <p><%= t('sign_in_panel.description') %></p>
+
+  <%= form_for(sign_in_resource, as: sign_in_resource_name,
+                                 url: session_path(sign_in_resource_name),
+                                 builder: Dough::Forms::Builders::Validation,
+                                 html: { class: 'form', novalidate: 'novalidate'}) do |f| %>
+
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :login do %>
+          <%= f.errors_for :login %>
+          <%= f.label :login, class: "form__label-heading" %>
+          <%= f.email_field :login, class: 't-login-field', autofocus: true, 'aria-describedby' => 'tooltip_login' %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.errors_for :password %>
+          <%= f.label :password, class: 'form__label-heading' %>
+          <%= f.password_field :password, class: 't-password-field', autocomplete: 'off', 'aria-describedby' => 'tooltip_password' %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="registration__row">
+      <div class="registration__field sign-in-panel__actions">
+        <%= link_to t('authentication.sign_in_page.forgot_password'), new_password_path(sign_in_resource_name), class: 'sign-in-panel__actions__link' %>
+        <%= f.submit t('authentication.sign_in_page.label'), class: 'button button--primary sign-in-panel__actions__submit' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,7 @@ en:
 
   registration:
     heading: Retirement Adviser Directory – Self Service
-    introduction: Register your firm to appear on the directory or sign in to edit your firm's details.
+    introduction: Sign in to edit your firm's details, or register your firm to appear on the directory.
     sub_heading: Register your firm
     eligibility_explanation: Answer the following questions to see if your firm is eligible to appear on the directory.
     notice: Selecting this option will reveal a further question below.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
     sub_heading: Register your firm
     eligibility_explanation: Answer the following questions to see if your firm is eligible to appear on the directory.
     notice: Selecting this option will reveal a further question below.
-    button_next: Register now
+    submit_button: Register now
 
     answer_yes: "Yes"
     answer_no: "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,11 +108,17 @@ en:
       advice: We advise you to keep this email safe as you will need the link below to continue your firm's registration process.
       verify_email_link: Please click the link below to verify your email address and continue with the registration process.
 
+  sign_in_panel:
+    heading: Already Registered?
+    description: Sign in to your account to edit your firm's details.
+
   registration:
-    heading: Register your firm
-    introduction: Register your firm on our Retirement Adviser Directory
+    heading: Retirement Adviser Directory – Self Service
+    introduction: Register your firm to appear on the directory or sign in to edit your firm's details.
+    sub_heading: Register your firm
+    eligibility_explanation: Answer the following questions to see if your firm is eligible to appear on the directory.
     notice: Selecting this option will reveal a further question below.
-    button_next: Next
+    button_next: Register now
 
     answer_yes: "Yes"
     answer_no: "No"

--- a/spec/features/sign_in_panel_spec.rb
+++ b/spec/features/sign_in_panel_spec.rb
@@ -1,0 +1,77 @@
+RSpec.feature 'Principal can sign in using the embedded sign in panel' do
+  let(:panel_host_page) { RootPage.new }
+  let(:sign_in_page) { SignInPage.new }
+  let(:after_signin_page) { SelfService::FirmsIndexPage.new }
+  let(:forgot_password_page) { ForgotPasswordPage.new }
+
+  before do
+    panel_host_page.load
+  end
+
+  scenario 'Principal can sign in with FRN and password' do
+    given_the_principal_user_exists
+    when_they_sign_in_with_frn_and_password
+    they_see_the_after_signin_page
+    they_have_logged_in
+  end
+
+  scenario 'Principal cannot sign in with incorrect details' do
+    given_the_principal_user_exists
+    when_they_sign_in_with_incorrect_details
+    they_have_not_logged_in
+    they_see_the_sign_in_page
+    and_they_see_a_notice_that_their_details_were_incorrect
+  end
+
+  scenario 'Principal clicks the forgotten password link' do
+    when_the_principal_clicks_the_forgotten_password_link
+    then_they_see_the_forgotten_password_page
+  end
+
+  def given_the_principal_user_exists
+    @user = FactoryGirl.create(:user)
+  end
+
+  def when_they_sign_in_with_frn_and_password
+    panel_host_page.sign_in_panel.login_field.set @user.principal.fca_number
+    panel_host_page.sign_in_panel.password_field.set 'Password1!'
+    panel_host_page.sign_in_panel.submit_button.click
+  end
+
+  def when_they_sign_in_with_incorrect_details
+    panel_host_page.sign_in_panel.login_field.set @user.email
+    panel_host_page.sign_in_panel.password_field.set 'not_a_password'
+    panel_host_page.sign_in_panel.submit_button.click
+  end
+
+  def they_have_logged_in
+    expect(@user.reload.sign_in_count).to eq 1
+    expect(after_signin_page.navigation).to have_sign_out
+  end
+
+  def they_have_not_logged_in
+    expect(@user.reload.sign_in_count).to eq 0
+    expect(after_signin_page.navigation).to have_sign_in
+  end
+
+  def they_see_the_after_signin_page
+    expect(after_signin_page).to be_displayed
+  end
+
+  def they_see_the_sign_in_page
+    expect(sign_in_page).to be_displayed
+  end
+
+  def and_they_see_a_notice_that_their_details_were_incorrect
+    expect(sign_in_page.devise_form_errors).to have_text(
+      I18n.t('devise.failure.invalid', authentication_keys: 'login'))
+  end
+
+  def when_the_principal_clicks_the_forgotten_password_link
+    panel_host_page.sign_in_panel.forgot_password_link.click
+  end
+
+  def then_they_see_the_forgotten_password_page
+    expect(forgot_password_page).to be_displayed
+  end
+end

--- a/spec/features/sign_in_panel_spec.rb
+++ b/spec/features/sign_in_panel_spec.rb
@@ -4,19 +4,17 @@ RSpec.feature 'Principal can sign in using the embedded sign in panel' do
   let(:after_signin_page) { SelfService::FirmsIndexPage.new }
   let(:forgot_password_page) { ForgotPasswordPage.new }
 
-  before do
-    panel_host_page.load
-  end
-
   scenario 'Principal can sign in with FRN and password' do
-    given_the_principal_user_exists
+    given_the_login_page_is_loaded
+    and_the_principal_user_exists
     when_they_sign_in_with_frn_and_password
     they_see_the_after_signin_page
     they_have_logged_in
   end
 
   scenario 'Principal cannot sign in with incorrect details' do
-    given_the_principal_user_exists
+    given_the_login_page_is_loaded
+    and_the_principal_user_exists
     when_they_sign_in_with_incorrect_details
     they_have_not_logged_in
     they_see_the_sign_in_page
@@ -24,11 +22,17 @@ RSpec.feature 'Principal can sign in using the embedded sign in panel' do
   end
 
   scenario 'Principal clicks the forgotten password link' do
+    given_the_login_page_is_loaded
     when_the_principal_clicks_the_forgotten_password_link
     then_they_see_the_forgotten_password_page
   end
 
-  def given_the_principal_user_exists
+  def given_the_login_page_is_loaded
+    panel_host_page.load
+    expect(panel_host_page).to be_displayed
+  end
+
+  def and_the_principal_user_exists
     @user = FactoryGirl.create(:user)
   end
 

--- a/spec/support/pre_qualification_page.rb
+++ b/spec/support/pre_qualification_page.rb
@@ -7,7 +7,7 @@ class PreQualificationPage < SitePrism::Page
   element :status_question, '.t-status-question'
   element :particular_market_question, '.t-particular-market-question'
   element :consider_available_providers_question, '.t-consider-available-providers-question'
-  element :submit, '.button--primary'
+  element :submit, '.t-button-next'
 
   element :error_message, '.global-alert--error'
 end

--- a/spec/support/pre_qualification_page.rb
+++ b/spec/support/pre_qualification_page.rb
@@ -7,7 +7,7 @@ class PreQualificationPage < SitePrism::Page
   element :status_question, '.t-status-question'
   element :particular_market_question, '.t-particular-market-question'
   element :consider_available_providers_question, '.t-consider-available-providers-question'
-  element :submit, '.t-button-next'
+  element :submit, '.t-submit-button'
 
   element :error_message, '.global-alert--error'
 end

--- a/spec/support/root_page.rb
+++ b/spec/support/root_page.rb
@@ -1,0 +1,6 @@
+class RootPage < SitePrism::Page
+  set_url '/'
+  set_url_matcher %r{/$}
+
+  section :sign_in_panel, SignInPanelSection, '.t-sign-in-panel'
+end

--- a/spec/support/root_page.rb
+++ b/spec/support/root_page.rb
@@ -1,6 +1,6 @@
 class RootPage < SitePrism::Page
   set_url '/'
-  set_url_matcher %r{/$}
+  set_url_matcher %r{#{Capybara.default_host}/$}
 
   section :sign_in_panel, SignInPanelSection, '.t-sign-in-panel'
 end

--- a/spec/support/sign_in_panel_section.rb
+++ b/spec/support/sign_in_panel_section.rb
@@ -1,0 +1,6 @@
+class SignInPanelSection < SitePrism::Section
+  element :login_field, '.t-login-field'
+  element :password_field, '.t-password-field'
+  element :submit_button, '.t-sign-in-button'
+  element :forgot_password_link, '.t-forgot-password'
+end


### PR DESCRIPTION
# Rationale

We will now have many more users visiting this page to sign-in rather than to register. Therefore we need to make it possible to sign-in more easily from the homepage.

# Screenshots

## On desktop:

![screen shot 2015-07-29 at 13 52 14](https://cloud.githubusercontent.com/assets/306583/8957916/93330af0-35f9-11e5-8d04-9cdb10b89eec.png)

## On mobile:

**Note:** Side column appears above main column on small screens

![screen shot 2015-07-29 at 13 53 31](https://cloud.githubusercontent.com/assets/306583/8957881/51ca4c5e-35f9-11e5-8e97-bf9c2810ba3b.png)
