### PR TITLE
Removing l-flashes and wrapping divs everywhere

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -10,7 +10,6 @@
 @import 'layouts/2col';
 @import 'layouts/constrained';
 @import 'layouts/content';
-@import 'layouts/flashes';
 @import 'layouts/footer';
 @import 'layouts/half_width';
 @import 'layouts/header';

--- a/app/assets/stylesheets/layouts/_content.scss
+++ b/app/assets/stylesheets/layouts/_content.scss
@@ -1,6 +1,6 @@
 // This mimics the Front End l-registration style as we needed to use that for our user registration
 // https://github.com/moneyadviceservice/frontend/blob/master/app/assets/stylesheets/layout/page_specific/_registration.scss#L1
-%l-content {
+.l-content {
   @include column(12);
   margin-bottom: $baseline-unit*4;
 }

--- a/app/assets/stylesheets/layouts/_flashes.scss
+++ b/app/assets/stylesheets/layouts/_flashes.scss
@@ -1,3 +1,0 @@
-.l-flashes {
-  @extend %l-content;
-}

--- a/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
+++ b/app/assets/stylesheets/layouts/_pre_qualification_questions.scss
@@ -1,7 +1,3 @@
-.l-pre-qualification {
-  @extend %l-content;
-}
-
 .l-pre-qualification--restricted-width {
   @include column(12);
 

--- a/app/assets/stylesheets/layouts/_self_service.scss
+++ b/app/assets/stylesheets/layouts/_self_service.scss
@@ -1,7 +1,3 @@
-.l-self-service {
-  @extend %l-content;
-}
-
 .l-self-service-action-row {
   text-align: right;
   margin: $baseline-unit*4 0 0;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,8 @@ module ApplicationHelper
     end
     safe_join(tags)
   end
+
+  def layout_class
+    controller.devise_controller? ? 'l-registration' : 'l-content'
+  end
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,55 +1,53 @@
-<div class='l-registration'>
-  <h1><%= t 'devise.invitations.edit.header' %></h1>
+<h1><%= t 'devise.invitations.edit.header' %></h1>
 
-  <%= form_for resource, as: resource_name,
-                         url: invitation_path(resource_name),
-                         builder: Dough::Forms::Builders::Validation,
-                         html: { method: :put, class: 'form', novalidate: 'novalidate' } do |f| %>
+<%= form_for resource, as: resource_name,
+                       url: invitation_path(resource_name),
+                       builder: Dough::Forms::Builders::Validation,
+                       html: { method: :put, class: 'form', novalidate: 'novalidate' } do |f| %>
 
-    <%= validation_summary_with_devise_alerts(form: f) %>
+  <%= validation_summary_with_devise_alerts(form: f) %>
 
-    <%= f.hidden_field :invitation_token %>
+  <%= f.hidden_field :invitation_token %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password do %>
-          <%= f.errors_for :password %>
-          <%= f.label :password, class: "form__label-heading" %>
-          <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password do %>
+        <%= f.errors_for :password %>
+        <%= f.label :password, class: "form__label-heading" %>
+        <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password_confirmation do %>
-          <%= f.errors_for :password_confirmation %>
-          <%= f.label :password_confirmation, t('authentication.accept_invitation_page.field_labels.password_confirmation'), class: "form__label-heading" %>
-          <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password_confirmation do %>
+        <%= f.errors_for :password_confirmation %>
+        <%= f.label :password_confirmation, t('authentication.accept_invitation_page.field_labels.password_confirmation'), class: "form__label-heading" %>
+        <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password_confirmation") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.accept_invitation_page.field_help_texts.password_confirmation") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.submit t("devise.invitations.edit.submit_button"), class: "button button--primary t-submit-button" %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.submit t("devise.invitations.edit.submit_button"), class: "button button--primary t-submit-button" %>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/devise/password_expired/show.html.erb
+++ b/app/views/devise/password_expired/show.html.erb
@@ -1,72 +1,70 @@
-<div class='l-registration'>
-  <h1><%= t('.title') %></h1>
-  <%= form_for(resource, as: resource_name,
-                           url: [resource_name, :password_expired],
-                           html: {class: "form", novalidate: 'novalidate', method: :put},
-                           builder: Dough::Forms::Builders::Validation) do |f| %>
+<h1><%= t('.title') %></h1>
+<%= form_for(resource, as: resource_name,
+                         url: [resource_name, :password_expired],
+                         html: {class: "form", novalidate: 'novalidate', method: :put},
+                         builder: Dough::Forms::Builders::Validation) do |f| %>
 
-    <%= devise_error_messages! %>
+  <%= devise_error_messages! %>
 
-      <div class="registration__row">
-        <div class="registration__field">
-          <%= f.form_row :current_password do %>
-            <%= f.errors_for :current_password %>
-            <%= f.label :current_password, class: "form__label-heading" %>
-            <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
-          <% end %>
-        </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :current_password do %>
+          <%= f.errors_for :current_password %>
+          <%= f.label :current_password, class: "form__label-heading" %>
+          <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
+        <% end %>
+      </div>
 
-        <div class="registration__helper">
-          <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
-            <div class="tooltip__content-container">
-              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.current_password") %></p>
-            </div>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.current_password") %></p>
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="registration__row">
-        <div class="registration__field">
-          <%= f.form_row :password do %>
-            <%= f.errors_for :password %>
-            <%= f.label :password, t("authentication.password_expiry_page.field_labels.new_password"), class: "form__label-heading" %>
-            <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_new_password" %>
-          <% end %>
-        </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password do %>
+          <%= f.errors_for :password %>
+          <%= f.label :password, t("authentication.password_expiry_page.field_labels.new_password"), class: "form__label-heading" %>
+          <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_new_password" %>
+        <% end %>
+      </div>
 
-        <div class="registration__helper">
-          <div class="field-help-text field-help-text--jshide" id="tooltip_new_password" data-dough-component="FieldHelpText">
-            <div class="tooltip__content-container">
-              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password") %></p>
-            </div>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_new_password" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password") %></p>
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="registration__row">
-        <div class="registration__field">
-          <%= f.form_row :password_confirmation do %>
-            <%= f.errors_for :password_confirmation %>
-            <%= f.label :password_confirmation, t("authentication.password_expiry_page.field_labels.new_password_confirmation"), class: "form__label-heading" %>
-            <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-          <% end %>
-        </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <%= f.form_row :password_confirmation do %>
+          <%= f.errors_for :password_confirmation %>
+          <%= f.label :password_confirmation, t("authentication.password_expiry_page.field_labels.new_password_confirmation"), class: "form__label-heading" %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+        <% end %>
+      </div>
 
-        <div class="registration__helper">
-          <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-            <div class="tooltip__content-container">
-              <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password_confirmation") %></p>
-            </div>
+      <div class="registration__helper">
+        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+          <div class="tooltip__content-container">
+            <p class="tooltip__text"><%= t("authentication.password_expiry_page.field_help_texts.password_confirmation") %></p>
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="registration__row">
-        <div class="registration__field">
-          <div class="form__row">
-            <%= f.submit t("authentication.settings.change_password"), class: "button button--primary" %>
-          </div>
+    <div class="registration__row">
+      <div class="registration__field">
+        <div class="form__row">
+          <%= f.submit t("authentication.settings.change_password"), class: "button button--primary" %>
         </div>
       </div>
-  <% end %>
-</div>
+    </div>
+<% end %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,38 +1,36 @@
-<div class='l-registration'>
-  <h1><%= t("authentication.edit_password_page.title") %></h1>
+<h1><%= t("authentication.edit_password_page.title") %></h1>
 
-  <p><%= t("authentication.edit_password_page.steps") %></p>
+<p><%= t("authentication.edit_password_page.steps") %></p>
 
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
-    <%= devise_error_messages! %>
-    <%= f.hidden_field :reset_password_token %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password do %>
-          <%= f.label :password %>
-          <%= f.password_field :password, class: 't-password-field', autofocus: true, autocomplete: "off" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password do %>
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 't-password-field', autofocus: true, autocomplete: "off" %>
+      <% end %>
     </div>
-
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password_confirmation do %>
-          <%= f.label :password_confirmation, t('authentication.edit_password_page.field_labels.password_confirmation') %>
-          <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off" %>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.submit t("authentication.edit_password_page.button_label"), class: 'button button--primary t-submit-button' %>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="registration__links">
-    <%= render "devise/shared/links" %>
   </div>
+
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password_confirmation do %>
+        <%= f.label :password_confirmation, t('authentication.edit_password_page.field_labels.password_confirmation') %>
+        <%= f.password_field :password_confirmation, class: 't-password-confirmation-field', autocomplete: "off" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.submit t("authentication.edit_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+    </div>
+  </div>
+<% end %>
+
+<div class="registration__links">
+  <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,30 +1,28 @@
-<div class='l-registration'>
-  <h1><%= t("authentication.reset_password_page.title") %></h1>
+<h1><%= t("authentication.reset_password_page.title") %></h1>
 
-  <p><%= t("authentication.reset_password_page.intro") %></p>
+<p><%= t("authentication.reset_password_page.intro") %></p>
 
-  <p><%= t("authentication.reset_password_page.instructions") %></p>
+<p><%= t("authentication.reset_password_page.instructions") %></p>
 
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form' }) do |f| %>
-    <%= devise_error_messages! %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form' }) do |f| %>
+  <%= devise_error_messages! %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :email do %>
-          <%= f.label :email %>
-          <%= f.email_field :email, class: 't-email-field', autofocus: true %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :email do %>
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 't-email-field', autofocus: true %>
+      <% end %>
     </div>
-
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.submit t("authentication.reset_password_page.button_label"), class: 'button button--primary t-submit-button' %>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="registration__links">
-    <%= render "devise/shared/links" %>
   </div>
+
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.submit t("authentication.reset_password_page.button_label"), class: 'button button--primary t-submit-button' %>
+    </div>
+  </div>
+<% end %>
+
+<div class="registration__links">
+  <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,91 +1,90 @@
-<div class='l-registration'>
-  <h1><%= t("authentication.settings.title") %></h1>
+<h1><%= t("authentication.settings.title") %></h1>
 
-  <%= form_for(resource, as: resource_name,
-                           url: registration_path(resource_name),
-                           html: {class: "form", novalidate: 'novalidate', method: :put},
-                           builder: Dough::Forms::Builders::Validation) do |f| %>
+<%= form_for(resource, as: resource_name,
+                         url: registration_path(resource_name),
+                         html: {class: "form", novalidate: 'novalidate', method: :put},
+                         builder: Dough::Forms::Builders::Validation) do |f| %>
 
-    <%= f.validation_summary %>
+  <%= f.validation_summary %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :email do %>
-          <%= f.errors_for :email %>
-          <%= f.label :email, class: "form__label-heading" %>
-          <%= f.email_field :email, autofocus: true, "aria-describedby" => "tooltip_email" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :email do %>
+        <%= f.errors_for :email %>
+        <%= f.label :email, class: "form__label-heading" %>
+        <%= f.email_field :email, autofocus: true, "aria-describedby" => "tooltip_email" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_email" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.email") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_email" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.email") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password do %>
-          <%= f.errors_for :password %>
-          <%= f.label :password, t('authentication.settings.field_labels.new_password'), class: "form__label-heading" %>
-          <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_password" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password do %>
+        <%= f.errors_for :password %>
+        <%= f.label :password, t('authentication.settings.field_labels.new_password'), class: "form__label-heading" %>
+        <%= f.password_field :password, autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password_confirmation do %>
-          <%= f.errors_for :password_confirmation %>
-          <%= f.label :password_confirmation, t('authentication.settings.field_labels.new_password_confirmation'), class: "form__label-heading" %>
-          <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password_confirmation do %>
+        <%= f.errors_for :password_confirmation %>
+        <%= f.label :password_confirmation, t('authentication.settings.field_labels.new_password_confirmation'), class: "form__label-heading" %>
+        <%= f.password_field :password_confirmation, autocomplete: "off", "aria-describedby" => "tooltip_password_confirmation" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password_confirmation") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_password_confirmation" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.password_confirmation") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :current_password do %>
-          <%= f.errors_for :current_password %>
-          <%= f.label :current_password, class: "form__label-heading" %>
-          <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :current_password do %>
+        <%= f.errors_for :current_password %>
+        <%= f.label :current_password, class: "form__label-heading" %>
+        <%= f.password_field :current_password, autocomplete: "off", "aria-describedby" => "tooltip_current_password" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.current_password") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_current_password" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.settings.field_help_texts.current_password") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <div class="form__row">
-          <%= f.submit t("authentication.settings.label"), class: "button button--primary" %>
-        </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <div class="form__row">
+        <%= f.submit t("authentication.settings.label"), class: "button button--primary" %>
       </div>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>
