### PR TITLE
Using full address for office geocoding again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.93'
+gem 'mas-rad_core', '0.0.94'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.93)
+    mas-rad_core (0.0.94)
       active_model_serializers
       geocoder
       httpclient
@@ -331,7 +331,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.93)
+  mas-rad_core (= 0.0.94)
   oga
   pg
   poltergeist

--- a/app/views/self_service/advisers/_form.html.erb
+++ b/app/views/self_service/advisers/_form.html.erb
@@ -32,10 +32,10 @@
   <%= paragraphs t('self_service.adviser_form.geographical_coverage_description') %>
 
   <fieldset class="form__group" data-dough-field-target="1">
-    <%= f.form_row :address do %>
-      <%= f.errors_for :address %>
+    <%= f.form_row :geocoding do %>
+      <%= f.errors_for :geocoding %>
 
-      <% if f.object.errors.include?(:address) %>
+      <% if f.object.errors.include?(:geocoding) %>
         <p><%= t('adviser.geocoding.failure_explanation') %></p>
       <% end %>
 

--- a/app/views/self_service/offices/_form.html.erb
+++ b/app/views/self_service/offices/_form.html.erb
@@ -38,10 +38,10 @@
     <%= f.text_field :address_county, class: 't-address-county' %>
   <% end %>
 
-  <%= f.form_row :address do %>
-    <%= f.errors_for :address %>
+  <%= f.form_row :geocoding do %>
+    <%= f.errors_for :geocoding %>
 
-    <% if f.object.errors.include?(:address) %>
+    <% if f.object.errors.include?(:geocoding) %>
       <p><%= t('office.geocoding.failure_explanation') %></p>
     <% end %>
 

--- a/app/views/self_service/offices/_form.html.erb
+++ b/app/views/self_service/offices/_form.html.erb
@@ -6,43 +6,43 @@
 
 <div class="l-half-width">
 
-  <%= f.form_row :address_line_one do %>
-    <%= f.errors_for :address_line_one %>
-    <%= f.label :address_line_one,
-                required_asterisk(Office.human_attribute_name(:address_line_one)),
-                class: 'form__label-heading' %>
-    <%= f.text_field :address_line_one, class: 't-address-line-one' %>
-  <% end %>
-
-  <%= f.form_row :address_line_two do %>
-    <%= f.errors_for :address_line_two %>
-    <%= f.label :address_line_two,
-                Office.human_attribute_name(:address_line_two),
-                class: 'form__label-heading' %>
-    <%= f.text_field :address_line_two, class: 't-address-line-two' %>
-  <% end %>
-
-  <%= f.form_row :address_town do %>
-    <%= f.errors_for :address_town %>
-    <%= f.label :address_town,
-                required_asterisk(Office.human_attribute_name(:address_town)),
-                class: 'form__label-heading' %>
-    <%= f.text_field :address_town, class: 't-address-town' %>
-  <% end %>
-
-  <%= f.form_row :address_county do %>
-    <%= f.errors_for :address_county %>
-    <%= f.label :address_county,
-                Office.human_attribute_name(:address_county),
-                class: 'form__label-heading' %>
-    <%= f.text_field :address_county, class: 't-address-county' %>
-  <% end %>
-
   <%= f.form_row :geocoding do %>
     <%= f.errors_for :geocoding %>
 
     <% if f.object.errors.include?(:geocoding) %>
       <p><%= t('office.geocoding.failure_explanation') %></p>
