### PR TITLE
[DEV APPROVED] Firm email and phone have been removed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.81'
+gem 'mas-rad_core', '0.0.82'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.81)
+    mas-rad_core (0.0.82)
       active_model_serializers
       geocoder
       httpclient
@@ -324,7 +324,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.81)
+  mas-rad_core (= 0.0.82)
   oga
   pg
   poltergeist

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -16,13 +16,7 @@
       <strong>Registered Name:</strong> <%= @firm.registered_name %>
     </p>
     <p>
-      <strong>Email Address:</strong> <%= mail_to @firm.email_address %>
-    </p>
-    <p>
       <strong>Website Address:</strong> <%= link_to @firm.website_address %>
-    </p>
-    <p>
-      <strong>Phone Number:</strong> <%= @firm.telephone_number %>
     </p>
     <p>
       <strong>Address:</strong>
@@ -90,7 +84,7 @@
   <p>No advisers registered.</p>
 <% end %>
 
-<% if @firm.email_address.present? %>
+<% if @firm.registered? %>
   <h2>Questionnaire Responses</h2>
   <ul>
     <% [

--- a/app/views/self_service/firms/questionnaire/_firm_details.erb
+++ b/app/views/self_service/firms/questionnaire/_firm_details.erb
@@ -1,18 +1,4 @@
 <fieldset class="form__group l-half-width">
-  <p><%= t('self_service.firm_form.email_address_description') %></p>
-  <%= f.form_row :email_address do %>
-    <%= f.errors_for :email_address %>
-    <%= f.label :email_address, t('self_service.firm_form.email_address_label'), class: 'form__label-heading' %>
-    <%= f.text_field :email_address, class: 't-email-address' %>
-  <% end %>
-
-  <p><%= t('self_service.firm_form.telephone_number_description') %></p>
-  <%= f.form_row :telephone_number do %>
-    <%= f.errors_for :telephone_number %>
-    <%= f.label :telephone_number, t('self_service.firm_form.telephone_number_label'), class: 'form__label-heading' %>
-    <%= f.text_field :telephone_number, class: 't-telephone-number' %>
-  <% end %>
-
   <p><%= t('self_service.firm_form.website_address_description') %></p>
   <%= f.form_row :website_address do %>
     <%= f.errors_for :website_address %>

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -4,12 +4,6 @@ en:
       initial_advice_fee_structures_heading: Initial advice
       initial_advice_fee_structures_description: Confirm the way(s) your firm charges for its services. Check all that apply.
 
-      email_address_description: This is the email account where you wish to receive messages from customers.
-      email_address_label: Firm email address *
-
-      telephone_number_description: Please provide a contact number for customers who wish to call you.
-      telephone_number_label: Firm telephone number *
-
       website_address_description: Please provide a website address for customers who wish to visit your website.
       website_address_label: Firm website address *
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150825090822) do
+ActiveRecord::Schema.define(version: 20150930140851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,8 +80,6 @@ ActiveRecord::Schema.define(version: 20150825090822) do
   create_table "firms", force: :cascade do |t|
     t.integer  "fca_number",                                               null: false
     t.string   "registered_name",                                          null: false
-    t.string   "email_address"
-    t.string   "telephone_number"
     t.datetime "created_at",                                               null: false
     t.datetime "updated_at",                                               null: false
     t.boolean  "free_initial_meeting"

--- a/lib/tasks/existing_firms_sign_up_task.rb
+++ b/lib/tasks/existing_firms_sign_up_task.rb
@@ -32,7 +32,7 @@ module Tasks
         principal.full_name,
         principal.email_address,
         inviter.invitation_url(user),
-        (firm.email_address.present? ? 'registered' : 'not registered'),
+        (firm.registered? ? 'registered' : 'not registered'),
         (firm.trading_names.registered.any? ? 'has trading names' : 'no trading names')
       ]
     end

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe SelfService::FirmsController, type: :controller do
     context 'when some trading names are registered' do
       before do
         trading_name = firm.trading_names.first
-        trading_name.email_address = nil
-        trading_name.save(validate: false)
+        trading_name.update_attribute(Firm::REGISTERED_MARKER_FIELD, nil)
       end
 
       it 'assigns only registered trading names' do
