### PR TITLE
Fixing layout

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -9,6 +9,7 @@
 
 @import 'layouts/2col';
 @import 'layouts/constrained';
+@import 'layouts/content';
 @import 'layouts/footer';
 @import 'layouts/half_width';
 @import 'layouts/header';

--- a/app/assets/stylesheets/layouts/_content.scss
+++ b/app/assets/stylesheets/layouts/_content.scss
@@ -1,0 +1,6 @@
+// This mimics the Front End l-registration style as we needed to use that for our user registration
+// https://github.com/moneyadviceservice/frontend/blob/master/app/assets/stylesheets/layout/page_specific/_registration.scss#L1
+%l-content {
+  @include column(12);
+  margin-bottom: $baseline-unit*4;
+}

--- a/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
+++ b/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
@@ -1,5 +1,5 @@
 .l-pre-qualification {
-  margin-bottom: $baseline-unit*8;
+  @extend %l-content;
 }
 
 .l-pre-qualification--restricted-width {

--- a/app/assets/stylesheets/layouts/_self_service.scss
+++ b/app/assets/stylesheets/layouts/_self_service.scss
@@ -1,5 +1,4 @@
 .l-self-service {
-  @extend .l-constrained;
   margin-bottom: $baseline-unit*8;
   padding-left: $baseline-unit*2;
   padding-right: $baseline-unit*2;

--- a/app/assets/stylesheets/layouts/_self_service.scss
+++ b/app/assets/stylesheets/layouts/_self_service.scss
@@ -1,7 +1,5 @@
 .l-self-service {
-  margin-bottom: $baseline-unit*8;
-  padding-left: $baseline-unit*2;
-  padding-right: $baseline-unit*2;
+  @extend %l-content;
 }
 
 .l-self-service-action-row {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,9 @@ module ApplicationHelper
   end
 
   def render_breadcrumbs(crumbs)
-    render 'shared/breadcrumbs', breadcrumbs: crumbs
+    content_for :breadcrumbs do
+      render 'shared/breadcrumbs', breadcrumbs: crumbs
+    end
   end
 
   def register_path

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,53 +1,55 @@
-<h1><%= t 'devise.invitations.edit.header' %></h1>
+<div class='l-registration'>
+  <h1><%= t 'devise.invitations.edit.header' %></h1>
 
-<%= form_for resource, as: resource_name,
-                       url: invitation_path(resource_name),
-                       builder: Dough::Forms::Builders::Validation,
-                       html: { method: :put, class: 'form', novalidate: 'novalidate' } do |f| %>
+  <%= form_for resource, as: resource_name,
+                         url: invitation_path(resource_name),
+                         builder: Dough::Forms::Builders::Validation,
+                         html: { method: :put, class: 'form', novalidate: 'novalidate' } do |f| %>
 
-  <%= validation_summary_with_devise_alerts(form: f) %>
+    <%= validation_summary_with_devise_alerts(form: f) %>
 
-  <%= f.hidden_field :invitation_token %>
+    <%= f.hidden_field :invitation_token %>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password do %>
-        <%= f.errors_for :password %>
-        <%= f.label :password, class: "form__label-heading" %>
-        <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.errors_for :password %>
+          <%= f.label :password, class: "form__label-heading" %>
+          <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password_confirmation do %>
-        <%= f.errors_for :password_confirmation %>
-        <%= f.label :password_confirmation, t('authentication.accept_invitation_page.field_labels.password_confirmation'), class: "form__label-heading" %>
-        <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password_confirmation do %>
+          <%= f.errors_for :password_confirmation %>
+          <%= f.label :password_confirmation, t('authentication.accept_invitation_page.field_labels.password_confirmation'), class: "form__label-heading" %>
+          <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password_confirmation") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password_confirmation") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.submit t("devise.invitations.edit.submit_button"), class: "button button--primary t-submit-button" %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.submit t("devise.invitations.edit.submit_button"), class: "button button--primary t-submit-button" %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/devise/password_expired/show.html.erb
+++ b/app/views/devise/password_expired/show.html.erb
@@ -1,70 +1,72 @@
-<h1><%= t('.title') %></h1>
-<%= form_for(resource, as: resource_name,
-                         url: [resource_name, :password_expired],
-                         html: {class: "form", novalidate: 'novalidate', method: :put},
-                         builder: Dough::Forms::Builders::Validation) do |f| %>
+<div class='l-registration'>
+  <h1><%= t('.title') %></h1>
+  <%= form_for(resource, as: resource_name,
+                           url: [resource_name, :password_expired],
+                           html: {class: "form", novalidate: 'novalidate', method: :put},
+                           builder: Dough::Forms::Builders::Validation) do |f| %>
 
-  <%= devise_error_messages! %>
+    <%= devise_error_messages! %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :current_password do %>
-          <%= f.errors_for :current_password %>
-          <%= f.label :current_password, class: "form__label-heading" %>
-          <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
-        <% end %>
-      </div>
+      <div class="registration__row">
+        <div class="registration__field">
+          <%= f.form_row :current_password do %>
+            <%= f.errors_for :current_password %>
+            <%= f.label :current_password, class: "form__label-heading" %>
+            <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
+          <% end %>
+        </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.current_password") %></p>
+        <div class="registration__helper">
+          <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
+            <div class="tooltip__content-container">
+              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.current_password") %></p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password do %>
-          <%= f.errors_for :password %>
-          <%= f.label :password, t("authentication.password_expiry_page.field_labels.new_password"), class: "form__label-heading" %>
-          <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_new_password" %>
-        <% end %>
-      </div>
+      <div class="registration__row">
+        <div class="registration__field">
+          <%= f.form_row :password do %>
+            <%= f.errors_for :password %>
+            <%= f.label :password, t("authentication.password_expiry_page.field_labels.new_password"), class: "form__label-heading" %>
+            <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_new_password" %>
+          <% end %>
+        </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_new_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password") %></p>
+        <div class="registration__helper">
+          <div class="field-help-text field-help-text--jshide" id="tooltip_new_password" data-dough-component="FieldHelpText">
+            <div class="tooltip__content-container">
+              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password") %></p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password_confirmation do %>
-          <%= f.errors_for :password_confirmation %>
-          <%= f.label :password_confirmation, t("authentication.password_expiry_page.field_labels.new_password_confirmation"), class: "form__label-heading" %>
-          <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-        <% end %>
-      </div>
+      <div class="registration__row">
+        <div class="registration__field">
+          <%= f.form_row :password_confirmation do %>
+            <%= f.errors_for :password_confirmation %>
+            <%= f.label :password_confirmation, t("authentication.password_expiry_page.field_labels.new_password_confirmation"), class: "form__label-heading" %>
+            <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+          <% end %>
+        </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password_confirmation") %></p>
+        <div class="registration__helper">
+          <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+            <div class="tooltip__content-container">
+              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password_confirmation") %></p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <div class="form__row">
-          <%= f.submit t("authentication.settings.change_password"), class: "button button--primary" %>
+      <div class="registration__row">
+        <div class="registration__field">
+          <div class="form__row">
+            <%= f.submit t("authentication.settings.change_password"), class: "button button--primary" %>
+          </div>
         </div>
       </div>
-    </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,36 +1,38 @@
-<h1><%= t("authentication.edit_password_page.title") %></h1>
+<div class='l-registration'>
+  <h1><%= t("authentication.edit_password_page.title") %></h1>
 
-<p><%= t("authentication.edit_password_page.steps") %></p>
+  <p><%= t("authentication.edit_password_page.steps") %></p>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
+    <%= devise_error_messages! %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password do %>
-        <%= f.label :password %>
-        <%= f.password_field :password, class: 't-password-field', autofocus: true, autocomplete: "off" %>
-      <% end %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.label :password %>
+          <%= f.password_field :password, class: 't-password-field', autofocus: true, autocomplete: "off" %>
+        <% end %>
+      </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password_confirmation do %>
-        <%= f.label :password_confirmation, t('authentication.edit_password_page.field_labels.password_confirmation') %>
-        <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off" %>
-      <% end %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password_confirmation do %>
+          <%= f.label :password_confirmation, t('authentication.edit_password_page.field_labels.password_confirmation') %>
+          <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off" %>
+        <% end %>
+      </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.submit t("authentication.edit_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.submit t("authentication.edit_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<div class="registration__links">
-  <%= render "devise/shared/links" %>
+  <div class="registration__links">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,28 +1,30 @@
-<h1><%= t("authentication.reset_password_page.title") %></h1>
+<div class='l-registration'>
+  <h1><%= t("authentication.reset_password_page.title") %></h1>
 
-<p><%= t("authentication.reset_password_page.intro") %></p>
+  <p><%= t("authentication.reset_password_page.intro") %></p>
 
-<p><%= t("authentication.reset_password_page.instructions") %></p>
+  <p><%= t("authentication.reset_password_page.instructions") %></p>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form' }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form' }) do |f| %>
+    <%= devise_error_messages! %>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :email do %>
-        <%= f.label :email %>
-        <%= f.email_field :email, class: 't-email-field', autofocus: true %>
-      <% end %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :email do %>
+          <%= f.label :email %>
+          <%= f.email_field :email, class: 't-email-field', autofocus: true %>
+        <% end %>
+      </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.submit t("authentication.reset_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.submit t("authentication.reset_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<div class="registration__links">
-  <%= render "devise/shared/links" %>
+  <div class="registration__links">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,89 +1,91 @@
-<h1><%= t("authentication.settings.title") %></h1>
+<div class='l-registration'>
+  <h1><%= t("authentication.settings.title") %></h1>
 
-<%= form_for(resource, as: resource_name,
-                         url: registration_path(resource_name),
-                         html: {class: "form", novalidate: 'novalidate', method: :put},
-                         builder: Dough::Forms::Builders::Validation) do |f| %>
+  <%= form_for(resource, as: resource_name,
+                           url: registration_path(resource_name),
+                           html: {class: "form", novalidate: 'novalidate', method: :put},
+                           builder: Dough::Forms::Builders::Validation) do |f| %>
 
-  <%= f.validation_summary %>
+    <%= f.validation_summary %>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :email do %>
-        <%= f.errors_for :email %>
-        <%= f.label :email, class: "form__label-heading" %>
-        <%= f.email_field :email, autofocus: true, "aria-describedby" => "tooltip_email" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :email do %>
+          <%= f.errors_for :email %>
+          <%= f.label :email, class: "form__label-heading" %>
+          <%= f.email_field :email, autofocus: true, "aria-describedby" => "tooltip_email" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_email" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.email") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_email" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.email") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password do %>
-        <%= f.errors_for :password %>
-        <%= f.label :password, t('authentication.settings.field_labels.new_password'), class: "form__label-heading" %>
-        <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_password" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.errors_for :password %>
+          <%= f.label :password, t('authentication.settings.field_labels.new_password'), class: "form__label-heading" %>
+          <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password_confirmation do %>
-        <%= f.errors_for :password_confirmation %>
-        <%= f.label :password_confirmation, t('authentication.settings.field_labels.new_password_confirmation'), class: "form__label-heading" %>
-        <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password_confirmation do %>
+          <%= f.errors_for :password_confirmation %>
+          <%= f.label :password_confirmation, t('authentication.settings.field_labels.new_password_confirmation'), class: "form__label-heading" %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password_confirmation") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password_confirmation") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :current_password do %>
-        <%= f.errors_for :current_password %>
-        <%= f.label :current_password, class: "form__label-heading" %>
-        <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :current_password do %>
+          <%= f.errors_for :current_password %>
+          <%= f.label :current_password, class: "form__label-heading" %>
+          <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.current_password") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.current_password") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <div class="form__row">
-        <%= f.submit t("authentication.settings.label"), class: "button button--primary" %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <div class="form__row">
+          <%= f.submit t("authentication.settings.label"), class: "button button--primary" %>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,55 +1,57 @@
-<h1><%= t('authentication.sign_in') %></h1>
+<div class='l-registration'>
+  <h1><%= t('authentication.sign_in') %></h1>
 