+

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,57 +1,55 @@
-<div class='l-registration'>
-  <h1><%= t('authentication.sign_in') %></h1>
+<h1><%= t('authentication.sign_in') %></h1>
 
-  <%= form_for(resource, as: resource_name,
-                         url: session_path(resource_name),
-                         builder: Dough::Forms::Builders::Validation,
-                         html: { class: "form", novalidate: 'novalidate'}) do |f| %>
+<%= form_for(resource, as: resource_name,
+                       url: session_path(resource_name),
+                       builder: Dough::Forms::Builders::Validation,
+                       html: { class: "form", novalidate: 'novalidate'}) do |f| %>
 
-    <%= validation_summary_with_devise_alerts(form: f) %>
+  <%= validation_summary_with_devise_alerts(form: f) %>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :login do %>
-          <%= f.errors_for :login %>
-          <%= f.label :login, class: "form__label-heading" %>
-          <%= f.email_field :login, class: 't-login-field', autofocus: true, "aria-describedby" => "tooltip_login" %>
-        <% end %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :login do %>
+        <%= f.errors_for :login %>
+        <%= f.label :login, class: "form__label-heading" %>
+        <%= f.email_field :login, class: 't-login-field', autofocus: true, "aria-describedby" => "tooltip_login" %>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_login" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.login") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_login" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.login") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :password do %>
-          <%= f.errors_for :password %>
-          <%= f.label :password, class: "form__label-heading" %>
-          <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.form_row :password do %>
+        <%= f.errors_for :password %>
+        <%= f.label :password, class: "form__label-heading" %>
+        <%= f.password_field :password, class: 't-password-field', autocomplete: "off", "aria-describedby" => "tooltip_password" %>
 
