### PR TITLE
[DEV APPROVED] Multiple offices part 1: the index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.65'
+gem 'mas-rad_core', '0.0.67'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.65)
+    mas-rad_core (0.0.67)
       active_model_serializers
       geocoder
       httpclient
@@ -322,7 +322,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.65)
+  mas-rad_core (= 0.0.67)
   oga
   pg
   poltergeist

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -34,6 +34,7 @@
 @import 'components/form/all';
 @import 'components/navigation';
 @import 'components/notice/all';
+@import 'components/offices_table';
 @import 'components/form_section';
 @import 'components/inline_list_with_separator';
 @import 'components/sign_in_panel';

--- a/app/assets/stylesheets/components/_advisers_table.scss
+++ b/app/assets/stylesheets/components/_advisers_table.scss
@@ -1,19 +1,19 @@
 .advisers-table {
   width: 100%;
+}
 
-  .advisers-table__reference-number {
-    width: 10%;
-  }
+.advisers-table__reference-number {
+  width: 10%;
+}
 
-  .advisers-table__name {
-    width: 60%;
-  }
+.advisers-table__name {
+  width: 60%;
+}
 
-  .advisers-table__postcode {
-    width: 10%;
-  }
+.advisers-table__postcode {
+  width: 10%;
+}
 
-  .advisers-table__action {
-    width: 20%;
-  }
+.advisers-table__action {
+  width: 20%;
 }

--- a/app/assets/stylesheets/components/_offices_table.scss
+++ b/app/assets/stylesheets/components/_offices_table.scss
@@ -1,27 +1,27 @@
 .offices-table {
   width: 100%;
+}
 
-  .offices-table__address {
-    width: auto;
-  }
+.offices-table__address {
+  width: auto;
+}
 
-  .offices-table__address-postcode {
-    width: 8%;
-  }
+.offices-table__address-postcode {
+  width: 8%;
+}
 
-  .offices-table__telephone-number {
-    width: 12%;
-  }
+.offices-table__telephone-number {
+  width: 12%;
+}
 
-  .offices-table__email-address {
-    width: auto;
-  }
+.offices-table__email-address {
+  width: auto;
+}
 
-  .offices-table__disabled-access {
-    width: 8%;
-  }
+.offices-table__disabled-access {
+  width: 8%;
+}
 
-  .offices-table__action {
-    width: 12%;
-  }
+.offices-table__action {
+  width: 12%;
 }

--- a/app/assets/stylesheets/components/_offices_table.scss
+++ b/app/assets/stylesheets/components/_offices_table.scss
@@ -1,0 +1,27 @@
+.offices-table {
+  width: 100%;
+
+  .offices-table__address {
+    width: auto;
+  }
+
+  .offices-table__address-postcode {
+    width: 8%;
+  }
+
+  .offices-table__telephone-number {
+    width: 12%;
+  }
+
+  .offices-table__email-address {
+    width: auto;
+  }
+
+  .offices-table__disabled-access {
+    width: 8%;
+  }
+
+  .offices-table__action {
+    width: 12%;
+  }
+}

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -4,6 +4,9 @@ module SelfService
     before_action -> { @firm = current_firm }
     before_action -> { @office = current_office }, only: [:destroy]
 
+    def index
+    end
+
     def destroy
       @office.destroy
       flash[:notice] = I18n.t('self_service.office_destroy.deleted', postcode: @office.address_postcode)

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -1,0 +1,5 @@
+module SelfService
+  class OfficesController < ApplicationController
+    before_action :authenticate_user!
+  end
+end

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -2,6 +2,14 @@ module SelfService
   class OfficesController < ApplicationController
     before_action :authenticate_user!
     before_action -> { @firm = current_firm }
+    before_action -> { @office = current_office }, only: [:destroy]
+
+    def destroy
+      @office.destroy
+      flash[:notice] = I18n.t('self_service.office_destroy.deleted', postcode: @office.address_postcode)
+
+      redirect_to :back
+    end
 
     private
 
@@ -11,6 +19,10 @@ module SelfService
 
     def current_firm
       Firm.find_by(id: params[:firm_id], fca_number: principal.fca_number)