-<%= form_for(resource, as: resource_name,
-                       url: session_path(resource_name),
-                       builder: Dough::Forms::Builders::Validation,
-                       html: { class: "form", novalidate: 'novalidate'}) do |f| %>
+  <%= form_for(resource, as: resource_name,
+                         url: session_path(resource_name),
+                         builder: Dough::Forms::Builders::Validation,
+                         html: { class: "form", novalidate: 'novalidate'}) do |f| %>
 
-  <%= validation_summary_with_devise_alerts(form: f) %>
+    <%= validation_summary_with_devise_alerts(form: f) %>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :login do %>
-        <%= f.errors_for :login %>
-        <%= f.label :login, class: "form__label-heading" %>
-        <%= f.email_field :login, class: 't-login-field', autofocus: true, "aria-describedby" => "tooltip_login" %>
-      <% end %>
-    </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :login do %>
+          <%= f.errors_for :login %>
+          <%= f.label :login, class: "form__label-heading" %>
+          <%= f.email_field :login, class: 't-login-field', autofocus: true, "aria-describedby" => "tooltip_login" %>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_login" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.login") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_login" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.login") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.form_row :password do %>
-        <%= f.errors_for :password %>
-        <%= f.label :password, class: "form__label-heading" %>
-        <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.errors_for :password %>
+          <%= f.label :password, class: "form__label-heading" %>
+          <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
 
