### PR TITLE
[DEV APPROVED] Language Selector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,9 @@ gem 'dough-ruby',
     ref: '77dc86f'
 gem 'jquery-rails'
 gem 'kaminari'
+gem 'language_list'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.69'
+gem 'mas-rad_core', '0.0.70'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'dough-ruby',
     ref: '77dc86f'
 gem 'jquery-rails'
 gem 'kaminari'
-gem 'language_list'
 gem 'letter_opener', group: :development
 gem 'mas-rad_core', '0.0.70'
 gem 'oga'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
+    language_list (1.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.3.0)
@@ -135,10 +136,11 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.69)
+    mas-rad_core (0.0.70)
       active_model_serializers
       geocoder
       httpclient
+      language_list
       pg
       rails (~> 4.2)
       redis
@@ -320,9 +322,10 @@ DEPENDENCIES
   faker
   jquery-rails
   kaminari
+  language_list
   launchy
   letter_opener
-  mas-rad_core (= 0.0.69)
+  mas-rad_core (= 0.0.70)
   oga
   pg
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,6 @@ DEPENDENCIES
   faker
   jquery-rails
   kaminari
-  language_list
   launchy
   letter_opener
   mas-rad_core (= 0.0.70)

--- a/app/assets/javascripts/modules/LanguageSelector.js
+++ b/app/assets/javascripts/modules/LanguageSelector.js
@@ -1,0 +1,103 @@
+/**
+ * # Language selector
+ *
+ * A set of select boxes that let the user select multiple languages.
+ *
+ * See test fixture (/spec/javascripts/fixtures/LanguageSelector.html)
+ * for example markup.
+ *
+ * @module LanguageSelector
+ * @returns {class} LanguageSelector
+ */
+
+define(['jquery', 'DoughBaseComponent'],
+       function($, DoughBaseComponent) {
+  'use strict';
+
+  var LanguageSelectorProto,
+      defaultConfig = {
+        messageAttribute: 'data-dough-confirmation-message',
+        selectorPrefix: 'data-dough-language-selector'
+      };
+
+  /**
+   * @constructor
+   * @extends {DoughBaseComponent}
+   * @param {HTMLElement} $el    Element with dough-component on it
+   * @param {Object}      config Hash of config options
+   */
+  function LanguageSelector($el, config) {
+    LanguageSelector.baseConstructor.call(this, $el, config, defaultConfig);
+  }
+
+  /**
+   * Inherit from base module, for shared methods and interface
+   */
+  DoughBaseComponent.extend(LanguageSelector);
+  LanguageSelector.componentName = 'LanguageSelector';
+  LanguageSelectorProto = LanguageSelector.prototype;
+
+  /**
+   * Init function
+   *
+   * Set up listeners and accept promise
+   *
+   * @param {Object} initialised Promise passed from eventsWithPromises (RSVP Promise).
+   * @returns {LanguageSelector}
+   */
+  LanguageSelectorProto.init = function(initialised) {
+    this.bindToElements();
+    this._initialisedSuccess(initialised);
+    return this;
+  };
+
+  /**
+   * Bind to events on elements
+   *
+   * Just the add and delete language links.
+   */
+  LanguageSelectorProto.bindToElements = function() {
+    this.$find('add-language').on('click', $.proxy(this.addLanguage, this));
+    this.$el.on('click', this._buildSelectorQuery('delete-language'), $.proxy(this.deleteLanguage, this));
+  };
+
+  /**
+   * Add a new language selector to the list of selectors
+   *
+   * Employs a template and clears all relevant attributes from it
+   * before cloning and inserting.
+   */
+  LanguageSelectorProto.addLanguage = function() {
+    var $container = this.$find('selectors').first(),
+        $template = this.$find('template').clone();
+    $template.find('select')
+      .attr('id', '');
+    $template
+      .removeClass('is-hidden')
+      .removeAttr(this.config.selectorPrefix + '-template')
+      .attr(this.config.selectorPrefix + '-selector', true)
+      .appendTo($container);
+  };
+
+  /**
+   * Delete a selector
+   *
+   * Uses the event target to work out which one to delete.
+   *
+   * @param {Event} Click event on a delete link
+   */
+  LanguageSelectorProto.deleteLanguage = function(e) {
+    var $selector = $(e.target).parents(this._buildSelectorQuery('selector'));
+    $selector.remove();
+  };
+
+  LanguageSelectorProto.$find = function(selector) {
+    return this.$el.find(this._buildSelectorQuery(selector));
+  };
+
+  LanguageSelectorProto._buildSelectorQuery = function(selector) {
+    return '[' + this.config.selectorPrefix + '-' + selector + ']';
+  };
+
+  return LanguageSelector;
+});

