### PR TITLE
Add required asterisk to initial meeting duration question.

### DIFF
--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -173,7 +173,7 @@
           </fieldset>
 
           <fieldset class="form__group form__group--inline" data-dough-field-target="how_long">
-            <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_meeting_duration.heading') %></legend>
+            <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.initial_meeting_duration.heading') %></legend>
 
             <%= f.form_row :initial_meeting_duration do %>
               <%= f.errors_for :initial_meeting_duration %>

--- a/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
+++ b/app/views/self_service/firms/questionnaire/_initial_meeting.html.erb
@@ -21,7 +21,7 @@
   </fieldset>
 
   <fieldset class="form__group form__group--inline" data-dough-field-target="how_long">
-    <legend class="l-questionnaire__legend"><%= t('questionnaire.initial_meeting_duration.heading') %></legend>
+    <legend class="l-questionnaire__legend"><%= required_asterisk t('questionnaire.initial_meeting_duration.heading') %></legend>
 
     <%= f.form_row :initial_meeting_duration do %>
       <%= f.errors_for :initial_meeting_duration %>


### PR DESCRIPTION
[Sorry for the back-and-forth on this!]

In the past, when we didn't conditionally show and hide this field depending on whether it was applicable, it wouldn't have made sense to mark this as required.

However, now it's only visible when it is required. So we should add an asterisk to it.