-        <div class="registration__links">
-          <%= render "devise/shared/links" %>
-        </div>
-      <% end %>
-    </div>
+          <div class="registration__links">
+            <%= render "devise/shared/links" %>
+          </div>
+        <% end %>
+      </div>
 
-    <div class="registration__helper">
-      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-        <div class="tooltip__content-container">
-          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.password") %></p>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.password") %></p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="registration__row">
-    <div class="registration__field">
-      <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary t-submit-button" %>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary t-submit-button" %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,15 +34,7 @@
 <main role="main" id="main">
   <div class='l-constrained'>
 
-    <% if devise_controller? %>
-      <div class='l-registration'>
-    <% end %>
-
     <%= yield %>
-
-    <% if devise_controller? %>
-      </div>
-    <% end %>
 
   </div>
 </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,19 +29,22 @@
 <%= render 'shared/skip_links' %>
 <%= render 'shared/header' %>
 <%= render 'shared/alerts' %>
+<%= yield :breadcrumbs %>
 
 <main role="main" id="main">
-  <% if devise_controller? %>
-    <div class='l-constrained'>
+  <div class='l-constrained'>
+
+    <% if devise_controller? %>
       <div class='l-registration'>
-  <% end %>
+    <% end %>
 
-  <%= yield %>
+    <%= yield %>
 