-          <div class="registration__links">
-            <%= render "devise/shared/links" %>
-          </div>
-        <% end %>
-      </div>
+        <div class="registration__links">
+          <%= render "devise/shared/links" %>
+        </div>
+      <% end %>
+    </div>
 
-      <div class="registration__helper">
-        <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
-          <div class="tooltip__content-container">
-            <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.password") %></p>
-          </div>
+    <div class="registration__helper">
+      <div class="field-help-text field-help-text--jshide" id="tooltip_password" data-dough-component="FieldHelpText">
+        <div class="tooltip__content-container">
+          <p class="tooltip__text"><%= t("authentication.sign_in_page.field_help_texts.password") %></p>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary t-submit-button" %>
-      </div>
+  <div class="registration__row">
+    <div class="registration__field">
+      <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary t-submit-button" %>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,13 +32,11 @@
 
 <main role="main" id="main">
   <div class='l-constrained'>
-    <div class="l-flashes">
+    <div class="<%= layout_class %>">
       <%= render 'shared/alerts' %>
       <%= yield :notifications %>
+      <%= yield %>
     </div>
-
-    <%= yield %>
-
   </div>
 </main>
 

--- a/app/views/principals/pre_qualification_form.html.erb
+++ b/app/views/principals/pre_qualification_form.html.erb
@@ -1,129 +1,127 @@
-<div class="l-pre-qualification">
-  <div class="l-1col">
-    <%= heading_tag(t('registration.heading'), level: 1) %>
-    <p class="intro"><%= t('registration.introduction') %></p>
-  </div>
+<div class="l-1col">
+  <%= heading_tag(t('registration.heading'), level: 1) %>
+  <p class="intro"><%= t('registration.introduction') %></p>
+</div>
 