--- a/app/assets/javascripts/modules/LanguageSelector.js
+++ b/app/assets/javascripts/modules/LanguageSelector.js
@@ -73,7 +73,7 @@ define(['jquery', 'DoughBaseComponent'],
     $template.find('select')
       .attr('id', '');
     $template
-      .removeClass('is-hidden')
+      .removeClass('language-selector__template')
       .removeAttr(this.config.selectorPrefix + '-template')
       .attr(this.config.selectorPrefix + '-selector', true)
       .appendTo($container);

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -13,6 +13,7 @@
 //= depend_on_asset modules/RemoteAndFaceToFaceOptions
 //= depend_on_asset modules/MultiTableFilter
 //= depend_on_asset modules/ConfirmableForm
+//= depend_on_asset modules/LanguageSelector
 
 <%
   def requirejs_path(asset)
@@ -30,6 +31,7 @@
       RemoteAndFaceToFaceOptions: requirejs_path('modules/RemoteAndFaceToFaceOptions'),
       MultiTableFilter: requirejs_path('modules/MultiTableFilter'),
       ConfirmableForm: requirejs_path('modules/ConfirmableForm'),
+      LanguageSelector: requirejs_path('modules/LanguageSelector'),
       componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
       utilities: requirejs_path('dough/assets/js/lib/utilities'),
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -29,6 +29,7 @@
 @import 'components/form/all';
 @import 'components/form_section';
 @import 'components/inline_list_with_separator';
+@import 'components/language_selector';
 @import 'components/navigation';
 @import 'components/notice/all';
 @import 'components/offices_table';

--- a/app/assets/stylesheets/components/_language_selector.scss
+++ b/app/assets/stylesheets/components/_language_selector.scss
@@ -2,9 +2,18 @@
   margin-bottom: $baseline-unit*2;
 }
 
+.language-selector__template {
+  display: none;
+}
+
 .language-selector__delete {
+  display: none;
   margin-left: 0.5em;
   padding: 0;
+
+  html.js & {
+    display: inline-block;
+  }
 }
 
 .language-selector__selectors {
@@ -12,5 +21,10 @@
 }
 
 .language-selector__add {
+  display: none;
   padding: 0;
+
+  html.js & {
+    display: inline-block;
+  }
 }

--- a/app/assets/stylesheets/components/_language_selector.scss
+++ b/app/assets/stylesheets/components/_language_selector.scss
@@ -4,7 +4,7 @@
 
 .language-selector__delete {
   margin-left: 0.5em;
-  cursor: pointer;
+  padding: 0;
 }
 
 .language-selector__selectors {
@@ -12,5 +12,5 @@
 }
 
 .language-selector__add {
-  cursor: pointer;
+  padding: 0;
 }

--- a/app/assets/stylesheets/components/_language_selector.scss
+++ b/app/assets/stylesheets/components/_language_selector.scss
@@ -1,0 +1,16 @@
+.language-selector__select {
+  margin-bottom: $baseline-unit*2;
+}
+
+.language-selector__delete {
+  margin-left: 0.5em;
+  cursor: pointer;
+}
+
+.language-selector__selectors {
+  margin-bottom: $baseline-unit*4;
+}
+
+.language-selector__add {
+  cursor: pointer;
+}

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -35,7 +35,8 @@ module SelfService
       initial_advice_fee_structure_ids: [],
       ongoing_advice_fee_structure_ids: [],
       allowed_payment_method_ids: [],
-      investment_size_ids: []
+      investment_size_ids: [],
+      languages: []
     ].freeze
 
     def firm_params

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -62,12 +62,14 @@ module SelfService
         value)
       select_tag('firm[languages][]', options,
                  {
-                   prompt: t('self_service.firm_form.languages_select_prompt'),
+                   prompt: t('self_service.firm_form.languages_select_prompt')
                  }.merge(html_options))
     end
 
     def firm_language_delete_link