-  <% if devise_controller? %>
+    <% if devise_controller? %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+
+  </div>
 </main>
 
 <%= render 'shared/footer' %>

--- a/app/views/pages/error.html.erb
+++ b/app/views/pages/error.html.erb
@@ -1,7 +1,5 @@
 <main role="main">
-  <div class="l-constrained">
-    <section class="l-notice">
-      <%= heading_tag(t('error_message'), level: 1) %>
-    </section>
-  </div>
+  <section class="l-notice">
+    <%= heading_tag(t('error_message'), level: 1) %>
+  </section>
 </main>

--- a/app/views/principals/new.html.erb
+++ b/app/views/principals/new.html.erb
@@ -1,117 +1,115 @@
-<div class="l-constrained">
-  <section class="l-identity">
-    <%= heading_tag(t('registration.heading'), level: 1) %>
-    <p><%= t('required') %></p>
+<section class="l-identity">
+  <%= heading_tag(t('registration.heading'), level: 1) %>
+  <p><%= t('required') %></p>
 
-    <%= form_for @user, url: {controller: 'principals', action: 'create'}, method: :post, html: { class: 'form' }, builder: Dough::Forms::Builders::Validation do |user_form| %>
+  <%= form_for @user, url: {controller: 'principals', action: 'create'}, method: :post, html: { class: 'form' }, builder: Dough::Forms::Builders::Validation do |user_form| %>
 