-  <div class="l-2col">
-    <section class="l-2col-side l-2col-side--pull-right">
-      <%= render 'shared/sign_in_panel' %>
-    </section>
+<div class="l-2col">
+  <section class="l-2col-side l-2col-side--pull-right">
+    <%= render 'shared/sign_in_panel' %>
+  </section>
 
-    <section class="l-2col-main">
-      <%= heading_tag(t('registration.sub_heading'), level: 2) %>
-      <p><%= t('registration.eligibility_explanation') %></p>
-      <%= form_for @prequalification, url: prequalify_principals_path, html: { class: 'form' } do |f| %>
-        <%= f.form_row :active_question do %>
-          <fieldset class="form__group form__group--inline t-active-question">
-            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.active_question.heading') %></legend>
-            <p><%= t('registration.active_question.description') %></p>
+  <section class="l-2col-main">
+    <%= heading_tag(t('registration.sub_heading'), level: 2) %>
+    <p><%= t('registration.eligibility_explanation') %></p>
+    <%= form_for @prequalification, url: prequalify_principals_path, html: { class: 'form' } do |f| %>
+      <%= f.form_row :active_question do %>
+        <fieldset class="form__group form__group--inline t-active-question">
+          <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.active_question.heading') %></legend>
+          <p><%= t('registration.active_question.description') %></p>
+
+          <div class="form__group-item">
+            <label>
+              <%= f.radio_button :active_question, 1, class: 'form__group-input' %>
+              <%= t('registration.answer_yes') %>
+            </label>
+          </div>
+
+          <div class="form__group-item">
+            <label>
+              <%= f.radio_button :active_question, 0, class: 'form__group-input' %>
+              <%= t('registration.answer_no') %>
+            </label>
+          </div>
+        </fieldset>
+      <% end %>
+
+      <%= f.form_row :business_model_question do %>
+        <fieldset class="form__group form__group--inline t-business-model-question">
+          <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.business_model_question.heading') %></legend>
+          <p><%= t('registration.business_model_question.description') %></p>
+
+          <div class="form__group-item">
+            <label>
+              <%= f.radio_button :business_model_question, 1, class: 'form__group-input' %>
+              <%= t('registration.answer_yes') %>
+            </label>
+          </div>
+
+          <div class="form__group-item">
+            <label>
+              <%= f.radio_button :business_model_question, 0, class: 'form__group-input' %>
+              <%= t('registration.answer_no') %>
+            </label>
+          </div>
+        </fieldset>
+      <% end %>
+
+      <div data-dough-component="FieldToggleVisibility">
+        <%= f.form_row :status_question do %>
+          <fieldset class="form__group form__group--inline t-status-question">
+            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.status_question.heading') %></legend>
+            <p><%= t('registration.status_question.description') %></p>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :active_question, 1, class: 'form__group-input' %>
-                <%= t('registration.answer_yes') %>
+                <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_hide: '1'  } %>
+                <%= t('registration.status_question.answer_one') %>
               </label>
             </div>
 
             <div class="form__group-item">
               <label>
-                <%= f.radio_button :active_question, 0, class: 'form__group-input' %>
-                <%= t('registration.answer_no') %>
+                <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_show: '1' } %>
+                <%= t('registration.status_question.answer_two') %>
+                <span class="visually-hidden"><%= t('registration.notice') %></span>
               </label>
             </div>
           </fieldset>
         <% end %>
 
-        <%= f.form_row :business_model_question do %>
-          <fieldset class="form__group form__group--inline t-business-model-question">
-            <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.business_model_question.heading') %></legend>
-            <p><%= t('registration.business_model_question.description') %></p>
-
-            <div class="form__group-item">
-              <label>
-                <%= f.radio_button :business_model_question, 1, class: 'form__group-input' %>
-                <%= t('registration.answer_yes') %>
-              </label>
-            </div>
-
-            <div class="form__group-item">
-              <label>
-                <%= f.radio_button :business_model_question, 0, class: 'form__group-input' %>
-                <%= t('registration.answer_no') %>
-              </label>
-            </div>
-          </fieldset>
-        <% end %>
-
-        <div data-dough-component="FieldToggleVisibility">
-          <%= f.form_row :status_question do %>
-            <fieldset class="form__group form__group--inline t-status-question">
-              <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.status_question.heading') %></legend>
-              <p><%= t('registration.status_question.description') %></p>
+        <div data-dough-field-target="1">
+          <%= f.form_row :particular_market_question do %>
+            <fieldset class="form__group form__group--inline t-particular-market-question">
+              <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.particular_market_question.heading') %></legend>
 
               <div class="form__group-item">
                 <label>