@@ -97,12 +96,12 @@ RSpec.describe SelfService::FirmsController, type: :controller do
   end
 
   describe 'PATCH #update' do
-    let(:firm_params) { extract_firm_params(firm, email_address: 'valid@example.com') }
+    let(:firm_params) { extract_firm_params(firm, website_address: 'http://www.valid.com') }
     context 'when passed valid details' do
       before { patch :update, id: 'ignored', firm: firm_params }
 
       it 'updates the firm' do
-        expect(firm.reload.email_address).to eq firm_params[:email_address]
+        expect(firm.reload.website_address).to eq firm_params[:website_address]
       end
 
       it 'redirects to the edit page' do
@@ -139,16 +138,16 @@ RSpec.describe SelfService::FirmsController, type: :controller do
       before { patch :update, id: other_firm.id, firm: firm_params }
 
       it 'fails to update the firm' do
-        expect(other_firm.email_address).not_to eq('valid@example.com')
+        expect(other_firm.website_address).not_to eq('http://www.valid.com')
       end
     end
 
     context 'when passed invalid details' do
-      let(:firm_params) { extract_firm_params(firm, email_address: 'not_valid') }
+      let(:firm_params) { extract_firm_params(firm, website_address: 'not_valid') }
       before { patch :update, id: 'ignored', firm: firm_params }
 
       it 'does not update the firm' do
-        expect(firm.reload.email_address).not_to eq firm_params[:email_address]
+        expect(firm.reload.website_address).not_to eq firm_params[:website_address]
       end
 
       it 'renders the edit page' do

--- a/spec/controllers/selfservice/firms_controller_spec.rb
+++ b/spec/controllers/selfservice/firms_controller_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe SelfService::FirmsController, type: :controller do
     context 'when some trading names are registered' do
       before do
         trading_name = firm.trading_names.first
-        trading_name.update_attribute(Firm::REGISTERED_MARKER_FIELD, nil)
+        trading_name.__set_registered(false)
+        trading_name.save(validate: false)
       end
 
       it 'assigns only registered trading names' do

--- a/spec/controllers/selfservice/trading_names_controller_spec.rb
+++ b/spec/controllers/selfservice/trading_names_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SelfService::TradingNamesController, type: :controller do
 
       it 'creates the firm' do
         expect(assigns(:firm).persisted?).to be_truthy
-        expect(assigns(:firm).email_address).to eq firm_params[:email_address]
+        expect(assigns(:firm).website_address).to eq firm_params[:website_address]
       end
 
       it 'assigns the firm to the principal’s firm' do
@@ -76,7 +76,7 @@ RSpec.describe SelfService::TradingNamesController, type: :controller do
     end
 
     context 'when passed invalid details' do
-      let(:firm_params) { build_firm_params(email_address: 'not_valid') }
+      let(:firm_params) { build_firm_params(website_address: 'not_valid') }
       before { post :create, firm: firm_params, lookup_id: lookup_subsidiary.id }
 
       it 'does not create the firm' do
@@ -115,12 +115,12 @@ RSpec.describe SelfService::TradingNamesController, type: :controller do
 
   describe 'PATCH #update' do
     let!(:trading_name) { create :firm, parent: firm }
-    let(:trading_name_params) { build_firm_params(firm: trading_name, email_address: 'valid@example.com') }
+    let(:trading_name_params) { build_firm_params(firm: trading_name, website_address: 'http://www.valid.com') }
     context 'when passed valid details' do
       before { patch :update, id: trading_name.id, firm: trading_name_params }
 
       it 'updates the trading_name' do
-        expect(trading_name.reload.email_address).to eq trading_name_params[:email_address]
+        expect(trading_name.reload.website_address).to eq trading_name_params[:website_address]
       end
 
       it 'redirects to the edit page' do
@@ -131,7 +131,7 @@ RSpec.describe SelfService::TradingNamesController, type: :controller do
 
     context 'when trying to access another users trading_name' do
       let!(:other_principal) { create :principal }
-      let(:trading_name_params) { build_firm_params(firm: trading_name, email_address: 'valid@example.com') }
+      let(:trading_name_params) { build_firm_params(firm: trading_name, website_address: 'http://www.valid.com') }
 
       it 'fails to respond successfully' do
         other_trading_name = create :firm, parent: other_principal.firm