-      <%= fields_for @principal, html: { class: 'form' },
-        builder: Dough::Forms::Builders::Validation do |principle_form| %>
-        <%= user_form.validation_summary %>
-        <%= heading_tag(t('registration.firm.heading'), level: 2) %>
+    <%= fields_for @principal, html: { class: 'form' },
+      builder: Dough::Forms::Builders::Validation do |principle_form| %>
+      <%= user_form.validation_summary %>
+      <%= heading_tag(t('registration.firm.heading'), level: 2) %>
 
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= principle_form.form_row(:fca_number) do %>
-              <%= user_form.errors_for :fca_number %>
-              <%= principle_form.label :fca_number, t('registration.firm.reference_number'), class: 'form__label-heading' %>
-              <%= principle_form.text_field :fca_number, class: 't-reference-number', maxlength: 6 %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= principle_form.form_row(:fca_number) do %>
+            <%= user_form.errors_for :fca_number %>
+            <%= principle_form.label :fca_number, t('registration.firm.reference_number'), class: 'form__label-heading' %>
+            <%= principle_form.text_field :fca_number, class: 't-reference-number', maxlength: 6 %>
+          <% end %>
         </div>
+      </div>
 
-        <hr>
+      <hr>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field l-identity__field--wide">
-            <%= heading_tag(t('registration.principal.heading'), level: 2) %>
-            <p><%= t('registration.principal.explanation') %></p>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field l-identity__field--wide">
+          <%= heading_tag(t('registration.principal.heading'), level: 2) %>
+          <p><%= t('registration.principal.explanation') %></p>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= principle_form.form_row(:first_name) do %>
-              <%= user_form.errors_for :first_name %>
-              <%= principle_form.label :first_name, t('registration.principal.first_name'), class: 'form__label-heading' %>
-              <%= principle_form.text_field :first_name, class: 't-first-name' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= principle_form.form_row(:first_name) do %>
+            <%= user_form.errors_for :first_name %>
+            <%= principle_form.label :first_name, t('registration.principal.first_name'), class: 'form__label-heading' %>
+            <%= principle_form.text_field :first_name, class: 't-first-name' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= principle_form.form_row(:last_name) do %>
-              <%= user_form.errors_for :last_name %>
-              <%= principle_form.label :last_name, t('registration.principal.last_name'), class: 'form__label-heading' %>
-              <%= principle_form.text_field :last_name, class: 't-last-name' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= principle_form.form_row(:last_name) do %>
+            <%= user_form.errors_for :last_name %>
+            <%= principle_form.label :last_name, t('registration.principal.last_name'), class: 'form__label-heading' %>
+            <%= principle_form.text_field :last_name, class: 't-last-name' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= principle_form.form_row(:job_title) do %>
-              <%= user_form.errors_for :job_title %>
-              <%= principle_form.label :job_title, t('registration.principal.job_title'), class: 'form__label-heading' %>
-              <%= principle_form.text_field :job_title, class: 't-job-title' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= principle_form.form_row(:job_title) do %>
+            <%= user_form.errors_for :job_title %>
+            <%= principle_form.label :job_title, t('registration.principal.job_title'), class: 'form__label-heading' %>
+            <%= principle_form.text_field :job_title, class: 't-job-title' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= user_form.form_row(:email) do %>
-              <%= user_form.errors_for :email %>
-              <%= user_form.label :email, t('registration.principal.email_address'), class: 'form__label-heading' %>
-              <%= user_form.text_field :email, class: 't-email-address' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= user_form.form_row(:email) do %>
+            <%= user_form.errors_for :email %>
+            <%= user_form.label :email, t('registration.principal.email_address'), class: 'form__label-heading' %>
+            <%= user_form.text_field :email, class: 't-email-address' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= principle_form.form_row(:telephone_number) do %>
-              <%= user_form.errors_for :telephone_number %>
-              <%= principle_form.label :telephone_number, t('registration.principal.telephone_number'), class: 'form__label-heading' %>
-              <%= principle_form.text_field :telephone_number, class: 't-telephone-number' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= principle_form.form_row(:telephone_number) do %>
+            <%= user_form.errors_for :telephone_number %>
+            <%= principle_form.label :telephone_number, t('registration.principal.telephone_number'), class: 'form__label-heading' %>
+            <%= principle_form.text_field :telephone_number, class: 't-telephone-number' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= user_form.form_row(:password) do %>
-              <%= user_form.errors_for :password %>
-              <%= user_form.label :password, t('registration.user.password'), class: 'form__label-heading' %>
-              <%= user_form.password_field :password, class: 't-password' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= user_form.form_row(:password) do %>
+            <%= user_form.errors_for :password %>
+            <%= user_form.label :password, t('registration.user.password'), class: 'form__label-heading' %>
+            <%= user_form.password_field :password, class: 't-password' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field">
-            <%= user_form.form_row(:password_confirmation) do %>
-              <%= user_form.errors_for :password_confirmation %>
-              <%= user_form.label :password_confirmation, t('registration.user.password_confirmation'), class: 'form__label-heading' %>
-              <%= user_form.password_field :password_confirmation, class: 't-password-confirmation' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field">
+          <%= user_form.form_row(:password_confirmation) do %>
+            <%= user_form.errors_for :password_confirmation %>
+            <%= user_form.label :password_confirmation, t('registration.user.password_confirmation'), class: 'form__label-heading' %>
+            <%= user_form.password_field :password_confirmation, class: 't-password-confirmation' %>
+          <% end %>
         </div>