+    <% end %>
+
+    <%= f.form_row :address_line_one do %>
+      <%= f.errors_for :address_line_one %>
+      <%= f.label :address_line_one,
+                  required_asterisk(Office.human_attribute_name(:address_line_one)),
+                  class: 'form__label-heading' %>
+      <%= f.text_field :address_line_one, class: 't-address-line-one' %>
+    <% end %>
+
+    <%= f.form_row :address_line_two do %>
+      <%= f.errors_for :address_line_two %>
+      <%= f.label :address_line_two,
+                  Office.human_attribute_name(:address_line_two),
+                  class: 'form__label-heading' %>
+      <%= f.text_field :address_line_two, class: 't-address-line-two' %>
+    <% end %>
+
+    <%= f.form_row :address_town do %>
+      <%= f.errors_for :address_town %>
+      <%= f.label :address_town,
+                  required_asterisk(Office.human_attribute_name(:address_town)),
+                  class: 'form__label-heading' %>
+      <%= f.text_field :address_town, class: 't-address-town' %>
+    <% end %>
+
+    <%= f.form_row :address_county do %>
+      <%= f.errors_for :address_county %>
+      <%= f.label :address_county,
+                  Office.human_attribute_name(:address_county),
+                  class: 'form__label-heading' %>
+      <%= f.text_field :address_county, class: 't-address-county' %>
     <% end %>
 
     <%= f.form_row :address_postcode, html_options: { classes: 'form-row--collapsed-margin-bottom' } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,11 +35,11 @@ en:
       adviser:
         name: Name
         postcode: Postcode
-        address: Postcode
+        geocoding: Postcode
         qualifications: Qualifications
         reference_number: Number
       office:
-        address: Postcode
+        geocoding: Postcode
       principal:
         fca_number: FCA Number
         confirmed_disclaimer: Truth confirmation statement
@@ -198,7 +198,7 @@ en:
   office:
     geocoding:
       failure_message: could not be found by the mapping service.
-      failure_explanation: We could not find the coordinates of your office postcode to plot it on the map in the directory. Please check and try again. If the postcode is correct and still cannot be found please contact RADenquiries@moneyadviceservice.org.uk for assistance.
+      failure_explanation: We could not find the coordinates of your office address to plot it on the map in the directory. Please check and try again. If the details are correct and still cannot be found please contact RADenquiries@moneyadviceservice.org.uk for assistance.
 
   lookup_adviser:
     error_responses:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
         qualifications: Qualifications
         reference_number: Number
       office:
-        geocoding: Postcode
+        geocoding: Address
       principal:
         fca_number: FCA Number
         confirmed_disclaimer: Truth confirmation statement

