### PR TITLE
[DEV APPROVED] Change verification email link to go to /users/sign_in

### DIFF
--- a/app/views/identification/contact.text.erb
+++ b/app/views/identification/contact.text.erb
@@ -4,4 +4,4 @@
 
 <%= t('.verify_email_link') %>
 
-<%= self_service_root_url %>
+<%= new_user_session_url %>

--- a/spec/features/principal_provides_identifying_information_spec.rb
+++ b/spec/features/principal_provides_identifying_information_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
 
   def and_i_am_sent_a_verification_email
     expect(ActionMailer::Base.deliveries).to_not be_empty
-    expect(ActionMailer::Base.deliveries.last.body).to include self_service_root_path
+    expect(ActionMailer::Base.deliveries.last.body).to include new_user_session_path
   end
 
   def when_i_visit_the_email_link

--- a/spec/mailers/identification_spec.rb
+++ b/spec/mailers/identification_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Identification, '#contact' do
 
   describe 'body' do
     it 'contains self service url' do
-      expect(subject.body.decoded).to include(self_service_root_path)
+      expect(subject.body.decoded).to include(new_user_session_path)
     end
   end
 end


### PR DESCRIPTION
By taking users to `/users/sign_in` instead of `/self_service` it prevents showing an access-denied style form error, when in fact there is no error we just want the user to log in.

Old verification email link took the user to:

![screen shot 2015-09-28 at 11 26 03](https://cloud.githubusercontent.com/assets/306583/10133254/c0096bb4-65d3-11e5-81a7-252be681fc4f.png)

New link from email:

![screen shot 2015-09-28 at 11 21 33](https://cloud.githubusercontent.com/assets/306583/10133230/9d5e0e3a-65d3-11e5-9af7-148e66b886e7.png)

Goes to:

![screen shot 2015-09-28 at 11 25 04](https://cloud.githubusercontent.com/assets/306583/10133229/9bc44530-65d3-11e5-8349-ed27bfd45f1e.png)