+      </div>
 
-        <div class="l-identity__row">
-          <div class="l-identity__field l-identity__field--wide">
-            <%= principle_form.form_row(:confirmed_disclaimer) do %>
-              <%= user_form.errors_for :confirmed_disclaimer %>
-              <%= principle_form.check_box :confirmed_disclaimer, class: 'l-identity__checkbox t-confirmation' %>
-              <%= principle_form.label :confirmed_disclaimer, t('confirmation_statement'), class: 'l-identity__disclaimer-label' %>
-            <% end %>
-          </div>
+      <div class="l-identity__row">
+        <div class="l-identity__field l-identity__field--wide">
+          <%= principle_form.form_row(:confirmed_disclaimer) do %>
+            <%= user_form.errors_for :confirmed_disclaimer %>
+            <%= principle_form.check_box :confirmed_disclaimer, class: 'l-identity__checkbox t-confirmation' %>
+            <%= principle_form.label :confirmed_disclaimer, t('confirmation_statement'), class: 'l-identity__disclaimer-label' %>
+          <% end %>
         </div>
+      </div>
 
-      <% end %>
-      <%= button_primary t('registration.register_button') %>
     <% end %>
-  </section>
-</div>
+    <%= button_primary t('registration.register_button') %>
+  <% end %>
+</section>

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -1,4 +1,4 @@
-<div class="l-constrained l-pre-qualification">
+<div class="l-pre-qualification">
   <div class="l-1col">
     <%= heading_tag(t('registration.heading'), level: 1) %>
     <p class="intro"><%= t('registration.introduction') %></p>

--- a/app/views/principals/rejection_form.html.erb
+++ b/app/views/principals/rejection_form.html.erb
@@ -1,31 +1,29 @@
-<div class="l-constrained">
-  <%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification l-pre-qualification--restricted-width' },
-    builder: Dough::Forms::Builders::Validation do |f| %>
-    <%= f.validation_summary %>
-    <%= heading_tag(t('rejection.heading'), level: 1) %>
-    <p><%= t('rejection.subheading') %></p>
+<%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification l-pre-qualification--restricted-width' },
+  builder: Dough::Forms::Builders::Validation do |f| %>
+  <%= f.validation_summary %>
+  <%= heading_tag(t('rejection.heading'), level: 1) %>
+  <p><%= t('rejection.subheading') %></p>
 
-    <section class="l-pre-qualification__explanation">
-      <% t('rejection.reasons').each do |item| %>
-        <%= heading_tag(item[:heading], level: 2, class: 'l-pre-qualification__question') %>
-        <p><%= item[:explanation] %></p>
-      <% end %>
-    </section>
-
-    <p class="form__label-heading"><%= t('rejection.input_label') %></p>
-
-    <%= f.form_row :email do %>
-      <%= f.errors_for :email %>
-      <label class="form__label-heading"><%= t('rejection.email_address') %></label>
-      <%= f.email_field :email, class: 't-email' %>
+  <section class="l-pre-qualification__explanation">
+    <% t('rejection.reasons').each do |item| %>
+      <%= heading_tag(item[:heading], level: 2, class: 'l-pre-qualification__question') %>
+      <p><%= item[:explanation] %></p>
     <% end %>
+  </section>
 
-    <%= f.form_row :message do %>
-      <%= f.errors_for :message %>
-      <label class="form__label-heading"><%= t('rejection.message') %></label>
-      <%= f.text_area :message, cols: 30, rows: 10, class: 't-message' %>
-    <% end %>
+  <p class="form__label-heading"><%= t('rejection.input_label') %></p>
 