-                  <%= f.radio_button :status_question, 1, class: 'form__group-input js-radio-button', data: { dough_field_hide: '1'  } %>
-                  <%= t('registration.status_question.answer_one') %>
+                  <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_show: '2'  } %>
+                  <%= t('registration.answer_yes') %>
+                  <span class="visually-hidden"><%= t('registration.notice') %></span>
                 </label>
               </div>
 
               <div class="form__group-item">
                 <label>
-                  <%= f.radio_button :status_question, 0, class: 'form__group-input js-radio-button', data: { dough_field_show: '1' } %>
-                  <%= t('registration.status_question.answer_two') %>
-                  <span class="visually-hidden"><%= t('registration.notice') %></span>
+                  <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_hide: '2'  } %>
+                  <%= t('registration.answer_no') %>
                 </label>
               </div>
             </fieldset>
           <% end %>
 
-          <div data-dough-field-target="1">
-            <%= f.form_row :particular_market_question do %>
-              <fieldset class="form__group form__group--inline t-particular-market-question">
-                <legend class="l-pre-qualification__question l-pre-qualification__question--with-desc"><%= t('registration.particular_market_question.heading') %></legend>
+          <%= f.form_row :consider_available_providers_question do %>
+            <fieldset class="form__group form__group--inline t-consider-available-providers-question" data-dough-field-target="2">
+              <legend class="l-pre-qualification__question"><%= t('registration.consider_available_providers_question.heading') %></legend>
 
-                <div class="form__group-item">
-                  <label>
-                    <%= f.radio_button :particular_market_question, 1, class: 'form__group-input', data: { dough_field_show: '2'  } %>
-                    <%= t('registration.answer_yes') %>
-                    <span class="visually-hidden"><%= t('registration.notice') %></span>
-                  </label>
-                </div>
+              <div class="form__group-item">
+                <label>
+                  <%= f.radio_button :consider_available_providers_question, 1, class: 'form__group-input' %>
+                  <%= t('registration.answer_yes') %>
+                </label>
+              </div>
 
-                <div class="form__group-item">
-                  <label>
-                    <%= f.radio_button :particular_market_question, 0, class: 'form__group-input', data: { dough_field_hide: '2'  } %>
-                    <%= t('registration.answer_no') %>
-                  </label>
-                </div>
-              </fieldset>
-            <% end %>
-
-            <%= f.form_row :consider_available_providers_question do %>
-              <fieldset class="form__group form__group--inline t-consider-available-providers-question" data-dough-field-target="2">
-                <legend class="l-pre-qualification__question"><%= t('registration.consider_available_providers_question.heading') %></legend>
-
-                <div class="form__group-item">
-                  <label>
-                    <%= f.radio_button :consider_available_providers_question, 1, class: 'form__group-input' %>
-                    <%= t('registration.answer_yes') %>
-                  </label>
-                </div>
-
-                <div class="form__group-item">
-                  <label>
-                    <%= f.radio_button :consider_available_providers_question, 0, class: 'form__group-input' %>
-                    <%= t('registration.answer_no') %>
-                  </label>
-                </div>
-              </fieldset>
-            <% end %>
-          </div>
+              <div class="form__group-item">
+                <label>
+                  <%= f.radio_button :consider_available_providers_question, 0, class: 'form__group-input' %>
+                  <%= t('registration.answer_no') %>
+                </label>
+              </div>
+            </fieldset>
+          <% end %>
         </div>
+      </div>
 
-        <button class="button button--primary t-submit-button"><%= t('registration.submit_button') %></button>
-      <% end %>
-    </section>
-  </div>
+      <button class="button button--primary t-submit-button"><%= t('registration.submit_button') %></button>
+    <% end %>
+  </section>
 </div>

--- a/app/views/principals/rejection_form.html.erb
+++ b/app/views/principals/rejection_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification l-pre-qualification--restricted-width' },
+<%= form_for @message, url: contact_path, as: :contact, html: { class: 'form form--collapse l-pre-qualification--restricted-width' },
   builder: Dough::Forms::Builders::Validation do |f| %>
   <%= f.validation_summary %>
   <%= heading_tag(t('rejection.heading'), level: 1) %>

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,16 +1,15 @@
 <% render_breadcrumbs(breadcrumbs_firm_adviser_edit) %>
+<% render_onboarding_message %>
 
-<div class="l-self-service">
-  <h1>
-    <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name) %>
-  </h1>
+<h1>
+  <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name) %>
+</h1>
 
-  <%= form_for @adviser,
-               url: self_service_firm_adviser_path(@firm, @adviser),
-               builder: Dough::Forms::Builders::Validation,
-               html: { class: 'form' } do |f| %>
+<%= form_for @adviser,
+             url: self_service_firm_adviser_path(@firm, @adviser),
+             builder: Dough::Forms::Builders::Validation,
+             html: { class: 'form' } do |f| %>
 
-    <%= render partial: 'self_service/advisers/form', locals: {f: f} %>
+  <%= render partial: 'self_service/advisers/form', locals: {f: f} %>
 
