### PR TITLE
Fix to prevent legend tag content escaping bounds on IE browsers

### DIFF
--- a/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
+++ b/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
@@ -18,6 +18,7 @@
   @include body(22,30);
   font-weight: 700;
   color: $color-heading-default;
+  width: 100%;
 }
 
 .l-pre-qualification__question--with-desc {


### PR DESCRIPTION
Same problem as observed in https://github.com/moneyadviceservice/rad/pull/267 but on a different screen.

Observed on IE8, 9, 10 & 11.

Before:

![screen shot 2015-07-30 at 15 16 44](https://cloud.githubusercontent.com/assets/306583/8985261/3f1daf9e-36ce-11e5-8fbd-8d5d51d0bff9.png)

After:

![screen shot 2015-07-30 at 15 17 53](https://cloud.githubusercontent.com/assets/306583/8985265/46ae5dee-36ce-11e5-8945-fc231386a21d.png)