-    <%= button_primary t('rejection.submit_button') %>
+  <%= f.form_row :email do %>
+    <%= f.errors_for :email %>
+    <label class="form__label-heading"><%= t('rejection.email_address') %></label>
+    <%= f.email_field :email, class: 't-email' %>
   <% end %>
-</div>
+
+  <%= f.form_row :message do %>
+    <%= f.errors_for :message %>
+    <label class="form__label-heading"><%= t('rejection.message') %></label>
+    <%= f.text_area :message, cols: 30, rows: 10, class: 't-message' %>
+  <% end %>
+
+  <%= button_primary t('rejection.submit_button') %>
+<% end %>

--- a/app/views/principals/show.html.erb
+++ b/app/views/principals/show.html.erb
@@ -1,7 +1,5 @@
-<div class="l-constrained">
-  <section class="l-notice">
-    <%= heading_tag(t('success.heading'), level: 1, class: '') %>
-    <p><%= t('success.message') %></p>
-    <p><%= t('success.contact_us') %> <%= mail_to t('email_address'), t('email_address') %></p>
-  </section>
-</div>
+<section class="l-notice">
+  <%= heading_tag(t('success.heading'), level: 1, class: '') %>
+  <p><%= t('success.message') %></p>
+  <p><%= t('success.contact_us') %> <%= mail_to t('email_address'), t('email_address') %></p>
+</section>

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_adviser_edit) %>
+<% render_breadcrumbs(breadcrumbs_firm_adviser_edit) %>
 
 <div class="l-self-service">
   <h1>

--- a/app/views/self_service/advisers/index.html.erb
+++ b/app/views/self_service/advisers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_advisers) %>
+<% render_breadcrumbs(breadcrumbs_firm_advisers) %>
 <%= render_onboarding_message(:advisers_index) %>
 
 <div class="l-self-service">

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_adviser_new) %>
+<% render_breadcrumbs(breadcrumbs_firm_adviser_new) %>
 <%= render_onboarding_message(:advisers_new) %>
 
 <div class="l-self-service">

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_edit) %>
+<% render_breadcrumbs(breadcrumbs_firm_edit) %>
 <%= render_onboarding_message(:firm_form) %>
 
 <div class="l-self-service">

--- a/app/views/self_service/firms/index.html.erb
+++ b/app/views/self_service/firms/index.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_root) %>
+<% render_breadcrumbs(breadcrumbs_root) %>
 <%= render_onboarding_message(:firms_index) %>
 
 <div class="l-self-service">

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_offices) %>
+<% render_breadcrumbs(breadcrumbs_firm_offices) %>
 
 <div class="l-self-service">
   <div class="l-heading-with-button">

--- a/app/views/self_service/principals/edit.html.erb
+++ b/app/views/self_service/principals/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_principal_edit) %>
+<% render_breadcrumbs(breadcrumbs_principal_edit) %>
 
 <div class="l-self-service">
   <h1>

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_firm_edit) %>
+<% render_breadcrumbs(breadcrumbs_firm_edit) %>
 <%= render_onboarding_message(:firm_form) %>
 
 <div class="l-self-service">

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -1,4 +1,4 @@
-<%= render_breadcrumbs(breadcrumbs_trading_name_new) %>
+<% render_breadcrumbs(breadcrumbs_trading_name_new) %>
 <%= render_onboarding_message(:firm_form) %>
 
 <div class="l-self-service">


### PR DESCRIPTION
As we were working on the notifications story we realised that the base layout was not following a common styling. For example, we are using the `l-registration` class on the devise views in order to match front end styles. However our own content wrappers such as `l-self-service` and `l-pre-qualification` were using different styling.

We were also in some cases nesting `l-constrained` because it wasn't obvious which views were using them and which were not. As such we've hoisted the `l-constrained` to the layout to make it more obvious.

Finally we had to use a named yield for the breadcrumbs because they were now being rendered inside the `l-constrained` due to where they were being called.

**N.B. the views look like there are a lot of changes due to us changing the indentation when we either extracted the `l-constrained` div wrapper (in the case of the principal views) or added the `l-registration` div wrapper (in the case of the devise views)**