+    end
+
+    def current_office
+      @firm.offices.find(params[:id])
     end
   end
 end

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -1,5 +1,16 @@
 module SelfService
   class OfficesController < ApplicationController
     before_action :authenticate_user!
+    before_action -> { @firm = current_firm }
+
+    private
+
+    def principal
+      current_user.principal
+    end
+
+    def current_firm
+      Firm.find_by(id: params[:firm_id], fca_number: principal.fca_number)
+    end
   end
 end

--- a/app/helpers/self_service/breadcrumbs_helper.rb
+++ b/app/helpers/self_service/breadcrumbs_helper.rb
@@ -20,6 +20,10 @@ module SelfService
       breadcrumbs_firm_advisers << crumb_firm_adviser_new
     end
 
+    def breadcrumbs_firm_offices
+      breadcrumbs_firm_edit << crumb_firm_offices
+    end
+
     def breadcrumbs_trading_name_new
       breadcrumbs_root << crumb_trading_name_new
     end
@@ -61,6 +65,13 @@ module SelfService
 
     def crumb_firm_adviser_new
       { name: t('self_service.adviser_new.breadcrumb') }
+    end
+
+    def crumb_firm_offices
+      {
+        name: t('self_service.offices_index.breadcrumb'),
+        url: self_service_firm_offices_path(@firm)
+      }
     end
 
     def crumb_trading_name_new

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -20,6 +20,15 @@ module SelfService
       end
     end
 
+    def add_office_button(firm:)
+      label = t('self_service.offices_index.add_office_button')
+      sr_label = t('self_service.offices_index.add_office_button_full', firm_name: firm.registered_name)
+      link_to new_self_service_firm_office_path(firm), class: 'button button--primary' do
+        concat content_tag(:span, label, 'aria-hidden' => true)
+        concat content_tag(:span, sr_label, class: 'visually-hidden')
+      end
+    end
+
     def create_or_update_self_service_trading_names_path(firm)
       return self_service_trading_name_path(firm) if firm.persisted?
       self_service_trading_names_path

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -24,5 +24,16 @@ module SelfService
       return self_service_trading_name_path(firm) if firm.persisted?
       self_service_trading_names_path
     end
+
+    def office_address_table_cell(office)
+      [
+        :address_line_one,
+        :address_line_two,
+        :address_town,
+        :address_county
+      ].map { |field| office.send(field) }
+        .reject(&:blank?)
+        .join(', ')
+    end
   end
 end

--- a/app/views/self_service/firms/questionnaire/_links.html.erb
+++ b/app/views/self_service/firms/questionnaire/_links.html.erb
@@ -5,6 +5,12 @@
       (<%= firm.advisers.count %>)
     <% end %>
   </li>
+  <li>
+    <%= link_to self_service_firm_offices_path(firm) do %>
+      <%= t('activerecord.models.office.other') %>
+      (<%= firm.offices.count %>)
+    <% end %>
+  </li>
   <% unless firm.trading_name? %>
     <li>
       <%= link_to edit_self_service_principal_path(firm.principal) do %>

--- a/app/views/self_service/offices/_offices_table.html.erb
+++ b/app/views/self_service/offices/_offices_table.html.erb
@@ -1,0 +1,40 @@
+<div class="table-wrapper">
+  <table class="offices-table">
+    <thead>
+      <tr>
+        <th class="offices-table__address">
+          <%= Office.human_attribute_name(:address) %>
+        </th>
+        <th class="offices-table__address-postcode">
+          <%= Office.human_attribute_name(:address_postcode) %>
+        </th>
+        <th class="offices-table__telephone-number">
+          <%= Office.human_attribute_name(:telephone_number) %>
+        </th>
+        <th class="offices-table__email-address">
+          <%= Office.human_attribute_name(:email_address) %>
+        </th>
+        <th class="offices-table__disabled-access">
+          <%= Office.human_attribute_name(:disabled_access) %>
+        </th>
+        <th class="offices-table__action"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% offices.each do |office| %>
+        <tr class="t-office-table-row">
+          <td class="t-address"><%= office_address_table_cell(office) %></td>
+          <td class="t-address-postcode"><%= office.address_postcode %></td>
+          <td class="t-telephone-number"><%= office.telephone_number %></td>
+          <td class="t-email-address"><%= office.email_address %></td>
+          <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
+          <td>
+            <% if office == @firm.main_office %>
+              <span class="t-main-office">Main Office</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/self_service/offices/_offices_table.html.erb
+++ b/app/views/self_service/offices/_offices_table.html.erb
@@ -20,13 +20,13 @@
         <th class="offices-table__action"></th>
       </tr>
     </thead>
