### PR TITLE
Create a rake report to audit the index against the database

### DIFF
--- a/lib/tasks/audit_index.rb
+++ b/lib/tasks/audit_index.rb
@@ -1,0 +1,132 @@
+require 'csv'
+require 'pp'
+require 'io/console'
+
+module Tasks
+  class AuditIndex
+    def all_es_firm_ids
+      @all_es_firm_ids ||= find_all_es_firm_ids
+    end
+
+    def all_pg_firm_ids
+      @all_pg_firm_ids ||= find_all_pg_firm_ids
+    end
+
+    def in_es_not_pg
+      @in_es_not_pg ||= all_es_firm_ids - all_pg_firm_ids
+    end
+
+    def in_pg_not_es
+      @in_pg_not_es ||= all_pg_firm_ids - all_es_firm_ids
+    end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def action(o)
+      if o[:publishable?] && o[:geocoded?] && !o[:exists_in_es?]
+        :index
+      elsif o[:publishable?] && !o[:geocoded?]
+        :invalid_firm_address?
+      elsif o[:exists_in_es?] && (!o[:exists_in_db?] || !o[:publishable?])
+        :delete_from_es
+      elsif !o[:exists_in_es?] && !o[:publishable?]
+        :do_nothing
+      else
+        :dunno
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    def analyse_in_es_not_pg
+      @analyse_in_es_not_pg ||= in_es_not_pg.map do |id|
+        exists_in_db = Firm.exists?(id)
+        firm = Firm.find(id) if exists_in_db
+        res = {
+          id: id,
+          exists_in_es?: true,
+          exists_in_db?: exists_in_db,
+          publishable?: firm.try(&:publishable?),
+          geocoded?: firm.try(&:geocoded?),
+          frn: firm.try(&:fca_number),
+          name: firm.try(&:registered_name)
+        }
+
+        res[:action] = action(res)
+
+        res
+      end
+    end
+
+    def analyse_in_pg_not_es
+      @analyse_in_pg_not_es ||= in_pg_not_es.map do |id|
+        firm = Firm.find(id)
+
+        res = {
+          id: id,
+          exists_in_es?: false,
+          exists_in_db?: true,
+          publishable?: firm.publishable?,
+          geocoded?: firm.geocoded?,
+          frn: firm.fca_number,
+          name: firm.registered_name
+        }
+
+        res[:action] = action(res)
+
+        res
+      end
+    end
+
+    def by_action(results)
+      results.group_by { |result| result[:action] }
+    end
+
+    def terminal_col_width
+      IO.console.winsize[1]
+    end
+
+    def analyse(out = $stdout)
+      # Pre-cache so we can see output after SQL logs in Pry
+      analyse_in_es_not_pg
+      analyse_in_pg_not_es
+
+      out.puts 'In ES not PG:'
+      PP.pp(by_action(analyse_in_es_not_pg), out, terminal_col_width)
+
+      out.puts 'In PG not ES:'
+      PP.pp(by_action(analyse_in_pg_not_es), out, terminal_col_width)
+    end
+
+    def to_csv
+      headers = [:id, :frn, :name, :exists_in_es?, :exists_in_db?, :publishable?, :geocoded?, :action]
+      CSV.generate do |csv|
+        csv << headers
+
+        (analyse_in_es_not_pg + analyse_in_pg_not_es).map do |o|
+          csv << headers.map { |key| o[key] }
+        end
+      end
+    end
+
+    def self.analyse
+      new.tap(&:analyse)
+    end
+
+    def self.to_csv
+      new.to_csv
+    end
+
+    private
+
+    def find_all_es_firm_ids
+      response = ElasticSearchClient.new.search('firms/_search?size=10000&fields=')
+      res = JSON.parse(response.body)
+      res['hits']['hits'].map do |hit|
+        hit['_id']
+      end.map(&:to_i).sort.freeze
+    end
+
+    def find_all_pg_firm_ids
+      Firm.registered.geocoded.pluck(:id).sort.freeze
+    end
+  end
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -3,4 +3,14 @@ namespace 'reports' do
   task firms_with_out_of_date_names: :environment do
     puts Tasks::Reports.firms_with_out_of_date_names_as_csv
   end
+
+  desc 'Analyses the differences between the DB and the Index and provides a suggested action to fix'
+  task audit_index: :environment do
+    Tasks::AuditIndex.analyse
+  end
+
+  desc 'Same as audit_index but outputs CSV'
+  task audit_index_csv: :environment do
+    puts Tasks::AuditIndex.to_csv
+  end
 end


### PR DESCRIPTION
We need to reindex the entire contents of our ElasticSearch index. When we did looked at doing this on the demo server we noticed there were 10 more records in the index than in the database. Not hugely surprising, but we need to work out what is happening here.

This rake task and helper class allow us to work out what's going on.

# Example of the Rake output

```
$ heroku run rake reports:audit_index_csv
Running rake reports:audit_index_csv on mas-rad-demo... up, run.2499
id,frn,name,exists_in_es?,exists_in_db?,publishable?,geocoded?,action
2,,,true,false,,,delete_from_es
4,,,true,false,,,delete_from_es
5,,,true,false,,,delete_from_es
7,,,true,false,,,delete_from_es
8,,,true,false,,,delete_from_es
9,,,true,false,,,delete_from_es
12,,,true,false,,,delete_from_es
40,503220,Redacted Firm Name,false,true,false,true,do_nothing
45,439620,Redacted Firm Name,false,true,false,true,do_nothing
62,501806,Redacted Firm Name,false,true,false,true,do_nothing
71,194713,Redacted Firm Name,false,true,false,true,do_nothing
74,607322,Redacted Firm Name,false,true,false,true,do_nothing
76,194713,Redacted Firm Name,false,true,false,true,do_nothing
109,153420,Redacted Firm Name,false,true,false,true,do_nothing

...
```

# Example console output using the helper class

```
irb(main):001:0> ai = Tasks::AuditIndex.new
=> #<Tasks::AuditIndex:0x007fd7bd2778f0>
irb(main):002:0> ai.all_es_firm_ids.count
=> 2494
irb(main):003:0> ai.all_pg_firm_ids.count
=> 2780
irb(main):004:0> ai.in_es_not_pg
=> [2, 4, 5, 7, 8, 9, 12]
```