-      content_tag(:a, 'data-dough-language-selector-delete-language' => true) do
+      content_tag(:a,
+                  class: 'language-selector__delete',
+                  'data-dough-language-selector-delete-language' => true) do
         t('self_service.firm_form.languages_delete_language')
       end
     end

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -66,9 +66,10 @@ module SelfService
                  }.merge(html_options))
     end
 
-    def firm_language_delete_link
-      content_tag(:a,
-                  class: 'language-selector__delete',
+    def firm_language_delete_button
+      content_tag(:button,
+                  type: 'button',
+                  class: 'button-link language-selector__delete',
                   'data-dough-language-selector-delete-language' => true) do
         t('self_service.firm_form.languages_delete_language')
       end

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -54,10 +54,22 @@ module SelfService
       principal.main_firm_with_trading_names.registered.first
     end
 
-    def language_select(f, html_options = {})
-      f.collection_select(:languages, LanguageList::COMMON_LANGUAGES, :iso_639_1, :name,
-                          { prompt: t('self_service.firm_form.languages_select_prompt') },
-                          { name: "#{f.object_name}[languages][]" }.merge(html_options))
+    def firm_language_select(value, html_options = {})
+      options = options_from_collection_for_select(
+        LanguageList::COMMON_LANGUAGES,
+        :iso_639_1,
+        :name,
+        value)
+      select_tag('firm[languages][]', options,
+                 {
+                   prompt: t('self_service.firm_form.languages_select_prompt'),
+                 }.merge(html_options))
+    end
+
+    def firm_language_delete_link
+      content_tag(:a, 'data-dough-language-selector-delete-language' => true) do
+        t('self_service.firm_form.languages_delete_language')
+      end
     end
   end
 end

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -53,5 +53,11 @@ module SelfService
     def first_registered_firm_for(principal)
       principal.main_firm_with_trading_names.registered.first
     end
+
+    def language_select(f, html_options = {})
+      f.collection_select(:languages, LanguageList::COMMON_LANGUAGES, :iso_639_1, :name,
+                          { prompt: t('self_service.firm_form.languages_select_prompt') },
+                          { name: "#{f.object_name}[languages][]" }.merge(html_options))
+    end
   end
 end

--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -56,7 +56,7 @@ module SelfService
 
     def firm_language_select(value, html_options = {})
       options = options_from_collection_for_select(
-        LanguageList::COMMON_LANGUAGES,
+        Firm.available_languages,
         :iso_639_1,
         :name,
         value)

--- a/app/views/self_service/firms/_form.html.erb
+++ b/app/views/self_service/firms/_form.html.erb
@@ -44,6 +44,7 @@
       <%= render partial: 'self_service/firms/questionnaire/business_split', locals: {f: f} %>
       <%= render partial: 'self_service/firms/questionnaire/other_services', locals: {f: f} %>
       <%= render partial: 'self_service/firms/questionnaire/status', locals: {f: f} %>
+      <%= render partial: 'self_service/firms/questionnaire/languages', locals: {f: f} %>
     </div>
   </div>
 </section>

--- a/app/views/self_service/firms/questionnaire/_languages.html.erb
+++ b/app/views/self_service/firms/questionnaire/_languages.html.erb
@@ -1,0 +1,9 @@
+<fieldset class="form__group">
+  <legend class="l-questionnaire__legend"><%= t('self_service.firm_form.languages_heading') %></legend>
+
+  <%= f.form_row :other_services do %>
+    <%= f.errors_for :other_services %>
+    <%= language_select f, class: 't-languages' %>
+  <% end %>
+
+</fieldset>

--- a/app/views/self_service/firms/questionnaire/_languages.html.erb
+++ b/app/views/self_service/firms/questionnaire/_languages.html.erb
@@ -1,25 +1,32 @@
 <fieldset class="form__group" data-dough-component="LanguageSelector">
   <legend class="l-questionnaire__legend"><%= t('self_service.firm_form.languages_heading') %></legend>
 
-  <div class="is-hidden" data-dough-language-selector-template>
+  <div class="is-hidden language-selector__select" data-dough-language-selector-template>
     <%= firm_language_select nil, class: 't-languages' %>
     <%= firm_language_delete_link %>
   </div>
 
-    <%= f.form_row :other_services do %>
-      <%= f.errors_for :other_services %>
-      <div data-dough-language-selector-selectors>
-        <% f.object.languages.each do |language| %>
-          <div data-dough-language-selector-selector>
-            <%= firm_language_select language, class: 't-languages' %>
-            <%= firm_language_delete_link %>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+  <%= f.form_row :other_services do %>
+    <%= f.errors_for :other_services %>
 
-  <a data-dough-language-selector-add-language>
-    <%= t('self_service.firm_form.languages_add_language') %>
-  </a>
+    <div class="language-selector__selectors" data-dough-language-selector-selectors>
+      <% if f.object.languages.empty? %>
+        <div class="language-selector__select" data-dough-language-selector-selector>
+          <%= firm_language_select nil, class: 't-languages' %>
+          <%= firm_language_delete_link %>
+        </div>
+      <% end %>
 
+      <% f.object.languages.each do |language| %>
+        <div class="language-selector__select" data-dough-language-selector-selector>
+          <%= firm_language_select language, class: 't-languages' %>
+          <%= firm_language_delete_link %>
+        </div>
+      <% end %>
+    </div>
+
+    <a class="language-selector__add" data-dough-language-selector-add-language>
+      <%= t('self_service.firm_form.languages_add_language') %>
+    </a>
+  <% end %>
 </fieldset>

--- a/app/views/self_service/firms/questionnaire/_languages.html.erb
+++ b/app/views/self_service/firms/questionnaire/_languages.html.erb
@@ -1,7 +1,7 @@
 <fieldset class="form__group" data-dough-component="LanguageSelector">
   <legend class="l-questionnaire__legend"><%= t('self_service.firm_form.languages_heading') %></legend>
 
-  <div class="is-hidden language-selector__select" data-dough-language-selector-template>
+  <div class="language-selector__template language-selector__select" data-dough-language-selector-template>
     <%= firm_language_select nil, class: 't-languages' %>
     <%= firm_language_delete_button %>
   </div>

--- a/app/views/self_service/firms/questionnaire/_languages.html.erb
+++ b/app/views/self_service/firms/questionnaire/_languages.html.erb
@@ -3,7 +3,7 @@
 
   <div class="is-hidden language-selector__select" data-dough-language-selector-template>
     <%= firm_language_select nil, class: 't-languages' %>
-    <%= firm_language_delete_link %>
+    <%= firm_language_delete_button %>
   </div>
 
   <%= f.form_row :other_services do %>
@@ -13,20 +13,20 @@
       <% if f.object.languages.empty? %>
         <div class="language-selector__select" data-dough-language-selector-selector>
           <%= firm_language_select nil, class: 't-languages' %>
-          <%= firm_language_delete_link %>
+          <%= firm_language_delete_button %>
         </div>
       <% end %>
 
       <% f.object.languages.each do |language| %>
         <div class="language-selector__select" data-dough-language-selector-selector>
           <%= firm_language_select language, class: 't-languages' %>
-          <%= firm_language_delete_link %>
+          <%= firm_language_delete_button %>
         </div>
       <% end %>
     </div>
 
-    <a class="language-selector__add" data-dough-language-selector-add-language>
+    <button type="button" class="button-link language-selector__add" data-dough-language-selector-add-language>
       <%= t('self_service.firm_form.languages_add_language') %>
-    </a>
+    </button>
   <% end %>
 </fieldset>

--- a/app/views/self_service/firms/questionnaire/_languages.html.erb
+++ b/app/views/self_service/firms/questionnaire/_languages.html.erb
@@ -1,9 +1,25 @@
-<fieldset class="form__group">
+<fieldset class="form__group" data-dough-component="LanguageSelector">
   <legend class="l-questionnaire__legend"><%= t('self_service.firm_form.languages_heading') %></legend>
 
-  <%= f.form_row :other_services do %>
-    <%= f.errors_for :other_services %>
-    <%= language_select f, class: 't-languages' %>
-  <% end %>
+  <div class="is-hidden" data-dough-language-selector-template>
+    <%= firm_language_select nil, class: 't-languages' %>
+    <%= firm_language_delete_link %>
+  </div>
+
+    <%= f.form_row :other_services do %>
+      <%= f.errors_for :other_services %>
+      <div data-dough-language-selector-selectors>
+        <% f.object.languages.each do |language| %>
+          <div data-dough-language-selector-selector>
+            <%= firm_language_select language, class: 't-languages' %>
+            <%= firm_language_delete_link %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+  <a data-dough-language-selector-add-language>
+    <%= t('self_service.firm_form.languages_add_language') %>
+  </a>
 
 </fieldset>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
     dough/assets/js/**/*.js
     modules/MultiTableFilter.js
     modules/ConfirmableForm.js
+    modules/LanguageSelector.js
     modules/FieldToggleVisibility.js
     modules/RemoteAndFaceToFaceOptions.js
     modules/AdviserAjaxCall.js

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -65,3 +65,5 @@ en:
 
       languages_heading: Which languages (other than English) can your firm's advisers offer advice in?
       languages_select_prompt: Please select
+      languages_add_language: Add another language
+      languages_delete_language: Remove

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -62,3 +62,6 @@ en:
       status_heading: Does your firm offer restricted or independent advice?
       status_answer_independent: "Independent"
       status_answer_restricted: "Restricted"
+
+      languages_heading: Which languages (other than English) can your firm's advisers offer advice in?
+      languages_select_prompt: Please select

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 20150817141257) do
     t.string   "website_address"
     t.boolean  "ethical_investing_flag",                   default: false, null: false
     t.boolean  "sharia_investing_flag",                    default: false, null: false