-    <tbody>
+    <tbody data-dough-filter-rows>
       <% offices.each do |office| %>
         <tr class="t-office-table-row">
-          <td class="t-address"><%= office_address_table_cell(office) %></td>
-          <td class="t-address-postcode"><%= office.address_postcode %></td>
-          <td class="t-telephone-number"><%= office.telephone_number %></td>
-          <td class="t-email-address"><%= office.email_address %></td>
+          <td class="t-address" data-dough-filterable><%= office_address_table_cell(office) %></td>
+          <td class="t-address-postcode" data-dough-filterable><%= office.address_postcode %></td>
+          <td class="t-telephone-number" data-dough-filterable><%= office.telephone_number %></td>
+          <td class="t-email-address" data-dough-filterable><%= office.email_address %></td>
           <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
           <td>
             <% if office == @firm.main_office %>

--- a/app/views/self_service/offices/_offices_table.html.erb
+++ b/app/views/self_service/offices/_offices_table.html.erb
@@ -31,6 +31,14 @@
           <td>
             <% if office == @firm.main_office %>
               <span class="t-main-office">Main Office</span>
+            <% else %>
+              <%= button_to t('self_service.offices_index.delete_office_button'),
+                            self_service_firm_office_path(office.firm, office),
+                            method: :delete,
+                            'data-dough-component' => 'ConfirmableForm',
+                            'data-dough-confirmation-message' => t('self_service.offices_index.delete_office_confirmation',
+                                                                   postcode: office.address_postcode),
+                            :class => 'button button--small t-delete-button' %>
             <% end %>
           </td>
         </tr>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,0 +1,1 @@
+TODO, make this page

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -2,13 +2,18 @@
 <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
 
 <table>
-  <% @firm.offices.each do |office| %>
+  <% @firm.offices.each_with_index do |office, index| %>
     <tr class="t-office-table-row">
       <td class="t-address"><%= office_address_table_cell(office) %></td>
       <td class="t-address-postcode"><%= office.address_postcode %></td>
       <td class="t-telephone-number"><%= office.telephone_number %></td>
       <td class="t-email-address"><%= office.email_address %></td>
       <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
+      <td>
+        <% if index == 0 %>
+          <span class="t-main-office">Main Office</span>
+        <% end %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -7,7 +7,10 @@
   </div>
 
   <% if @firm.offices.present? %>
-    <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+    <div data-dough-component="MultiTableFilter">
+      <%= filter_field :offices, locale_prefix: 'self_service.offices_index.office_filter' %>
+      <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+    </div>
   <% else %>
     <p class="t-no-offices-message">
       <%= t('self_service.offices_index.no_offices_message') %>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -6,5 +6,14 @@
     <%= add_office_button(firm: @firm) %>
   </div>
 
-  <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+  <% if @firm.offices.present? %>
+    <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+  <% else %>
+    <p class="t-no-offices-message">
+      <%= t('self_service.offices_index.no_offices_message') %>
+      <%= link_to(t('self_service.offices_index.add_office_link', firm_name: @firm.registered_name),
+                  new_self_service_firm_office_path(@firm),
+                  class: 't-add-office-link')  %>
+    </p>
+  <% end %>
 </div>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,2 +1,6 @@
 <%= render_breadcrumbs(breadcrumbs_firm_offices) %>
 <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
+
+<table>
+  <tr class="t-office-table-row"><td></td></tr>
+</table>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,1 +1,1 @@
-TODO, make this page
+<h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -2,7 +2,7 @@
 <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
 
 <table>
-  <% @firm.offices.each_with_index do |office, index| %>
+  <% @firm.offices.each do |office| %>
     <tr class="t-office-table-row">
       <td class="t-address"><%= office_address_table_cell(office) %></td>
       <td class="t-address-postcode"><%= office.address_postcode %></td>