@@ -140,11 +140,11 @@ RSpec.describe SelfService::TradingNamesController, type: :controller do
     end
 
     context 'when passed invalid details' do
-      let(:firm_params) { build_firm_params(firm: trading_name, email_address: 'not_valid') }
+      let(:firm_params) { build_firm_params(firm: trading_name, website_address: 'not_valid') }
       before { patch :update, id: trading_name.id, firm: firm_params }
 
       it 'does not update the firm' do
-        expect(trading_name.reload.email_address).not_to eq firm_params[:email_address]
+        expect(trading_name.reload.website_address).not_to eq firm_params[:website_address]
       end
 
       it 'renders the edit page' do

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'The self service firm edit page' do
   def and_i_have_a_firm
     firm_attrs = FactoryGirl.attributes_for(:firm, fca_number: @principal.fca_number)
     @principal.firm.update_attributes(firm_attrs)
-    @original_firm_email = @principal.firm.email_address
+    @original_firm_website = @principal.firm.website_address
   end
 
   def and_i_am_logged_in
@@ -76,11 +76,10 @@ RSpec.feature 'The self service firm edit page' do
     complete_part_1
     complete_part_2
     complete_part_3
-    complete_part_4
   end
 
   def when_i_invalidate_the_information
-    firm_edit_page.email_address.set 'clearly_not_a_valid_email!'
+    firm_edit_page.website_address.set 'clearly_not_a_valid_web_address!'
   end
 
   def and_i_click_save
@@ -99,36 +98,20 @@ RSpec.feature 'The self service firm edit page' do
     validate_part_1
     validate_part_2
     validate_part_3
-    validate_part_4
 
     @principal.reload
-    expect(@principal.firm.email_address).to eq firm_changes.email_address
+    expect(@principal.firm.minimum_fixed_fee).to eq firm_changes.minimum_fixed_fee
   end
 
   def and_the_information_is_not_changed
-    expect(firm_edit_page.email_address.value).to eq 'clearly_not_a_valid_email!'
+    expect(firm_edit_page.website_address.value).to eq 'clearly_not_a_valid_web_address!'
     @principal.reload
-    expect(@principal.firm.email_address).to eq @original_firm_email
+    expect(@principal.firm.website_address).to eq @original_firm_website
   end
 
   def complete_part_1
     firm_edit_page.tap do |p|
-      p.email_address.set firm_changes.email_address
       p.website_address.set firm_changes.website_address
-      p.telephone_number.set firm_changes.telephone_number
-    end
-  end
-
-  def validate_part_1
-    firm_edit_page.tap do |p|
-      expect(p.email_address.value).to eq firm_changes.email_address
-      expect(p.website_address.value).to eq firm_changes.website_address
-      expect(p.telephone_number.value).to eq firm_changes.telephone_number
-    end
-  end
-
-  def complete_part_2
-    firm_edit_page.tap do |p|
       p.retirement_income_products_flag.set firm_changes.retirement_income_products_flag
       p.pension_transfer_flag.set firm_changes.pension_transfer_flag
       p.long_term_care_flag.set firm_changes.long_term_care_flag
@@ -139,8 +122,9 @@ RSpec.feature 'The self service firm edit page' do
     end
   end
 
-  def validate_part_2
+  def validate_part_1
     firm_edit_page.tap do |p|
+      expect(p.website_address.value).to eq firm_changes.website_address
       expect(p.retirement_income_products_flag?).to eq firm_changes.retirement_income_products_flag
       expect(p.pension_transfer_flag?).to eq firm_changes.pension_transfer_flag
       expect(p.long_term_care_flag?).to eq firm_changes.long_term_care_flag
@@ -151,7 +135,7 @@ RSpec.feature 'The self service firm edit page' do
     end
   end
 
-  def complete_part_3
+  def complete_part_2
     firm_edit_page.tap do |p|
       set_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods,
                                label: :friendly_name)
@@ -165,7 +149,7 @@ RSpec.feature 'The self service firm edit page' do
     end
   end
 
