### PR TITLE
Firm offering a free initial meeting need to fill out how-long question

### DIFF
--- a/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
+++ b/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
@@ -1,36 +1,38 @@
-<fieldset class="form__group form__group--inline">
-  <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.free_initial_meeting.heading') %></legend>
+<div data-dough-component="FieldToggleVisibility">
+  <fieldset class="form__group form__group--inline">
+    <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.free_initial_meeting.heading') %></legend>
 
-  <%= f.form_row :free_initial_meeting do %>
-    <%= f.errors_for :free_initial_meeting %>
-    <div class="form__group-item">
-      <label>
-        <%= f.radio_button :free_initial_meeting, true, class: 'form__group-input t-free-initial-meeting-true' %>
-        <%= t('questionnaire.free_initial_meeting.answer_yes') %>
-      </label>
-    </div>
-
-    <div class="form__group-item">
-      <label>
-        <%= f.radio_button :free_initial_meeting, false, class: 'form__group-input t-free-initial-meeting-false' %>
-        <%= t('questionnaire.free_initial_meeting.answer_no') %>
-      </label>
-    </div>
-  <% end %>
-</fieldset>
-
-<fieldset class="form__group form__group--inline">
-  <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_meeting_duration.heading') %></legend>
-
-  <%= f.form_row :initial_meeting_duration do %>
-    <%= f.errors_for :initial_meeting_duration %>
-    <% InitialMeetingDuration.all.each do |initial_meeting_duration| %>
+    <%= f.form_row :free_initial_meeting do %>
+      <%= f.errors_for :free_initial_meeting %>
       <div class="form__group-item">
         <label>
-          <%= radio_button_tag 'firm[initial_meeting_duration_id]', initial_meeting_duration.id, @firm.initial_meeting_duration == initial_meeting_duration, class: 'form__group-input t-questionnaire__firm-initial-meeting-duration-id' %>
-          <%= initial_meeting_duration.name %>
+          <%= f.radio_button :free_initial_meeting, true, class: 'form__group-input t-free-initial-meeting-true', data: { dough_field_show: 'how_long' } %>
+          <%= t('questionnaire.free_initial_meeting.answer_yes') %>
+        </label>
+      </div>
+
+      <div class="form__group-item">
+        <label>
+          <%= f.radio_button :free_initial_meeting, false, class: 'form__group-input t-free-initial-meeting-false', data: { dough_field_hide: 'how_long' } %>
+          <%= t('questionnaire.free_initial_meeting.answer_no') %>
         </label>
       </div>
     <% end %>
-  <% end %>
-</fieldset>
+  </fieldset>
+
+  <fieldset class="form__group form__group--inline" data-dough-field-target="how_long">
+    <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_meeting_duration.heading') %></legend>
+
+    <%= f.form_row :initial_meeting_duration do %>
+      <%= f.errors_for :initial_meeting_duration %>
+      <% InitialMeetingDuration.all.each do |initial_meeting_duration| %>
+        <div class="form__group-item">
+          <label>
+            <%= radio_button_tag 'firm[initial_meeting_duration_id]', initial_meeting_duration.id, @firm.initial_meeting_duration == initial_meeting_duration, class: 'form__group-input t-questionnaire__firm-initial-meeting-duration-id' %>
+            <%= initial_meeting_duration.name %>
+          </label>
+        </div>
+      <% end %>
+    <% end %>
+  </fieldset>
+</div>


### PR DESCRIPTION
Firms not offering free initial meeting should have the how-long question hidden.

It isn't immediately obvious in the diff below that a wrapping div has been added to make use of the dough component FieldToggleVisibility.

On line 9 `dough_field_show` has been introduced and on line 16 `dough_field_hide` has been introduced.