-  <% end %>
-</div>
+<% end %>

--- a/app/views/self_service/advisers/index.html.erb
+++ b/app/views/self_service/advisers/index.html.erb
@@ -1,25 +1,24 @@
 <% render_breadcrumbs(breadcrumbs_firm_advisers) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <div class="l-heading-with-button">
-    <h1 class="t-firm-name">
-      <%= t('self_service.advisers_index.title', firm_name: @firm.registered_name) %>
-    </h1>
-    <%= add_adviser_button(firm: @firm) %>
-  </div>
 
-  <% if @firm.advisers.present? %>
-    <div data-dough-component="MultiTableFilter">
-      <%= filter_field :trading_names, locale_prefix: 'self_service.advisers_index.adviser_names_filter' %>
-      <%= render 'self_service/advisers/advisers_table', advisers: @firm.advisers %>
-    </div>
-  <% else %>
-    <p class="t-no-advisers-message">
-      <%= t('self_service.advisers_index.no_advisers_message') %>
-      <%= link_to(t('self_service.advisers_index.add_adviser_link', firm_name: @firm.registered_name),
-                  new_self_service_firm_adviser_path(@firm),
-                  class: 't-add-adviser-link')  %>
-    </p>
-  <% end %>
+<div class="l-heading-with-button">
+  <h1 class="t-firm-name">
+    <%= t('self_service.advisers_index.title', firm_name: @firm.registered_name) %>
+  </h1>
+  <%= add_adviser_button(firm: @firm) %>
 </div>
+
+<% if @firm.advisers.present? %>
+  <div data-dough-component="MultiTableFilter">
+    <%= filter_field :trading_names, locale_prefix: 'self_service.advisers_index.adviser_names_filter' %>
+    <%= render 'self_service/advisers/advisers_table', advisers: @firm.advisers %>
+  </div>
+<% else %>
+  <p class="t-no-advisers-message">
+    <%= t('self_service.advisers_index.no_advisers_message') %>
+    <%= link_to(t('self_service.advisers_index.add_adviser_link', firm_name: @firm.registered_name),
+                new_self_service_firm_adviser_path(@firm),
+                class: 't-add-adviser-link')  %>
+  </p>
+<% end %>

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -1,19 +1,17 @@
 <% render_breadcrumbs(breadcrumbs_firm_adviser_new) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <h1>
-    <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>
-  </h1>
+<h1>
+  <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>
+</h1>
 
-  <p><%= t('self_service.adviser_new.description') %></p>
+<p><%= t('self_service.adviser_new.description') %></p>
 
-  <%= form_for @adviser,
-               url: self_service_firm_advisers_path(@firm),
-               builder: Dough::Forms::Builders::Validation,
-               html: { class: 'form' } do |f| %>
+<%= form_for @adviser,
+             url: self_service_firm_advisers_path(@firm),
+             builder: Dough::Forms::Builders::Validation,
+             html: { class: 'form' } do |f| %>
 
-    <%= render partial: 'self_service/advisers/form', locals: {f: f} %>
+  <%= render partial: 'self_service/advisers/form', locals: {f: f} %>
 
-  <% end %>
-</div>
+<% end %>

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -1,19 +1,17 @@
 <% render_breadcrumbs(breadcrumbs_firm_edit) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <div class="l-heading-with-inline-links">
-    <h1 class="t-firm-name">
-      <%= t('self_service.firm_edit.title', firm_name: @firm.registered_name) %>
-    </h1>
-    <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
-  </div>
-
-  <%= form_for @firm,
-               url: self_service_firm_path(@firm),
-               builder: Dough::Forms::Builders::Validation do |f| %>
-
-    <%= render partial: 'self_service/firms/form', locals: {f: f} %>
-
-  <% end %>
+<div class="l-heading-with-inline-links">
+  <h1 class="t-firm-name">
+    <%= t('self_service.firm_edit.title', firm_name: @firm.registered_name) %>
+  </h1>
+  <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
 </div>
+
+<%= form_for @firm,
+             url: self_service_firm_path(@firm),
+             builder: Dough::Forms::Builders::Validation do |f| %>
+
+  <%= render partial: 'self_service/firms/form', locals: {f: f} %>
+
+<% end %>

--- a/app/views/self_service/firms/index.html.erb
+++ b/app/views/self_service/firms/index.html.erb
@@ -1,38 +1,36 @@
 <% render_breadcrumbs(breadcrumbs_root) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <h1 class="t-page-title">
-    <%= t('self_service.firms_index.title', count: @presenter.total_firms) %>
-  </h1>
+<h1 class="t-page-title">
+  <%= t('self_service.firms_index.title', count: @presenter.total_firms) %>
+</h1>
 
-  <% if @presenter.firm_has_trading_names? %>
-    <h2 class="t-parent-firm-heading"><%= t('self_service.firms_index.firm_heading') %></h2>
-  <% end %>
+<% if @presenter.firm_has_trading_names? %>
+  <h2 class="t-parent-firm-heading"><%= t('self_service.firms_index.firm_heading') %></h2>
+<% end %>
 
-  <%= render 'table_parent_firm' %>
+<%= render 'table_parent_firm' %>
 