-  def validate_part_3
+  def validate_part_2
     firm_edit_page.tap do |p|
       expect_checkbox_group_state(p, InPersonAdviceMethod.all, firm_changes.in_person_advice_methods,
                                   label: :friendly_name)
@@ -179,7 +163,7 @@ RSpec.feature 'The self service firm edit page' do
     end
   end
 
-  def complete_part_4
+  def complete_part_3
     firm_edit_page.tap do |p|
       p.ethical_investing_flag.set firm_changes.ethical_investing_flag
       p.sharia_investing_flag.set firm_changes.sharia_investing_flag
@@ -188,7 +172,7 @@ RSpec.feature 'The self service firm edit page' do
     end
   end
 
-  def validate_part_4
+  def validate_part_3
     firm_edit_page.tap do |p|
       expect(p.ethical_investing_flag?).to eq(firm_changes.ethical_investing_flag)
       expect(p.sharia_investing_flag?).to eq(firm_changes.sharia_investing_flag)

--- a/spec/features/self_service/trading_names_edit_spec.rb
+++ b/spec/features/self_service/trading_names_edit_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature 'The self service trading name edit page' do
 
   let(:firms_index_page) { SelfService::FirmsIndexPage.new }
   let(:trading_name_edit_page) { SelfService::TradingNameEditPage.new }
-  let(:telephone_number) { '07777999999' }
+  let(:website_address) { 'http://www.blahblah.com' }
 
   scenario 'The principal can visit the edit page for the first trading name' do
     given_i_am_a_fully_registered_principal_user
@@ -39,7 +39,7 @@ RSpec.feature 'The self service trading name edit page' do
   def and_i_have_a_firm_with_trading_names
     firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: @principal.fca_number)
     @principal.firm.update_attributes(firm_attrs)
-    @original_trading_name_email = trading_names(@principal).first.email_address
+    @original_website_address = trading_names(@principal).first.website_address
   end
 
   def and_i_am_logged_in
@@ -62,11 +62,11 @@ RSpec.feature 'The self service trading name edit page' do
   end
 
   def when_i_change_the_information
-    trading_name_edit_page.telephone_number.set(telephone_number)
+    trading_name_edit_page.website_address.set(website_address)
   end
 
   def when_i_invalidate_the_information
-    trading_name_edit_page.email_address.set 'clearly_not_a_valid_email!'
+    trading_name_edit_page.website_address.set 'clearly_not_a_valid_web_address!'
   end
 
   def and_i_click_save
@@ -82,16 +82,16 @@ RSpec.feature 'The self service trading name edit page' do
   end
 
   def and_the_information_is_changed
-    expect(trading_name_edit_page.telephone_number.value).to eq telephone_number
+    expect(trading_name_edit_page.website_address.value).to eq website_address
 
     @principal.reload
-    expect(trading_names(@principal).first.telephone_number).to eq telephone_number
+    expect(trading_names(@principal).first.website_address).to eq website_address
   end
 
   def and_the_information_is_not_changed
-    expect(trading_name_edit_page.email_address.value).to eq 'clearly_not_a_valid_email!'
+    expect(trading_name_edit_page.website_address.value).to eq 'clearly_not_a_valid_web_address!'
     @principal.reload
-    expect(trading_names(@principal).first.email_address).to eq @original_trading_name_email
+    expect(trading_names(@principal).first.website_address).to eq @original_website_address
   end
 
   private

--- a/spec/forms/admin/move_advisers_form_spec.rb
+++ b/spec/forms/admin/move_advisers_form_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Admin::MoveAdvisersForm, type: :model do
 
         context 'destination_firm_fca_number returns only invalid/unregistered firm records' do
           let!(:invalid_firm) do
-            f = build(:firm, email_address: nil)
+            f = build(:invalid_firm)
             f.save!(validate: false)
             f
           end
@@ -170,7 +170,7 @@ RSpec.describe Admin::MoveAdvisersForm, type: :model do
     let!(:sandras_firm) { create(:firm, registered_name: 'Sandras Firm', fca_number: shared_fca_number) }
     let!(:unrelated_firm) { create(:firm, registered_name: 'Unrelated Firm', fca_number: 999999) }
     let!(:no_registered_firm) do