--- a/spec/features/self_service/offices_add_spec.rb
+++ b/spec/features/self_service/offices_add_spec.rb
@@ -3,9 +3,20 @@ RSpec.feature 'The self service office add page', vcr: vcr_options_for(:features
   let(:office_add_page) { SelfService::OfficeAddPage.new }
   let(:office_edit_page) { SelfService::OfficeEditPage.new }
 
+  let(:address_line_one) { '120 Holborn' }
+  let(:address_town) { 'London' }
+  let(:address_postcode) { 'EC1N 2TD' }
+
   let(:principal) { FactoryGirl.create(:principal) }
   let(:user) { FactoryGirl.create(:user, principal: principal) }
-  let(:office) { FactoryGirl.attributes_for(:office) }
+  let(:office) do
+    FactoryGirl.attributes_for(:office,
+                               address_line_one: address_line_one,
+                               address_line_two: '',
+                               address_town: address_town,
+                               address_county: '',
+                               address_postcode: address_postcode)
+  end
 
   scenario 'The principal can create a new office' do
     given_i_am_a_fully_registered_principal_user

--- a/spec/features/self_service/offices_edit_spec.rb
+++ b/spec/features/self_service/offices_edit_spec.rb
@@ -1,15 +1,25 @@
 RSpec.feature 'The self service office edit page', vcr: vcr_options_for(:features_self_service_offices_edit_spec) do
   let(:offices_index_page) { SelfService::OfficesIndexPage.new }
   let(:office_edit_page) { SelfService::OfficeEditPage.new }
-  let(:original_postcode) { 'L1 2NH' }
-  let(:updated_postcode) { 'EH11 2AB' }
+
+  let(:address_line_one) { '119 Holborn' }
+  let(:address_town) { 'London' }
+  let(:address_postcode) { 'EC1N 2TD' }
+
+  let(:original_line_one) { address_line_one }
+  let(:updated_line_one) { '120 Holborn' }
+  let(:original_postcode) { address_postcode }
 
   let(:principal) { FactoryGirl.create(:principal) }
   let(:user) { FactoryGirl.create(:user, principal: principal) }
   let(:office) do
     FactoryGirl.create(:office,
                        firm: principal.firm,
-                       address_postcode: original_postcode,
+                       address_line_one: address_line_one,
+                       address_line_two: '',
+                       address_town: address_town,
+                       address_county: '',
+                       address_postcode: address_postcode,
                        disabled_access: false)
   end
   let(:offices) { [office] }
@@ -84,7 +94,7 @@ RSpec.feature 'The self service office edit page', vcr: vcr_options_for(:feature
   end
 
   def when_i_change_the_information
-    office_edit_page.address_postcode.set updated_postcode
+    office_edit_page.address_line_one.set updated_line_one
     office_edit_page.disabled_access.set true
   end
 
@@ -106,7 +116,7 @@ RSpec.feature 'The self service office edit page', vcr: vcr_options_for(:feature
 
   def then_the_information_is_changed
     office.reload
-    expect(office.address_postcode).to eq updated_postcode
+    expect(office.address_line_one).to eq updated_line_one
     expect(office.disabled_access).to eq true
   end
 

--- a/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 10 Nov 2015 16:52:42 GMT
+      - Fri, 13 Nov 2015 13:18:09 GMT
       Expires:
-      - Wed, 11 Nov 2015 16:52:42 GMT
+      - Sat, 14 Nov 2015 13:18:09 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - mafe
       Content-Length:
-      - '495'
+      - '503'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
@@ -44,9 +44,14 @@ http_interactions:
               {
                  "address_components" : [
                     {
-                       "long_name" : "EC1N 2TD",
-                       "short_name" : "EC1N 2TD",
-                       "types" : [ "postal_code" ]
+                       "long_name" : "120",
+                       "short_name" : "120",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Holborn",
+                       "short_name" : "Holborn",
+                       "types" : [ "route" ]
                     },
                     {
                        "long_name" : "London",
@@ -67,42 +72,37 @@ http_interactions:
                        "long_name" : "United Kingdom",
                        "short_name" : "GB",
                        "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
                     }
                  ],
-                 "formatted_address" : "London EC1N 2TD, UK",
+                 "formatted_address" : "120 Holborn, London EC1N 2TD, UK",
                  "geometry" : {
-                    "bounds" : {
-                       "northeast" : {
-                          "lat" : 51.5182639,
-                          "lng" : -0.1078729
-                       },
-                       "southwest" : {
-                          "lat" : 51.5173261,
-                          "lng" : -0.1094075
-                       }
-                    },
                     "location" : {
-                       "lat" : 51.5180697,
-                       "lng" : -0.1085203
+                       "lat" : 51.5181479,
+                       "lng" : -0.1080125
                     },
-                    "location_type" : "APPROXIMATE",
+                    "location_type" : "ROOFTOP",
                     "viewport" : {
                        "northeast" : {
-                          "lat" : 51.5191439802915,
-                          "lng" : -0.107291219708498
+                          "lat" : 51.5194968802915,
+                          "lng" : -0.106663519708498
                        },
                        "southwest" : {
-                          "lat" : 51.5164460197085,
-                          "lng" : -0.109989180291502
+                          "lat" : 51.5167989197085,
+                          "lng" : -0.109361480291502
                        }
                     }
                  },
-                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
-                 "types" : [ "postal_code" ]
+                 "place_id" : "ChIJ1y3irE0bdkgRz3w__Q4S9sI",
+                 "types" : [ "street_address" ]
               }
            ],
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 16:52:42 GMT
+  recorded_at: Fri, 13 Nov 2015 13:18:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/features_self_service_offices_edit_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_self_service_offices_edit_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH11%202AB,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 10 Nov 2015 16:52:24 GMT
+      - Fri, 13 Nov 2015 13:43:23 GMT
       Expires:
-      - Wed, 11 Nov 2015 16:52:24 GMT
+      - Sat, 14 Nov 2015 13:43:23 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - mafe
       Content-Length:
-      - '487'
+      - '503'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
@@ -44,65 +44,65 @@ http_interactions:
               {
                  "address_components" : [
                     {
-                       "long_name" : "EH11 2AB",
-                       "short_name" : "EH11 2AB",
-                       "types" : [ "postal_code" ]
+                       "long_name" : "120",
+                       "short_name" : "120",
+                       "types" : [ "street_number" ]
                     },
                     {
-                       "long_name" : "Edinburgh",
-                       "short_name" : "Edinburgh",
+                       "long_name" : "Holborn",
+                       "short_name" : "Holborn",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
                        "types" : [ "locality", "political" ]
                     },
                     {
-                       "long_name" : "Edinburgh",
-                       "short_name" : "Edinburgh",
+                       "long_name" : "London",
+                       "short_name" : "London",
                        "types" : [ "postal_town" ]
                     },
                     {
-                       "long_name" : "Edinburgh",
-                       "short_name" : "Edinburgh",
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
                        "types" : [ "administrative_area_level_2", "political" ]
                     },
                     {
                        "long_name" : "United Kingdom",
                        "short_name" : "GB",
                        "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
                     }
                  ],
-                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH11 2AB, UK",
+                 "formatted_address" : "120 Holborn, London EC1N 2TD, UK",
                  "geometry" : {
-                    "bounds" : {
-                       "northeast" : {
-                          "lat" : 55.9438156,
-                          "lng" : -3.2188073
-                       },
-                       "southwest" : {
-                          "lat" : 55.9432559,
-                          "lng" : -3.2197304
-                       }
-                    },
                     "location" : {
-                       "lat" : 55.9435255,
-                       "lng" : -3.2192103
+                       "lat" : 51.5181479,
+                       "lng" : -0.1080125
                     },
-                    "location_type" : "APPROXIMATE",
+                    "location_type" : "ROOFTOP",
                     "viewport" : {
                        "northeast" : {
-                          "lat" : 55.9448847302915,
-                          "lng" : -3.217919869708498
+                          "lat" : 51.5194968802915,
+                          "lng" : -0.106663519708498
                        },
                        "southwest" : {
-                          "lat" : 55.9421867697085,
-                          "lng" : -3.220617830291502
+                          "lat" : 51.5167989197085,
+                          "lng" : -0.109361480291502
                        }
                     }
                  },
-                 "place_id" : "ChIJKQxzD6bHh0gRyUDWgg-clYQ",
-                 "types" : [ "postal_code" ]
+                 "place_id" : "ChIJ1y3irE0bdkgRz3w__Q4S9sI",
+                 "types" : [ "street_address" ]
               }
            ],
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 16:52:24 GMT
+  recorded_at: Fri, 13 Nov 2015 13:43:23 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This change integrates the following to mas-rad_core changes into the rad:

* [Change the geocoding errors key to 'geocoding' for clarity](https://github.com/moneyadviceservice/mas-rad_core/pull/135)
* [Go back to using whole address to geocode offices again](https://github.com/moneyadviceservice/mas-rad_core/pull/134)

UI now looks like this for offices when there are geocoding errors:

![screen shot 2015-11-13 at 13 06 48](https://cloud.githubusercontent.com/assets/306583/11147398/8b0d1c04-8a0d-11e5-9a70-2d9f4869b9c6.png)

And like for this advisers:

![screen shot 2015-11-13 at 12 59 32](https://cloud.githubusercontent.com/assets/306583/11147404/95b03678-8a0d-11e5-9c7f-b03b4f6386e7.png)