-  <% if @presenter.firm_has_trading_names? %>
-    <div id="firm-list" class="t-trading-names-block" data-dough-component="MultiTableFilter">
-      <h2><%= t('self_service.firms_index.trading_names_heading') %></h2>
+<% if @presenter.firm_has_trading_names? %>
+  <div id="firm-list" class="t-trading-names-block" data-dough-component="MultiTableFilter">
+    <h2><%= t('self_service.firms_index.trading_names_heading') %></h2>
 
-      <% if @presenter.no_trading_names_have_been_added? %>
-        <p class="t-add-trading-names-prompt">
-          <%= t('self_service.firms_index.add_trading_names_prompt') %>
-        </p>
-      <% else %>
-        <%= filter_field :trading_names, locale_prefix: 'self_service.firms_index.trading_names_filter' %>
-        <%= render 'table_trading_names' %>
-      <% end %>
-    </div>
-  <% end %>
+    <% if @presenter.no_trading_names_have_been_added? %>
+      <p class="t-add-trading-names-prompt">
+        <%= t('self_service.firms_index.add_trading_names_prompt') %>
+      </p>
+    <% else %>
+      <%= filter_field :trading_names, locale_prefix: 'self_service.firms_index.trading_names_filter' %>
+      <%= render 'table_trading_names' %>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if @presenter.trading_names_are_available_to_add? %>
-    <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="MultiTableFilter">
-      <h2><%= t('self_service.firms_index.available_trading_names_heading') %></h2>
+<% if @presenter.trading_names_are_available_to_add? %>
+  <div id="trading-name-list" class="t-available-trading-names-block" data-dough-component="MultiTableFilter">
+    <h2><%= t('self_service.firms_index.available_trading_names_heading') %></h2>
 
-      <%= filter_field :trading_names, locale_prefix: 'self_service.firms_index.available_trading_names_filter' %>
-      <%= render 'table_available_trading_names' %>
-    </div>
-  <% end %>
-</div>
+    <%= filter_field :trading_names, locale_prefix: 'self_service.firms_index.available_trading_names_filter' %>
+    <%= render 'table_available_trading_names' %>
+  </div>
+<% end %>

--- a/app/views/self_service/offices/edit.html.erb
+++ b/app/views/self_service/offices/edit.html.erb
@@ -1,17 +1,15 @@
 <%= render_breadcrumbs(breadcrumbs_firm_office_edit) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <h1>
-    <%= t('self_service.office_edit.title', postcode: @office.address_postcode) %>
-  </h1>
+<h1>
+  <%= t('self_service.office_edit.title', postcode: @office.address_postcode) %>
+</h1>
 
-  <%= form_for @office,
-               url: self_service_firm_office_path(@firm, @office),
-               builder: Dough::Forms::Builders::Validation,
-               html: { class: 'form' } do |f| %>
+<%= form_for @office,
+             url: self_service_firm_office_path(@firm, @office),
+             builder: Dough::Forms::Builders::Validation,
+             html: { class: 'form' } do |f| %>
 
-    <%= render partial: 'self_service/offices/form', locals: {f: f} %>
+  <%= render partial: 'self_service/offices/form', locals: {f: f} %>
 
-  <% end %>
-</div>
+<% end %>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,23 +1,22 @@
 <% render_breadcrumbs(breadcrumbs_firm_offices) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <div class="l-heading-with-button">
-    <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
-    <%= add_office_button(firm: @firm) %>
-  </div>
 
-  <% if @firm.offices.present? %>
-    <div data-dough-component="MultiTableFilter">
-      <%= filter_field :offices, locale_prefix: 'self_service.offices_index.office_filter' %>
-      <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
-    </div>
-  <% else %>
-    <p class="t-no-offices-message">
-      <%= t('self_service.offices_index.no_offices_message') %>
-      <%= link_to(t('self_service.offices_index.add_office_link', firm_name: @firm.registered_name),
-                  new_self_service_firm_office_path(@firm),
-                  class: 't-add-office-link')  %>
-    </p>
-  <% end %>
+<div class="l-heading-with-button">
+  <h1 class="t-page-title"><%= t('self_service.offices_index.title', firm_name: @firm.registered_name) %></h1>
+  <%= add_office_button(firm: @firm) %>
 </div>
+
+<% if @firm.offices.present? %>
+  <div data-dough-component="MultiTableFilter">
+    <%= filter_field :offices, locale_prefix: 'self_service.offices_index.office_filter' %>
+    <%= render 'self_service/offices/offices_table', offices: @firm.offices %>
+  </div>
+<% else %>
+  <p class="t-no-offices-message">
+    <%= t('self_service.offices_index.no_offices_message') %>
+    <%= link_to(t('self_service.offices_index.add_office_link', firm_name: @firm.registered_name),
+                new_self_service_firm_office_path(@firm),
+                class: 't-add-office-link')  %>
+  </p>
+<% end %>

--- a/app/views/self_service/offices/new.html.erb
+++ b/app/views/self_service/offices/new.html.erb
@@ -1,18 +1,16 @@
 <%= render_breadcrumbs(breadcrumbs_firm_office_new) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
+<h1>
+  <%= t('self_service.office_new.title', firm_name: @firm.registered_name) %>
+</h1>
 