-      f = build(:firm, email_address: nil, fca_number: shared_fca_number)
+      f = build(:invalid_firm, fca_number: shared_fca_number)
       f.save!(validate: false)
       f
     end

--- a/spec/helpers/self_service/self_service_helper_spec.rb
+++ b/spec/helpers/self_service/self_service_helper_spec.rb
@@ -45,6 +45,11 @@ module SelfService
     describe '#first_registered_firm_for' do
       let(:principal) { create(:principal, fca_number: '123456') }
 
+      def make_firm_look_registered(firm)
+        firm.update_attribute(Firm::REGISTERED_MARKER_FIELD,
+                              Firm::REGISTERED_MARKER_FIELD_VALID_VALUES.first)
+      end
+
       context 'when the principal has no registered firms' do
         it 'is nil' do
           expect(helper.first_registered_firm_for(principal)).to be_nil
@@ -53,7 +58,7 @@ module SelfService
 
       context 'when the principal has registered firm and has no trading names' do
         it 'provides the firm' do
-          principal.firm.update_attribute(:email_address, 'test@example.com')
+          make_firm_look_registered(principal.firm)
           expect(helper.first_registered_firm_for(principal)).to eq(principal.firm)
         end
       end
@@ -68,7 +73,7 @@ module SelfService
 
       context 'principal has registered firm and registered trading name' do
         it 'returns the firm' do
-          principal.firm.update_attribute(:email_address, 'test@example.com')
+          make_firm_look_registered(principal.firm)
           create(:trading_name, fca_number: principal.fca_number)
 
           expect(helper.first_registered_firm_for(principal)).to eq(principal.firm)

--- a/spec/helpers/self_service/self_service_helper_spec.rb
+++ b/spec/helpers/self_service/self_service_helper_spec.rb
@@ -46,8 +46,8 @@ module SelfService
       let(:principal) { create(:principal, fca_number: '123456') }
 
       def make_firm_look_registered(firm)
-        firm.update_attribute(Firm::REGISTERED_MARKER_FIELD,
-                              Firm::REGISTERED_MARKER_FIELD_VALID_VALUES.first)
+        firm.__set_registered(true)
+        firm.save(validate: false)
       end
 
       context 'when the principal has no registered firms' do

--- a/spec/lib/tasks/existing_firms_sign_up_task_spec.rb
+++ b/spec/lib/tasks/existing_firms_sign_up_task_spec.rb
@@ -90,7 +90,8 @@ RSpec.describe Tasks::ExistingFirmsSignUpTask do
 
     context 'when principal has not verified account via email link' do
       before do
-        @firm.update_attribute Firm::REGISTERED_MARKER_FIELD, nil
+        @firm.__set_registered(false)
+        @firm.save(validate: false)
         described_class.notify(stub_inviter, output)
       end
 

--- a/spec/lib/tasks/existing_firms_sign_up_task_spec.rb
+++ b/spec/lib/tasks/existing_firms_sign_up_task_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Tasks::ExistingFirmsSignUpTask do
 
     context 'when principal has not verified account via email link' do
       before do
-        @firm.update_attribute :email_address, nil
+        @firm.update_attribute Firm::REGISTERED_MARKER_FIELD, nil
         described_class.notify(stub_inviter, output)
       end
 

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -9,13 +9,7 @@ module SelfService
     element :firm_name, '.t-firm-name'
     element :firm_fca_number, '.t-firm-fca-number'
 
-    element :email_address, '.t-email-address'
     element :website_address, '.t-website-address'
-    element :telephone_number, '.t-telephone-number'
-    element :address_line_one, '.t-address-line-one'
-    element :address_town, '.t-address-town'
-    element :address_county, '.t-address-county'
-    element :address_postcode, '.t-address-postcode'
 
     elements :in_person_advice_methods, '.t-questionnaire__in-person-advice-method-id'
     elements :other_advice_methods, '.t-questionnaire__other-advice-method-id'


### PR DESCRIPTION
Due to the changes introduced by https://github.com/moneyadviceservice/mas-rad_core/pull/106 and https://github.com/moneyadviceservice/mas-rad_core/pull/107, we now have some work to do to:

1. Remove all reference to `Firm#email_address` and `Firm#telephone_number`
2. Stop using `Firm#email_address` as a way to mark a firm as registered.