### PR TITLE
Reports update

### DIFF
--- a/lib/tasks/adhoc.rake
+++ b/lib/tasks/adhoc.rake
@@ -14,29 +14,64 @@ namespace 'adhoc' do
 
   desc 'Prints several interesting stats about the firms in the directory'
   task firm_stats: :environment do
+    puts 'Generating, please wait ...'
     published_firms = Firm.registered.select(&:publishable?)
+    published_firm_ids = published_firms.map(&:id)
 
-    puts "Total firms (face-to-face & remote): #{published_firms.count}"
+    puts
+    puts 'WHOLE SYSTEM'
+    puts "Total firm records in the system: #{Firm.count}"
+    puts 'Which breaks down into:'
+    puts "  Total parent firms: #{Firm.where(parent: nil).count}"
+    puts "  Total trading names: #{Firm.where.not(parent: nil).count}"
+    puts "Total advisers in the system: #{Adviser.count}"
+    puts "Total principals in the system: #{Principal.count}"
+
+    puts
+    puts 'FIRMS'
+    puts '(Here "registered" means that a firm record has been filled out but more'
+    puts 'information would be required before they can appear on the directory.'
+    puts 'The total number of principals in the whole system may be a better'
+    puts 'indicator of how many distinct businesses have signed up.)'
+    puts
+
+    puts "Total number of firms registered: #{Firm.registered.count}"
+    puts 'Which breaks down into:'
+    puts "  Parent firms registered: #{Firm.registered.where(parent: nil).count}"
+    puts "  Trading names registered: #{Firm.registered.where.not(parent: nil).count}"
+
+    puts
+    puts "Total number of firms appearing on the directory (published): #{published_firms.count}"
     remote = published_firms.select { |f| f.primary_advice_method == :remote }
-    puts "Total firms (remote): #{remote.count}"
+    puts 'Which breaks down into:'
+    puts "  Face-to-face only advice: #{published_firms.count - remote.count}"
+    puts "  Remote-only advice: #{remote.count}"
 
+    puts
+    puts 'FEES & POT SIZE'
     no_min_fee = published_firms.select { |f| [0, nil].include?(f.minimum_fixed_fee) }
-    puts "Firms with NO minimum fee: #{no_min_fee.count}"
+    puts "Published firms with NO minimum fee: #{no_min_fee.count}"
 
     fee_between_1_and_500 = published_firms.select { |f| (1..500).include?(f.minimum_fixed_fee) }
-    puts "Firms who have a minimum fee between £1.00 - £500: #{fee_between_1_and_500.count}"
+    puts "Published firms who have a minimum fee between £1.00 - £500: #{fee_between_1_and_500.count}"
 
     fee_between_501_and_1000 = published_firms.select { |f| (501..1000).include?(f.minimum_fixed_fee) }
-    puts "Firms who have a minimum fee between £501 - £1000: #{fee_between_501_and_1000.count}"
+    puts "Published firms who have a minimum fee between £501 - £1000: #{fee_between_501_and_1000.count}"
 
     under_50k_size = InvestmentSize.find_by(name: 'Under £50,000')
     firms_who_ticked_under_50k = published_firms.select { |f| f.investment_sizes.exists?(under_50k_size.id) }
-    puts "Firms who will deal with any pot size i.e they have ticked under £50,000: #{firms_who_ticked_under_50k.count}"
+    puts 'Published firms who will deal with any pot size i.e they have ticked' \
+         "under £50,000: #{firms_who_ticked_under_50k.count}"
 
     firms_who_ticked_under_50k_lt_500_fee = firms_who_ticked_under_50k.select do |f|
       f.minimum_fixed_fee.nil? || f.minimum_fixed_fee < 500
     end
-    puts 'Firms who will deal with any pot size and have a minimum fee of ' \
+    puts 'Published firms who will deal with any pot size and have a minimum fee of ' \
          "less than £500: #{firms_who_ticked_under_50k_lt_500_fee.count}"
+
+    puts
+    puts 'ADVISERS'
+    puts "Total number of published advisers: #{Adviser.geocoded.where(firm: published_firm_ids).count}"
+    puts
   end
 end


### PR DESCRIPTION
Stats gen updates based on feedback from the RAD admin team.

I’ve updated the reports with new data, which hopefully makes it clearer, or at least more possible to work out what things mean.

There is now more information in the `adhoc:firm_stats` report. Note, it’s a little unclear what registered actually means after the last few months of changes, so I’ve defined it based on what the code does (see the note in brackets) to try to clear up any confusion.

The by-country report is now generated based on all firms that appear on the directory, which in the code refer to as “published”. The numbers now look consistent with the report generated last month.