+    t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
   end
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Retirement Adviser Directory",
   "scripts": {
-    "test": "./node_modules/.bin/karma start spec/javascripts/karma.conf.js --single-run=true && ./node_modules/.bin/jshint app/assets/javascripts/"
+    "test": "./node_modules/.bin/karma start spec/javascripts/karma.conf.js --single-run=true && ./node_modules/.bin/jshint app/assets/javascripts/ spec/javascripts"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -201,7 +201,7 @@ RSpec.feature 'The self service firm edit page' do
       expect(p.ethical_investing_flag?).to eq(firm_changes.ethical_investing_flag)
       expect(p.sharia_investing_flag?).to eq(firm_changes.sharia_investing_flag)
       expect(p.status).to eq(firm_changes.status)
-      expect(p.languages.map &:value).to include('fr')
+      expect(p.languages.map(&:value)).to include('fr')
     end
   end
 end

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature 'The self service firm edit page' do
       p.ethical_investing_flag.set firm_changes.ethical_investing_flag
       p.sharia_investing_flag.set firm_changes.sharia_investing_flag
       p.status = firm_changes.status
-      p.languages.select LanguageList::LanguageInfo.find(firm_changes.languages.first).name
+      p.languages.first.select LanguageList::LanguageInfo.find(firm_changes.languages.first).name
     end
   end
 
@@ -201,7 +201,7 @@ RSpec.feature 'The self service firm edit page' do
       expect(p.ethical_investing_flag?).to eq(firm_changes.ethical_investing_flag)
       expect(p.sharia_investing_flag?).to eq(firm_changes.sharia_investing_flag)
       expect(p.status).to eq(firm_changes.status)
-      expect(p.languages.value).to eq('fr')
+      expect(p.languages.map &:value).to include('fr')
     end
   end
 end

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature 'The self service firm edit page' do
                       wills_and_probate_flag: false,
                       ethical_investing_flag: true,
                       sharia_investing_flag: true,
-                      status: :restricted)
+                      status: :restricted,
+                      languages: ['fr'])
   end
 
   scenario 'The principal can edit their firm' do