@@ -10,7 +10,7 @@
       <td class="t-email-address"><%= office.email_address %></td>
       <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
       <td>
-        <% if index == 0 %>
+        <% if office == @firm.main_office %>
           <span class="t-main-office">Main Office</span>
         <% end %>
       </td>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,1 +1,2 @@
+<%= render_breadcrumbs(breadcrumbs_firm_offices) %>
 <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -2,5 +2,13 @@
 <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
 
 <table>
-  <tr class="t-office-table-row"><td></td></tr>
+  <% @firm.offices.each do |office| %>
+    <tr class="t-office-table-row">
+      <td class="t-address"><%= office_address_table_cell(office) %></td>
+      <td class="t-address-postcode"><%= office.address_postcode %></td>
+      <td class="t-telephone-number"><%= office.telephone_number %></td>
+      <td class="t-email-address"><%= office.email_address %></td>
+      <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
+    </tr>
+  <% end %>
 </table>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,19 +1,10 @@
 <%= render_breadcrumbs(breadcrumbs_firm_offices) %>
-<h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
 
-<table>
-  <% @firm.offices.each do |office| %>
-    <tr class="t-office-table-row">
-      <td class="t-address"><%= office_address_table_cell(office) %></td>
-      <td class="t-address-postcode"><%= office.address_postcode %></td>
-      <td class="t-telephone-number"><%= office.telephone_number %></td>
-      <td class="t-email-address"><%= office.email_address %></td>
-      <td class="t-disabled-access"><%= office.disabled_access ? 'Yes' : 'No' %></td>
-      <td>
-        <% if office == @firm.main_office %>
-          <span class="t-main-office">Main Office</span>
-        <% end %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<div class="l-self-service">
+  <div class="l-heading-with-button">
+    <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
+    <%= add_office_button(firm: @firm) %>
+  </div>
+
+  <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,9 @@ en:
       adviser:
         one: Adviser
         other: Advisers
+      office:
+        one: Office
+        other: Offices
       trading_name:
         one: Trading name
         other: Trading names

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -66,6 +66,7 @@ en:
       questionnaire_heading: Questionnaire Responses
 
     offices_index:
+      breadcrumb: Offices
       title: "Offices for %{firm_name}"
 
     trading_name_destroy:

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -72,6 +72,11 @@ en:
       add_office_button_full: Add an office to %{firm_name}
       add_office_link: Add an office to %{firm_name}.
       no_offices_message: You have not added any offices to this firm.
+      delete_office_button: Remove
+      delete_office_confirmation: Are you sure you want to remove the %{postcode} office from the directory?
+
+    office_destroy:
+      deleted: "The %{postcode} office has been successfully removed."
 
     trading_name_destroy:
       deleted: "%{name} has been successfully removed."

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -68,6 +68,8 @@ en:
     offices_index:
       breadcrumb: Offices
       title: "Offices for %{firm_name}"
+      add_office_button: Add an office
+      add_office_button_full: Add an office to %{firm_name}
 
     trading_name_destroy:
       deleted: "%{name} has been successfully removed."

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -65,6 +65,9 @@ en:
       address_heading: Address
       questionnaire_heading: Questionnaire Responses
 
+    offices_index:
+      title: "Offices for %{firm_name}"
+
     trading_name_destroy:
       deleted: "%{name} has been successfully removed."
 

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -70,6 +70,8 @@ en:
       title: "Offices for %{firm_name}"
       add_office_button: Add an office
       add_office_button_full: Add an office to %{firm_name}
+      add_office_link: Add an office to %{firm_name}.
+      no_offices_message: You have not added any offices to this firm.
 
     trading_name_destroy:
       deleted: "%{name} has been successfully removed."

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -68,6 +68,8 @@ en:
     offices_index:
       breadcrumb: Offices
       title: "Offices for %{firm_name}"
+      office_filter_label: "Filter offices:"
+      office_filter_placeholder: e.g. office postcode
       add_office_button: Add an office
       add_office_button_full: Add an office to %{firm_name}
       add_office_link: Add an office to %{firm_name}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
 
     resources :firms, only: [:index, :edit, :update] do
       resources :advisers, except: [:show]
