### PR TITLE
[WIP] Adding a report to view the uptake on sent invitations

### DIFF
--- a/app/reports/invitation_uptake.rb
+++ b/app/reports/invitation_uptake.rb
@@ -1,0 +1,35 @@
+class InvitationUptake
+  def run
+    CSV.generate do |csv|
+      csv << ['FCA Number', 'Registered Name', 'Invitation Sent', 'Invitation Accepted', 'Password Reset Sent']
+      query.all.each do |row|
+        csv << [
+          row.fca_number,
+          row.registered_name,
+          nice_date(row.invitation_sent_at),
+          nice_date(row.invitation_accepted_at),
+          nice_date(row.reset_password_sent_at)
+        ]
+      end
+    end
+  end
+
+  private
+
+  def query
+    User.where.not(invitation_sent_at: nil)
+      .joins(principal: [:firm])
+      .select(
+        'firms.fca_number',
+        'firms.registered_name',
+        'users.invitation_sent_at',
+        'users.invitation_accepted_at',
+        'users.reset_password_sent_at'
+      )
+      .order('firms.fca_number')
+  end
+
+  def nice_date(date)
+    date.try(:strftime, '%d-%b-%Y %H:%M')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20150716123032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,0 +1,6 @@
+namespace :reports do
+  desc 'Run a report to see how many invitations have been acted upon.'
+  task invitation_uptake: :environment do
+    puts InvitationUptake.new.run
+  end
+end

--- a/spec/reports/invitation_uptake_spec.rb
+++ b/spec/reports/invitation_uptake_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe InvitationUptake do
+  describe '#run' do
+    describe 'result' do
+      let(:data) { CSV.parse(subject.run) }
+      let(:now)  { Time.zone.now }
+
+      before :each do
+        Timecop.freeze(now)
+        @users = users
+      end
+
+      after :each do
+        Timecop.return
+      end
+
+      context 'when the query does not return data' do
+        let(:users) { [] }
+
+        it 'generates a header row' do
+          header_row = data[0]
+          expect(header_row).to eq([
+            'FCA Number',
+            'Registered Name',
+            'Invitation Sent',
+            'Invitation Accepted',
+            'Password Reset Sent'
+          ])
+        end
+
+        it 'does not generate any other data' do
+          expect(data.length).to eq(1)
+        end
+      end
+
+      context 'when the query returns data' do
+        let(:uninvited_user) do
+          FactoryGirl.create(
+            :user,
+            invitation_sent_at: nil,
+            invitation_accepted_at: nil,
+            reset_password_sent_at: nil
+          )
+        end
+        let(:invited_user) do
+          FactoryGirl.create(
+            :user,
+            invitation_sent_at: 2.days.ago,
+            invitation_accepted_at: nil,
+            reset_password_sent_at: nil
+          )
+        end
+        let(:accepted_user) do
+          FactoryGirl.create(
+            :user,
+            invitation_sent_at: 2.days.ago,
+            invitation_accepted_at: 1.day.ago,
+            reset_password_sent_at: nil
+          )
+        end
+        let(:reset_user) do
+          FactoryGirl.create(
+            :user,
+            invitation_sent_at: 2.days.ago,
+            invitation_accepted_at: 1.day.ago,
+            reset_password_sent_at: 1.day.ago
+          )
+        end
+
+        let(:users) { [uninvited_user, invited_user, accepted_user, reset_user] }
+
+        it 'generates a header row' do
+          header_row = data[0]
+          expect(header_row).to eq([
+            'FCA Number',
+            'Registered Name',
+            'Invitation Sent',
+            'Invitation Accepted',
+            'Password Reset Sent'
+          ])
+        end
+
+        it 'generates a row of data per invited user and a header row' do
+          expect(data.length).to eq(4)
+        end
+
+        it 'does not generate a row for the uninvited user' do
+          expect(data).to_not include([
+            uninvited_user.principal.fca_number.to_s,
+            uninvited_user.principal.firm.registered_name,
+            nil,
+            nil,
+            nil
+          ])
+        end
+
+        it 'generates a row for the invited user' do
+          expect(data).to include([
+            invited_user.principal.fca_number.to_s,
+            invited_user.principal.firm.registered_name,
+            2.days.ago.strftime('%d-%b-%Y %H:%M'),
+            nil,
+            nil
+          ])
+        end
+
+        it 'generates a row for the accepted user' do
+          expect(data).to include([
+            accepted_user.principal.fca_number.to_s,
+            accepted_user.principal.firm.registered_name,
+            2.days.ago.strftime('%d-%b-%Y %H:%M'),
+            1.day.ago.strftime('%d-%b-%Y %H:%M'),
+            nil
+          ])
+        end
+
+        it 'generates a row for the reset user' do
+          expect(data).to include([
+            reset_user.principal.fca_number.to_s,
+            reset_user.principal.firm.registered_name,
+            2.days.ago.strftime('%d-%b-%Y %H:%M'),
+            1.day.ago.strftime('%d-%b-%Y %H:%M'),
+            1.day.ago.strftime('%d-%b-%Y %H:%M')
+          ])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Mark Nutley wanted to be able to see what the uptake was like on the invitations that they had sent out to firms. As the uptake looks to have been pretty slow so far, we figured that this report will need to be run reasonably frequently in the near future and so have turned it into a simple rake task.