### PR TITLE
Invitation report in admin area

### DIFF
--- a/app/controllers/admin/firms_controller.rb
+++ b/app/controllers/admin/firms_controller.rb
@@ -7,4 +7,10 @@ class Admin::FirmsController < Admin::ApplicationController
   def show
     @firm = Firm.find(params[:id])
   end
+
+  def invitation_report
+    users = User.includes(principal: [:firm]).order('firms.registered_name ASC')
+    @accepted_firms = users.where.not(invitation_accepted_at: nil)
+    @not_accepted_firms = users.where(invitation_accepted_at: nil)
+  end
 end

--- a/app/views/admin/firms/_invitation_table.html.erb
+++ b/app/views/admin/firms/_invitation_table.html.erb
@@ -1,0 +1,30 @@
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>FCA Number</th>
+      <th>Name</th>
+      <% if display_invitation_accepted_at %>
+        <th>Accepted invitation at</th>
+        <th>Sign in count</th>
+        <th>Last signed in at</th>
+      <% else %>
+        <th>Principal email</th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% users.each do |user| %>
+    <tr>
+      <td><%= user.principal.firm.fca_number %></td>
+      <td><%= user.principal.firm.registered_name %></td>
+      <% if display_invitation_accepted_at %>
+        <td><%= user.invitation_accepted_at.to_s(:long)%></td>
+        <td><%= user.sign_in_count %></td>
+        <td><%= user.last_sign_in_at.to_s(:long) %></td>
+      <% else %>
+        <td><%= user.principal.email_address %></td>
+      <% end %>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -29,6 +29,9 @@
     <p>
       <%= page_entries_info @firms %>
     </p>
+    <p>
+      <%= link_to 'Invitation report', invitation_report_admin_firms_path %>
+    </p>
   </div>
   <div class="col-xs-10">
     <table class="table table-bordered">

--- a/app/views/admin/firms/invitation_report.html.erb
+++ b/app/views/admin/firms/invitation_report.html.erb
@@ -1,0 +1,22 @@
+<h1>Invitation Report</h1>
+<h2>Total number of firms: <%= User.count %></h2>
+
+<div>
+  <ul class="nav nav-tabs">
+    <li class="active">
+      <a href="#accepted" data-toggle="tab">List of Firms accepted (<%= @accepted_firms.count %>)</a>
+    </li>
+    <li>
+      <a href="#pending" data-toggle="tab">List of Firms pending (<%= @not_accepted_firms.count %>)</a>
+    </li>
+  </ul>
+
+   <div class="tab-content">
+    <div class="tab-pane active" id="accepted">
+      <%= render 'invitation_table', users: @accepted_firms, display_invitation_accepted_at: true %>
+    </div>
+    <div class="tab-pane" id="pending">
+      <%= render 'invitation_table', users: @not_accepted_firms, display_invitation_accepted_at: false %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Rails.application.routes.draw do
     resources :advisers, only: [:index, :show, :edit, :update, :destroy]
 
     resources :firms, only: [:index, :show] do
+      collection do
+        get :invitation_report
+      end
+
       resources :advisers, only: :index
       member do
         resources :move_advisers, only: [:new] do

--- a/spec/controllers/admin/firms_controller_spec.rb
+++ b/spec/controllers/admin/firms_controller_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Admin::FirmsController, type: :controller do
+  def create_user_with_firm(user_attrs, firm_attrs = {})
+    principal = FactoryGirl.create(:principal)
+
+    firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names,
+                                            fca_number: principal.fca_number).merge(firm_attrs)
+    principal.firm.update_attributes!(firm_attrs)
+
+    FactoryGirl.create :user, { principal: principal }.merge(user_attrs)
+  end
+
+  describe '#invitation_report' do
+    let!(:first_user)  { create_user_with_firm({ invitation_accepted_at: Time.zone.today }, registered_name: 'Delta') }
+    let!(:second_user) { create_user_with_firm({ invitation_accepted_at: Time.zone.today }, registered_name: 'Alpha') }
+    let!(:third_user)  { create_user_with_firm({ invitation_accepted_at: nil }, registered_name: 'Gamma') }
+    let!(:fourth_user)  { create_user_with_firm({ invitation_accepted_at: nil }, registered_name: 'Charlie') }
+
+    before :each do
+      get :invitation_report
+    end
+
+    describe 'accepted_firms assignment' do
+      it 'assigns records that have accepted an invitation' do
+        expect(assigns(:accepted_firms)).to include(first_user, second_user)
+        expect(assigns(:accepted_firms)).to_not include(third_user, fourth_user)
+      end
+
+      it 'orders the firms by registered name' do
+        expect(assigns(:accepted_firms).pluck(:registered_name)).to eq(%w(Alpha Delta))
+      end
+    end
+
+    describe 'not_accepted_firms assignment' do
+      it 'assigns records that have not accepted their invitation' do
+        expect(assigns(:not_accepted_firms)).to include(third_user, fourth_user)
+        expect(assigns(:not_accepted_firms)).to_not include(first_user, second_user)
+      end
+
+      it 'orders the firms by registered name' do
+        expect(assigns(:not_accepted_firms).pluck(:registered_name)).to eq(%w(Charlie Gamma))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stakeholders need access to stats on the uptake of inviting firms to maintain their own data via the new self-service area of the site.

This PR makes that data available on the admin area of the site so that the most up to date data can be viewed whenever it is needed.

![screen shot 2015-08-04 at 10 40 09](https://cloud.githubusercontent.com/assets/67151/9057944/52fcc6e2-3a95-11e5-9ace-eafa4bf62993.png)