-  <h1>
-    <%= t('self_service.office_new.title', firm_name: @firm.registered_name) %>
-  </h1>
+<%= form_for @office,
+             url: self_service_firm_offices_path(@firm),
+             builder: Dough::Forms::Builders::Validation,
+             html: { class: 'form' } do |f| %>
 
-  <%= form_for @office,
-               url: self_service_firm_offices_path(@firm),
-               builder: Dough::Forms::Builders::Validation,
-               html: { class: 'form' } do |f| %>
+  <%= render partial: 'self_service/offices/form', locals: {f: f} %>
 
-    <%= render partial: 'self_service/offices/form', locals: {f: f} %>
+<% end %>
 
-  <% end %>
-</div>

--- a/app/views/self_service/principals/edit.html.erb
+++ b/app/views/self_service/principals/edit.html.erb
@@ -1,14 +1,12 @@
 <% render_breadcrumbs(breadcrumbs_principal_edit) %>
 
-<div class="l-self-service">
-  <h1>
-    <%= t('self_service.principal_edit.title', firm_name: @principal.firm.registered_name) %>
-  </h1>
+<h1>
+  <%= t('self_service.principal_edit.title', firm_name: @principal.firm.registered_name) %>
+</h1>
 
-  <%= form_for @principal,
-              url: self_service_principal_path(@principal),
-              html: { class: 'form' },
-              builder: Dough::Forms::Builders::Validation do |f| %>
-    <%= render 'self_service/principals/form', {f: f} %>
-  <% end %>
-</div>
+<%= form_for @principal,
+            url: self_service_principal_path(@principal),
+            html: { class: 'form' },
+            builder: Dough::Forms::Builders::Validation do |f| %>
+  <%= render 'self_service/principals/form', {f: f} %>
+<% end %>

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -1,19 +1,17 @@
 <% render_breadcrumbs(breadcrumbs_firm_edit) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
-  <div class="l-heading-with-inline-links">
-    <h1 class="t-firm-name">
-      <%= t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) %>
-    </h1>
-    <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
-  </div>
-
-  <%= form_for @firm,
-               url: self_service_trading_name_path(@firm),
-               builder: Dough::Forms::Builders::Validation do |f| %>
-
-    <%= render partial: 'self_service/firms/form', locals: {f: f} %>
-
-  <% end %>
+<div class="l-heading-with-inline-links">
+  <h1 class="t-firm-name">
+    <%= t('self_service.trading_name_edit.title', firm_name: @firm.registered_name) %>
+  </h1>
+  <%= render partial: 'self_service/firms/questionnaire/links', locals: {firm: @firm} %>
 </div>
+
+<%= form_for @firm,
+             url: self_service_trading_name_path(@firm),
+             builder: Dough::Forms::Builders::Validation do |f| %>
+
+  <%= render partial: 'self_service/firms/form', locals: {f: f} %>
+
+<% end %>

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -1,19 +1,16 @@
 <% render_breadcrumbs(breadcrumbs_trading_name_new) %>
 <% render_onboarding_message %>
 
-<div class="l-self-service">
+<h1 class="t-firm-name">
+  <%= t('self_service.trading_name_new.title', firm_name: @firm.registered_name) %>
+</h1>
 
-  <h1 class="t-firm-name">
-    <%= t('self_service.trading_name_new.title', firm_name: @firm.registered_name) %>
-  </h1>
+<%= form_for @firm,
+             url: create_or_update_self_service_trading_names_path(@firm),
+             builder: Dough::Forms::Builders::Validation,
+             html: { class: 'form' } do |f| %>
 
-  <%= form_for @firm,
-               url: create_or_update_self_service_trading_names_path(@firm),
-               builder: Dough::Forms::Builders::Validation,
-               html: { class: 'form' } do |f| %>
+  <%= hidden_field_tag 'lookup_id', params[:lookup_id] %>
+  <%= render partial: 'self_service/firms/form', locals: {f: f} %>
 
-    <%= hidden_field_tag 'lookup_id', params[:lookup_id] %>
-    <%= render partial: 'self_service/firms/form', locals: {f: f} %>
-
-  <% end %>
-</div>
+<% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to eq '<p>hello</p>' }
     end
   end
+
+  describe '#layout_class' do
+    it 'provides l-content for a non-devise controller' do
+      allow(controller).to receive(:devise_controller?).and_return(false)
+      expect(helper.layout_class).to eq('l-content')
+    end
+
+    it 'provides l-registration for a devise controller' do
+      allow(controller).to receive(:devise_controller?).and_return(true)
+      expect(helper.layout_class).to eq('l-registration')
+    end
+  end
 end


### PR DESCRIPTION
This PR is to allow easier lifting of the new flash message style from RAD into Dough by removing the wrapping l-flashes div within application.html.erb.

There should be no noticeable change to the user.

This involved removing the 
* l-pre-qualification class and wrapping div from the prequalification page
* l-registration class and wrapping div from the devise views
* l-self-service class and wrapping div from the self service views

There is also a helper which switches the top level class between l-content and l-registration.

At a glance, some of the diffs look a larger than they are. In the vast majority of html.erb files we've just removed a wrapping div and unindented.