-      resources :offices, only: [:index]
+      resources :offices, only: [:index, :new]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
 
     resources :firms, only: [:index, :edit, :update] do
       resources :advisers, except: [:show]
-      resources :offices, only: [:index, :new]
+      resources :offices, only: [:index, :new, :destroy]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
     resources :firms, only: [:index, :edit, :update] do
       resources :advisers, except: [:show]
+      resources :offices, only: [:index]
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806143047) do
+ActiveRecord::Schema.define(version: 20150812140642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,20 @@ ActiveRecord::Schema.define(version: 20150806143047) do
   end
 
   add_index "lookup_subsidiaries", ["fca_number"], name: "index_lookup_subsidiaries_on_fca_number", using: :btree
+
+  create_table "offices", force: :cascade do |t|
+    t.string   "address_line_one",                 null: false
+    t.string   "address_line_two"
+    t.string   "address_town",                     null: false
+    t.string   "address_county"
+    t.string   "address_postcode",                 null: false
+    t.string   "email_address"
+    t.string   "telephone_number"
+    t.boolean  "disabled_access",  default: false, null: false
+    t.integer  "firm_id",                          null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+  end
 
   create_table "old_passwords", force: :cascade do |t|
     t.string   "encrypted_password",       null: false

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'The self service firm offices list page' do
     when_i_navigate_to_the_offices_page_for_my_firm
     then_i_see(the_page: offices_index_page)
     then_no_errors_are_displayed_on(the_page: offices_index_page)
+    then_i_see_the_firm_name_in_the_page_title
   end
 
   def given_i_am_a_fully_registered_principal_user
@@ -39,5 +40,9 @@ RSpec.feature 'The self service firm offices list page' do
   def then_no_errors_are_displayed_on(the_page:)
     expect(the_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
     expect(the_page.status_code).not_to eq(500)
+  end
+
+  def then_i_see_the_firm_name_in_the_page_title
+    expect(offices_index_page.page_title).to have_text(principal.firm.registered_name)
   end
 end

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -30,6 +30,13 @@ RSpec.feature 'The self service firm offices list page' do
     then_i_see_the_first_office_in_the_list_is_the_main_office
   end
 
+  scenario 'The principal has not added any offices yet' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_there_is_a_prompt_to_add_an_office
+  end
+
   def given_i_am_a_fully_registered_principal_user
     firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
     principal.firm.update_attributes(firm_attrs)
@@ -62,7 +69,7 @@ RSpec.feature 'The self service firm offices list page' do
   end
 
   def then_i_see_the_list_of_offices_associated_with_my_firm
-    expect(offices_index_page.offices).not_to be_empty
+    expect(offices_index_page).to have_offices
     expect_table_to_match_offices(offices_index_page, principal.firm.offices)
   end
 
@@ -70,6 +77,13 @@ RSpec.feature 'The self service firm offices list page' do
     expect(offices_index_page.offices.first).to be_the_main_office
     expect(offices_index_page.offices.drop(1))
       .to rspec_all(have_attributes(the_main_office?: false))
+  end
+
+  def then_there_is_a_prompt_to_add_an_office
+    expect(offices_index_page).not_to have_offices
+    expect(offices_index_page).to have_no_offices_message(
+      text: I18n.t('self_service.offices_index.no_offices_message'))
+    expect(offices_index_page).to have_add_office_link
   end
 
   private

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -1,0 +1,43 @@
+RSpec.feature 'The self service firm offices list page' do
+  let(:offices_index_page) { SelfService::OfficesIndexPage.new }
+  let(:sign_in_page) { SignInPage.new }
+
+  let(:principal) { FactoryGirl.create(:principal) }
+  let(:user) { FactoryGirl.create(:user, principal: principal) }
+
+  scenario 'The page requires authentication to access' do
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_i_see(the_page: sign_in_page)
+  end
+
+  scenario 'We can get to the offices page for a given firm' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_i_see(the_page: offices_index_page)
+    then_no_errors_are_displayed_on(the_page: offices_index_page)
+  end
+
+  def given_i_am_a_fully_registered_principal_user
+    firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
+    principal.firm.update_attributes(firm_attrs)
+    expect(Firm.registered.find(principal.firm.id)).to be_present
+  end
+
+  def and_i_am_logged_in
+    login_as(user, scope: :user)
+  end
+
+  def when_i_navigate_to_the_offices_page_for_my_firm
+    offices_index_page.load(firm_id: principal.firm.id)
+  end
+
+  def then_i_see(the_page:)
+    expect(the_page).to be_displayed
+  end
+
+  def then_no_errors_are_displayed_on(the_page:)
+    expect(the_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
+    expect(the_page.status_code).not_to eq(500)
+  end
+end

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature 'The self service firm offices list page' do
     then_i_see_the_firm_name_in_the_page_title
   end
 
+  scenario 'The page shows the list of offices for the given firm' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_i_see_the_list_of_offices_associated_with_my_firm
+  end
+
   def given_i_am_a_fully_registered_principal_user
     firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
     principal.firm.update_attributes(firm_attrs)
@@ -44,5 +51,9 @@ RSpec.feature 'The self service firm offices list page' do
 
   def then_i_see_the_firm_name_in_the_page_title
     expect(offices_index_page.page_title).to have_text(principal.firm.registered_name)
+  end
+
+  def then_i_see_the_list_of_offices_associated_with_my_firm
+    expect(offices_index_page.offices).not_to be_empty
   end
 end

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -37,6 +37,23 @@ RSpec.feature 'The self service firm offices list page' do
     then_there_is_a_prompt_to_add_an_office
   end
 
+  scenario 'The principal can delete all offices except the main office' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    and_my_firm_has_offices
+
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_no_errors_are_displayed_on(the_page: offices_index_page)
+    then_i_see_delete_buttons_for_all_offices_except_the_main_firm
+
+    when_i_delete_the_first_deletable_office
+    then_i_see(the_page: offices_index_page)
+    then_no_errors_are_displayed_on(the_page: offices_index_page)
+    then_i_can_see_a_success_message
+    then_there_is_one_less_office
+    then_i_cannot_see_the_deleted_office
+  end
+
   def given_i_am_a_fully_registered_principal_user
     firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
     principal.firm.update_attributes(firm_attrs)
@@ -53,6 +70,13 @@ RSpec.feature 'The self service firm offices list page' do
 
   def when_i_navigate_to_the_offices_page_for_my_firm
     offices_index_page.load(firm_id: principal.firm.id)
+  end
+
+  def when_i_delete_the_first_deletable_office
+    @num_offices_before = offices_index_page.offices.count
+    @deleted_office_address = offices_index_page.offices.second.address.text
+    @deleted_office_address_postcode = offices_index_page.offices.second.address_postcode.text
+    offices_index_page.offices.second.delete_button.click
   end
 
   def then_i_see(the_page:)
@@ -84,6 +108,26 @@ RSpec.feature 'The self service firm offices list page' do
     expect(offices_index_page).to have_no_offices_message(
       text: I18n.t('self_service.offices_index.no_offices_message'))
     expect(offices_index_page).to have_add_office_link
+  end
+
+  def then_i_see_delete_buttons_for_all_offices_except_the_main_firm
+    expect(offices_index_page).to have_offices
+    expect(offices_index_page.offices.first).not_to have_delete_button
+    expect(offices_index_page.offices.drop(1)).to rspec_all(have_delete_button)
+  end
+
+  def then_i_can_see_a_success_message
+    expect(offices_index_page).to have_flash_message
+    expect(offices_index_page.flash_message).to have_text(@deleted_office_address_postcode)
+  end
+
+  def then_i_cannot_see_the_deleted_office
+    addresses = offices_index_page.offices.map { |office| office.address.text }
+    expect(addresses).not_to include(@deleted_office_address)
+  end
+
+  def then_there_is_one_less_office
+    expect(offices_index_page.offices.count).to eq(@num_offices_before - 1)
   end
 
   private

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'The self service firm offices list page' do
     when_i_navigate_to_the_offices_page_for_my_firm
     then_no_errors_are_displayed_on(the_page: offices_index_page)
     then_i_see_the_list_of_offices_associated_with_my_firm
+    then_i_see_the_first_office_in_the_list_is_the_main_office
   end
 
   def given_i_am_a_fully_registered_principal_user
@@ -63,6 +64,12 @@ RSpec.feature 'The self service firm offices list page' do
   def then_i_see_the_list_of_offices_associated_with_my_firm
     expect(offices_index_page.offices).not_to be_empty
     expect_table_to_match_offices(offices_index_page, principal.firm.offices)
+  end
+
+  def then_i_see_the_first_office_in_the_list_is_the_main_office
+    expect(offices_index_page.offices.first).to be_the_main_office
+    expect(offices_index_page.offices.drop(1))
+      .to rspec_all(have_attributes(the_main_office?: false))
   end
 
   private

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'The self service firm offices list page' do
 
   let(:principal) { FactoryGirl.create(:principal) }
   let(:user) { FactoryGirl.create(:user, principal: principal) }
+  let(:offices) { FactoryGirl.create_list(:office, 3, firm: principal.firm) }
 
   scenario 'The page requires authentication to access' do
     when_i_navigate_to_the_offices_page_for_my_firm
@@ -21,8 +22,10 @@ RSpec.feature 'The self service firm offices list page' do
 
   scenario 'The page shows the list of offices for the given firm' do
     given_i_am_a_fully_registered_principal_user
+    and_my_firm_has_offices
     and_i_am_logged_in
     when_i_navigate_to_the_offices_page_for_my_firm
+    then_no_errors_are_displayed_on(the_page: offices_index_page)
     then_i_see_the_list_of_offices_associated_with_my_firm
   end
 
@@ -30,6 +33,10 @@ RSpec.feature 'The self service firm offices list page' do
     firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: principal.fca_number)
     principal.firm.update_attributes(firm_attrs)
     expect(Firm.registered.find(principal.firm.id)).to be_present
+  end
+
+  def and_my_firm_has_offices
+    principal.firm.update!(offices: offices)
   end
 
   def and_i_am_logged_in
@@ -55,5 +62,22 @@ RSpec.feature 'The self service firm offices list page' do
 
   def then_i_see_the_list_of_offices_associated_with_my_firm
     expect(offices_index_page.offices).not_to be_empty
+    expect_table_to_match_offices(offices_index_page, principal.firm.offices)
+  end
+
+  private
+
+  def expect_table_to_match_offices(table, offices)
+    offices.each.with_index do |office, office_index|
+      expect_section_to_match_record(table.offices[office_index], office)
+    end
+  end
+
+  def expect_section_to_match_record(section, record)
+    expect(section.address).to have_text(record.address_line_one)
+    expect(section.address_postcode).to have_text(record.address_postcode)
+    expect(section.telephone_number).to have_text(record.telephone_number)
+    expect(section.email_address).to have_text(record.email_address)
+    expect(section.disabled_access).to have_text(%r{Yes|No})
   end
 end

--- a/spec/helpers/self_service/self_service_helper_spec.rb
+++ b/spec/helpers/self_service/self_service_helper_spec.rb
@@ -19,5 +19,27 @@ module SelfService
         end
       end
     end
+
+    describe '#office_address_table_cell' do
+      let(:office) do
+        FactoryGirl.build(:office,
+                          address_line_one: 'a',
+                          address_line_two: 'b',
+                          address_town: 'c',
+                          address_county: 'd',
+                          address_postcode: '!!!')
+      end
+      subject { helper.office_address_table_cell(office) }
+
+      it 'returns the office address, not including postcode, as a comma separated string' do
+        expect(subject).to eq('a, b, c, d')
+      end
+
+      it 'filters out blank fields' do
+        office.address_line_two = ''
+        office.address_town = nil
+        expect(subject).to eq('a, d')
+      end
+    end
   end
 end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -9,5 +9,6 @@ module SelfService
     sections :offices, OfficesTableRowSection, '.t-office-table-row'
     element :add_office_link, '.t-add-office-link'
     element :no_offices_message, '.t-no-offices-message'
+    element :flash_message, '.t-flash-message'
   end
 end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -1,9 +1,11 @@
+require_relative './offices_table_row_section'
+
 module SelfService
   class OfficesIndexPage < SitePrism::Page
     set_url '/self_service/firms/{firm_id}/offices'
     set_url_matcher %r{/self_service/firms/\d+/offices}
 
     element :page_title, '.t-page-title'
-    elements :offices, '.t-office-table-row'
+    sections :offices, OfficesTableRowSection, '.t-office-table-row'
   end
 end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -1,0 +1,6 @@
+module SelfService
+  class OfficesIndexPage < SitePrism::Page
+    set_url '/self_service/firms/{firm_id}/offices'
+    set_url_matcher %r{/self_service/firms/\d+/offices}
+  end
+end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -7,5 +7,7 @@ module SelfService
 
     element :page_title, '.t-page-title'
     sections :offices, OfficesTableRowSection, '.t-office-table-row'
+    element :add_office_link, '.t-add-office-link'
+    element :no_offices_message, '.t-no-offices-message'
   end
 end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -2,5 +2,7 @@ module SelfService
   class OfficesIndexPage < SitePrism::Page
     set_url '/self_service/firms/{firm_id}/offices'
     set_url_matcher %r{/self_service/firms/\d+/offices}
+
+    element :page_title, '.t-page-title'
   end
 end

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -4,5 +4,6 @@ module SelfService
     set_url_matcher %r{/self_service/firms/\d+/offices}
 
     element :page_title, '.t-page-title'
+    elements :offices, '.t-office-table-row'
   end
 end

--- a/spec/support/self_service/offices_table_row_section.rb
+++ b/spec/support/self_service/offices_table_row_section.rb
@@ -6,6 +6,7 @@ module SelfService
     element :email_address, '.t-email-address'
     element :disabled_access, '.t-disabled-access'
     element :main_firm, '.t-main-office'
+    element :delete_button, '.t-delete-button'
 
     def the_main_office?
       main_firm.present?

--- a/spec/support/self_service/offices_table_row_section.rb
+++ b/spec/support/self_service/offices_table_row_section.rb
@@ -5,5 +5,12 @@ module SelfService
     element :telephone_number, '.t-telephone-number'
     element :email_address, '.t-email-address'
     element :disabled_access, '.t-disabled-access'
+    element :main_firm, '.t-main-office'
+
+    def the_main_office?
+      main_firm.present?
+    rescue
+      false
+    end
   end
 end

--- a/spec/support/self_service/offices_table_row_section.rb
+++ b/spec/support/self_service/offices_table_row_section.rb
@@ -1,0 +1,9 @@
+module SelfService
+  class OfficesTableRowSection < SitePrism::Section
+    element :address, '.t-address'
+    element :address_postcode, '.t-address-postcode'
+    element :telephone_number, '.t-telephone-number'
+    element :email_address, '.t-email-address'
+    element :disabled_access, '.t-disabled-access'
+  end
+end


### PR DESCRIPTION
Just the index page functionality for the multiple offices feature we are working on. Below are some screenies of what's been done in this PR.

* First office added is considered the 'Main Office' that will be shown as the primary office on the directory. It is not removable as all firms must have at least one office.
* Add and edit screens will be done in a subsequent PR
* Depends on changes in PR: https://github.com/moneyadviceservice/mas-rad_core/pull/84

## Link from the Firm edit page

![screen shot 2015-08-14 at 14 14 38](https://cloud.githubusercontent.com/assets/306583/9274687/adfe6954-428f-11e5-92ed-118dc1b748bb.png)

## Message shown when there are no offices yet

![screen shot 2015-08-14 at 14 16 24](https://cloud.githubusercontent.com/assets/306583/9274688/b363de60-428f-11e5-96b3-7714b1077f57.png)

## A bunch of office records

![screen shot 2015-08-14 at 14 14 07](https://cloud.githubusercontent.com/assets/306583/9274695/bbc73b7e-428f-11e5-82ec-0e6e6b81108b.png)

## Confirmation on hitting the remove button

![screen shot 2015-08-14 at 14 15 03](https://cloud.githubusercontent.com/assets/306583/9274690/b7fefef0-428f-11e5-96f9-1b206707b4cb.png)

## On-page Filtering

![screen shot 2015-08-14 at 14 24 09](https://cloud.githubusercontent.com/assets/306583/9274756/33834fcc-4290-11e5-80d4-e7d7a90a4bc9.png)