@@ -191,6 +192,7 @@ RSpec.feature 'The self service firm edit page' do
       p.ethical_investing_flag.set firm_changes.ethical_investing_flag
       p.sharia_investing_flag.set firm_changes.sharia_investing_flag
       p.status = firm_changes.status
+      p.languages.select LanguageList::LanguageInfo.find(firm_changes.languages.first).name
     end
   end
 
@@ -199,6 +201,7 @@ RSpec.feature 'The self service firm edit page' do
       expect(p.ethical_investing_flag?).to eq(firm_changes.ethical_investing_flag)
       expect(p.sharia_investing_flag?).to eq(firm_changes.sharia_investing_flag)
       expect(p.status).to eq(firm_changes.status)
+      expect(p.languages.value).to eq('fr')
     end
   end
 end

--- a/spec/javascripts/fixtures/LanguageSelector.html
+++ b/spec/javascripts/fixtures/LanguageSelector.html
@@ -1,7 +1,7 @@
 <div>
   <div data-dough-language-selector-template>
     <select id="selector_template"></select>
-    <a data-dough-language-selector-delete-language>
+    <button type="button" data-dough-language-selector-delete-language>
       Delete a language
     </a>
   </div>
@@ -12,5 +12,5 @@
     </div>
   </div>
 
-  <a data-dough-language-selector-add-language>Add language</a>
+  <button type="button" data-dough-language-selector-add-language>Add language</a>
 </div>

--- a/spec/javascripts/fixtures/LanguageSelector.html
+++ b/spec/javascripts/fixtures/LanguageSelector.html
@@ -1,0 +1,16 @@
+<div>
+  <div data-dough-language-selector-template>
+    <select id="selector_template"></select>
+    <a data-dough-language-selector-delete-language>
+      Delete a language
+    </a>
+  </div>
+
+  <div data-dough-language-selector-selectors>
+    <div data-dough-language-selector-selector>
+      <select id="selector_0"></select>
+    </div>
+  </div>
+
+  <a data-dough-language-selector-add-language>Add language</a>
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -29,6 +29,7 @@ require.config({
     FieldToggleVisibility: 'app/assets/javascripts/modules/FieldToggleVisibility',
     MultiTableFilter: 'app/assets/javascripts/modules/MultiTableFilter',
     ConfirmableForm: 'app/assets/javascripts/modules/ConfirmableForm',
+    LanguageSelector: 'app/assets/javascripts/modules/LanguageSelector',
     utilities: 'vendor/assets/bower_components/dough/assets/js/lib/utilities',
     List: 'vendor/assets/bower_components/list.js/dist/list'
   },

--- a/spec/javascripts/tests/LanguageSelector_spec.js
+++ b/spec/javascripts/tests/LanguageSelector_spec.js
@@ -1,0 +1,48 @@
+describe('language selector', function () {
+  'use strict';
+  var sandbox;
+
+  beforeEach(function (done) {
+    var self = this;
+
+    requirejs(['jquery', 'LanguageSelector'], function ($, LanguageSelector) {
+      self.$html = $(window.__html__['spec/javascripts/fixtures/LanguageSelector.html']).appendTo('body');
+      self.LanguageSelector = new LanguageSelector(self.$html).init();
+      self.$selectorsContainer = self.$html.find('[data-dough-language-selector-selectors]');
+      self.$template = self.$html.find('[data-dough-language-selector-template]');
+      self.$addLanguage = self.$html.find('[data-dough-language-selector-add-language]');
+      self.$selectors = function() { return self.$html.find('[data-dough-language-selector-selector]'); };
+      done();
+    }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  context('when "add language" is clicked', function() {
+    beforeEach(function() { this.$addLanguage.trigger('click'); });
+
+    it('adds a new select box', function() {
+      expect(this.$selectors().length).to.eq(2);
+    });
+
+    it('clears attributes from select element', function() {
+      expect(this.$selectorsContainer.find('select').last().attr('id')).to.eq('');
+    });
+
+    it('does not duplicate template', function() {
+      expect(this.$html.find('[data-dough-language-selector-template]').length).to.eq(1);
+    });
+
+    context('when "remove language" is clicked', function() {
+      beforeEach(function() {
+        this.$selectors().last().find('[data-dough-language-selector-delete-language]').trigger('click');
+      });
+
+      it('removes the language', function() {
+        expect(this.$selectors().length).to.eq(1);
+      });
+    });
+  });
+});

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -43,7 +43,7 @@ module SelfService
 
     elements :investment_sizes, '.t-questionnaire__firm-investment-size-id'
 
-    element :languages, '.t-languages'
+    elements :languages, '.t-languages'
 
     element :save_button, '.t-save-button'
 

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -43,6 +43,8 @@ module SelfService
 
     elements :investment_sizes, '.t-questionnaire__firm-investment-size-id'
 
+    element :languages, '.t-languages'
+
     element :save_button, '.t-save-button'
 
     def offers_free_initial_meeting=(choice)


### PR DESCRIPTION
Firms want to be able to display languages they can give advice in. Here's a component that lets them do that.

It'll probably still be subject to some iteration on UX and other feedback, but I think this is good to merge.

## How it is

![Example](http://g.recordit.co/LfZtMFescK.gif)

## The designs

![Designs](https://cloud.githubusercontent.com/assets/1007202/9379817/d8a35640-4723-11e5-936f-59b519b8455f.png)
