### PR TITLE
Add advisers without a reference number to a firm

### DIFF
--- a/app/controllers/admin/advisers_controller.rb
+++ b/app/controllers/admin/advisers_controller.rb
@@ -7,6 +7,24 @@ class Admin::AdvisersController < Admin::ApplicationController
     @advisers = @advisers.page(params[:page]).per(20)
   end
 
+  def new
+    @adviser = Adviser.new
+    @firm = Firm.find(params[:firm_id])
+  end
+
+  def create
+    @firm = Firm.find(params[:firm_id])
+    @adviser = @firm.advisers.build(adviser_params)
+    @adviser.reference_number = "NOREF"
+    @adviser.bypass_reference_number_check = true
+
+    if @adviser.save
+      redirect_to admin_firm_path(firm)
+    else
+      render :new
+    end
+  end
+
   def show
     @adviser = adviser
   end
@@ -45,6 +63,7 @@ class Admin::AdvisersController < Admin::ApplicationController
 
   def adviser_params
     params.require(:adviser).permit(
+      :name,
       :postcode,
       :travel_distance,
       qualification_ids: [],

--- a/app/controllers/admin/advisers_controller.rb
+++ b/app/controllers/admin/advisers_controller.rb
@@ -15,7 +15,7 @@ class Admin::AdvisersController < Admin::ApplicationController
   def create
     @firm = Firm.find(params[:firm_id])
     @adviser = @firm.advisers.build(adviser_params)
-    @adviser.reference_number = "NOREF"
+    @adviser.reference_number = 'NOREF'
     @adviser.bypass_reference_number_check = true
 
     if @adviser.save

--- a/app/views/admin/advisers/_form.html.erb
+++ b/app/views/admin/advisers/_form.html.erb
@@ -1,0 +1,50 @@
+<div class="form-group">
+  <%= f.label :postcode %>
+  <% if @adviser.errors.include?(:address) %>
+    <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation') %></p>
+  <% end %>
+  <%= f.text_field(:postcode, class: 'form-control t-postcode') %>
+</div>
+
+<div class="form-group">
+  <%= f.label :travel_distance %>
+  <%= f.select :travel_distance, TravelDistance.all, { include_blank: true }, { class: 'form-control t-travel-distance' } %>
+</div>
+
+<div class="form-group">
+  <h4>Accreditations</h4>
+  <%= f.collection_check_boxes(:accreditation_ids, Accreditation.all, :id, :name) do |c| %>
+    <div class="checkbox">
+      <%= c.label { c.check_box + c.text } %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-group">
+  <h4>Qualifications</h4>
+  <%= f.collection_check_boxes(:qualification_ids, Qualification.all, :id, :name) do |c| %>
+    <div class="checkbox">
+      <%= c.label { c.check_box + c.text } %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-group">
+  <h4>Statements of Professional Standing</h4>
+  <%= f.collection_check_boxes(:professional_standing_ids, ProfessionalStanding.all, :id, :name) do |c| %>
+    <div class="checkbox">
+      <%= c.label { c.check_box + c.text } %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-group">
+  <h4>Professional Bodies</h4>
+  <%= f.collection_check_boxes(:professional_body_ids, ProfessionalBody.all, :id, :name)  do |c| %>
+    <div class="checkbox">
+      <%= c.label { c.check_box + c.text } %>
+    </div>
+  <% end %>
+</div>
+
+<%= f.submit 'Save', class: 'btn btn-primary t-save' %>

--- a/app/views/admin/advisers/edit.html.erb
+++ b/app/views/admin/advisers/edit.html.erb
@@ -8,56 +8,7 @@
   <%= form_for([:admin, @adviser]) do |f| %>
     <%= render 'admin/shared/errors', model: @adviser %>
 
-    <div class="form-group">
-      <%= f.label :postcode %>
-      <% if @adviser.errors.include?(:address) %>
-        <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation') %></p>
-      <% end %>
-      <%= f.text_field(:postcode, class: 'form-control') %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :travel_distance %>
-      <%= f.select :travel_distance, TravelDistance.all, { include_blank: true }, { class: 'form-control' } %>
-    </div>
-
-    <div class="form-group">
-      <h4>Accreditations</h4>
-      <%= f.collection_check_boxes(:accreditation_ids, Accreditation.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Qualifications</h4>
-      <%= f.collection_check_boxes(:qualification_ids, Qualification.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Statements of Professional Standing</h4>
-      <%= f.collection_check_boxes(:professional_standing_ids, ProfessionalStanding.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Professional Bodies</h4>
-      <%= f.collection_check_boxes(:professional_body_ids, ProfessionalBody.all, :id, :name)  do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <%= f.submit 'Save', class: 'btn btn-primary' %>
+    <%= render partial: 'admin/advisers/form', locals: {f: f} %>
   <% end %>
   </div>
 </div>

--- a/app/views/admin/advisers/new.html.erb
+++ b/app/views/admin/advisers/new.html.erb
@@ -1,0 +1,65 @@
+<h1>Add new adviser without an FCA number</h1>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+  <%= form_for([:admin, @firm, @adviser]) do |f| %>
+    <%= render 'admin/shared/errors', model: @adviser %>
+
+    <div class="form-group">
+      <%= f.label(:name) %>
+      <%= f.text_field(:name, class: 'form-control t-name') %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :postcode %>
+      <% if @adviser.errors.include?(:address) %>
+        <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation') %></p>
+      <% end %>
+      <%= f.text_field(:postcode, class: 'form-control t-postcode') %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :travel_distance %>
+      <%= f.select :travel_distance, TravelDistance.all, { include_blank: true }, { class: 'form-control t-travel-distance' } %>
+    </div>
+
+    <div class="form-group">
+      <h4>Accreditations</h4>
+      <%= f.collection_check_boxes(:accreditation_ids, Accreditation.all, :id, :name) do |c| %>
+        <div class="checkbox">
+          <%= c.label { c.check_box + c.text } %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="form-group">
+      <h4>Qualifications</h4>
+      <%= f.collection_check_boxes(:qualification_ids, Qualification.all, :id, :name) do |c| %>
+        <div class="checkbox">
+          <%= c.label { c.check_box + c.text } %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="form-group">
+      <h4>Statements of Professional Standing</h4>
+      <%= f.collection_check_boxes(:professional_standing_ids, ProfessionalStanding.all, :id, :name) do |c| %>
+        <div class="checkbox">
+          <%= c.label { c.check_box + c.text } %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="form-group">
+      <h4>Professional Bodies</h4>
+      <%= f.collection_check_boxes(:professional_body_ids, ProfessionalBody.all, :id, :name)  do |c| %>
+        <div class="checkbox">
+          <%= c.label { c.check_box + c.text } %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= f.submit 'Save', class: 'btn btn-primary t-save' %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/admin/advisers/new.html.erb
+++ b/app/views/admin/advisers/new.html.erb
@@ -10,56 +10,7 @@
       <%= f.text_field(:name, class: 'form-control t-name') %>
     </div>
 
-    <div class="form-group">
-      <%= f.label :postcode %>
-      <% if @adviser.errors.include?(:address) %>
-        <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation') %></p>
-      <% end %>
-      <%= f.text_field(:postcode, class: 'form-control t-postcode') %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :travel_distance %>
-      <%= f.select :travel_distance, TravelDistance.all, { include_blank: true }, { class: 'form-control t-travel-distance' } %>
-    </div>
-
-    <div class="form-group">
-      <h4>Accreditations</h4>
-      <%= f.collection_check_boxes(:accreditation_ids, Accreditation.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Qualifications</h4>
-      <%= f.collection_check_boxes(:qualification_ids, Qualification.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Statements of Professional Standing</h4>
-      <%= f.collection_check_boxes(:professional_standing_ids, ProfessionalStanding.all, :id, :name) do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <h4>Professional Bodies</h4>
-      <%= f.collection_check_boxes(:professional_body_ids, ProfessionalBody.all, :id, :name)  do |c| %>
-        <div class="checkbox">
-          <%= c.label { c.check_box + c.text } %>
-        </div>
-      <% end %>
-    </div>
-
-    <%= f.submit 'Save', class: 'btn btn-primary t-save' %>
+    <%= render partial: 'admin/advisers/form', locals: {f: f} %>
   <% end %>
   </div>
 </div>

--- a/app/views/admin/advisers/new.html.erb
+++ b/app/views/admin/advisers/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Add new adviser without an FCA number</h1>
+<h1>New adviser (without reference number)</h1>
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -56,15 +56,16 @@
 
   <ul>
     <% @firm.advisers.each do |adviser| %>
-      <li><%= link_to adviser.name, admin_adviser_path(adviser) %>, added <%= adviser.created_at.to_s(:short) %></li>
+      <li class='t-adviser'><%= link_to adviser.name, admin_adviser_path(adviser) %>, added <%= adviser.created_at.to_s(:short) %></li>
     <% end %>
   </ul>
 
-  <%= button_to 'Move advisers', new_admin_move_adviser_path,
-                :class => "t-move-advisers", :method => :get %>
+  <%= link_to 'Move advisers', new_admin_move_adviser_path, class: 'btn btn-default t-move-advisers', method: :get %>
 <% else %>
   <p>No advisers registered.</p>
 <% end %>
+
+<%= link_to 'New adviser', new_admin_firm_adviser_path(@firm), class: 'btn btn-success t-new-adviser', method: :get %>
 
 <% if @firm.registered? %>
   <h2>Questionnaire Responses</h2>

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -65,7 +65,7 @@
   <p>No advisers registered.</p>
 <% end %>
 
-<%= link_to 'New adviser', new_admin_firm_adviser_path(@firm), class: 'btn btn-success t-new-adviser', method: :get %>
+<%= link_to 'New adviser (without reference number)', new_admin_firm_adviser_path(@firm), class: 'btn btn-success t-new-adviser', method: :get %>
 
 <% if @firm.registered? %>
   <h2>Questionnaire Responses</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         get :login_report
       end
 
-      resources :advisers, only: :index
+      resources :advisers, only: [:index, :new, :create]
       member do
         resources :move_advisers, only: [:new] do
           collection do

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -5,29 +5,36 @@ RSpec.feature 'Add a new adviser without an FCA number' do
   before do
     given_there_is_a_firm
     when_i_visit_the_firm_admin_page
+    then_no_errors_are_displayed_on(the_page: firm_page)
     then_there_should_be_no_advisers
 
     when_i_click_the_new_adviser_button
     then_i_am_on_the_new_adviser_page
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
   end
 
   scenario 'Adding an adviser' do
     when_i_complete_the_form
     and_i_click_save
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
 
     then_i_am_on_the_firm_page
+    then_no_errors_are_displayed_on(the_page: firm_page)
     and_i_can_see_1_adviser
   end
 
   scenario 'Adding an adviser after we fail once' do
     when_i_click_save
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
     then_there_are_validation_errors
     and_i_am_still_on_the_page
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
 
     when_i_complete_the_form
     and_i_click_save
 
     then_i_am_on_the_firm_page
+    then_no_errors_are_displayed_on(the_page: firm_page)
     and_i_can_see_1_adviser
   end
 
@@ -80,5 +87,12 @@ RSpec.feature 'Add a new adviser without an FCA number' do
 
   def and_i_can_see_1_adviser
     expect(firm_page.advisers.count).to eq(1)
+  end
+
+  def then_no_errors_are_displayed_on(the_page:)
+    # Matching only on title-case 'Error' as the word 'error' appears in the
+    # validation message preamble
+    expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
+    expect(the_page.status_code).not_to eq(500)
   end
 end

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -92,9 +92,7 @@ RSpec.feature 'Add a new adviser without an FCA number' do
     # validation message preamble
     # expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
 
-    if the_page.status_code == 500
-      puts the_page.text
-    end
+    puts the_page.text if the_page.status_code == 500
 
     expect(the_page.status_code).not_to eq(500)
   end

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -5,30 +5,24 @@ RSpec.feature 'Add a new adviser without an FCA number' do
   before do
     given_there_is_a_firm
     when_i_visit_the_firm_admin_page
-    then_no_errors_are_displayed_on(the_page: firm_page)
     then_there_should_be_no_advisers
 
     when_i_click_the_new_adviser_button
     then_i_am_on_the_new_adviser_page
-    then_no_errors_are_displayed_on(the_page: new_adviser_page)
   end
 
   scenario 'Adding an adviser' do
     when_i_complete_the_form
     and_i_click_save
-    then_no_errors_are_displayed_on(the_page: new_adviser_page)
 
     then_i_am_on_the_firm_page
-    then_no_errors_are_displayed_on(the_page: firm_page)
     and_i_can_see_1_adviser
   end
 
   scenario 'Adding an adviser after we fail once' do
     when_i_click_save
-    then_no_errors_are_displayed_on(the_page: new_adviser_page)
     then_there_are_validation_errors
     and_i_am_still_on_the_page
-    then_no_errors_are_displayed_on(the_page: new_adviser_page)
 
     when_i_complete_the_form
     and_i_click_save
@@ -45,6 +39,7 @@ RSpec.feature 'Add a new adviser without an FCA number' do
   def when_i_visit_the_firm_admin_page
     firm_page.load(firm_id: @firm.id)
     expect(firm_page).to be_displayed
+    then_no_errors_are_displayed_on(the_page: firm_page)
   end
 
   def then_there_should_be_no_advisers
@@ -57,6 +52,7 @@ RSpec.feature 'Add a new adviser without an FCA number' do
 
   def then_i_am_on_the_new_adviser_page
     expect(new_adviser_page).to be_displayed
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
   end
 
   def when_i_complete_the_form
@@ -79,10 +75,12 @@ RSpec.feature 'Add a new adviser without an FCA number' do
 
   def and_i_am_still_on_the_page
     expect(new_adviser_page).to be_displayed
+    then_no_errors_are_displayed_on(the_page: new_adviser_page)
   end
 
   def then_i_am_on_the_firm_page
     expect(firm_page).to be_displayed
+    then_no_errors_are_displayed_on(the_page: firm_page)
   end
 
   def and_i_can_see_1_adviser
@@ -92,7 +90,12 @@ RSpec.feature 'Add a new adviser without an FCA number' do
   def then_no_errors_are_displayed_on(the_page:)
     # Matching only on title-case 'Error' as the word 'error' appears in the
     # validation message preamble
-    expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
+    # expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
+
+    if the_page.status_code == 500
+      puts the_page.text
+    end
+
     expect(the_page.status_code).not_to eq(500)
   end
 end

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -1,0 +1,84 @@
+RSpec.feature 'Add a new adviser without an FCA number' do
+  let(:firm_page) { Admin::FirmPage.new }
+  let(:new_adviser_page) { Admin::NewAdviserPage.new }
+
+  before do
+    given_there_is_a_firm
+    when_i_visit_the_firm_admin_page
+    then_there_should_be_no_advisers
+
+    when_i_click_the_new_adviser_button
+    then_i_am_on_the_new_adviser_page
+  end
+
+  scenario 'Adding an adviser' do
+    when_i_complete_the_form
+    and_i_click_save
+
+    then_i_am_on_the_firm_page
+    and_i_can_see_1_adviser
+  end
+
+  scenario 'Adding an adviser after we fail once' do
+    when_i_click_save
+    then_there_are_validation_errors
+    and_i_am_still_on_the_page
+
+    when_i_complete_the_form
+    and_i_click_save
+
+    then_i_am_on_the_firm_page
+    and_i_can_see_1_adviser
+  end
+
+  def given_there_is_a_firm
+    @firm = FactoryGirl.create(:firm_with_principal, :without_advisers)
+  end
+
+  def when_i_visit_the_firm_admin_page
+    firm_page.load(firm_id: @firm.id)
+    expect(firm_page).to be_displayed
+  end
+
+  def then_there_should_be_no_advisers
+    expect(firm_page.advisers.count).to eq(0)
+  end
+
+  def when_i_click_the_new_adviser_button
+    firm_page.new_adviser.click
+  end
+
+  def then_i_am_on_the_new_adviser_page
+    expect(new_adviser_page).to be_displayed
+  end
+
+  def when_i_complete_the_form
+    new_adviser_page.name.set 'Example Adviser'
+    new_adviser_page.postcode.set 'EH1 2AS'
+    new_adviser_page.travel_distance.select '10 miles'
+  end
+
+  def and_i_click_save
+    new_adviser_page.save.click
+  end
+
+  def when_i_click_save
+    new_adviser_page.save.click
+  end
+
+  def then_there_are_validation_errors
+    expect(new_adviser_page).to have_errors
+  end
+
+  def and_i_am_still_on_the_page
+    expect(new_adviser_page).to be_displayed
+  end
+
+  def then_i_am_on_the_firm_page
+    expect(firm_page).to be_displayed
+  end
+
+  def and_i_can_see_1_adviser
+    expect(firm_page.advisers.count).to eq(1)
+  end
+end

--- a/spec/support/admin/firm_page.rb
+++ b/spec/support/admin/firm_page.rb
@@ -2,6 +2,9 @@ class Admin::FirmPage < SitePrism::Page
   set_url '/admin/firms/{firm_id}'
   set_url_matcher %r{/admin/firms/[0-9]+}
 
+  elements :advisers, '.t-adviser'
+
   element :move_advisers, '.t-move-advisers'
   element :sign_in_as_principal, '.t-sign-in-as-principal'
+  element :new_adviser, '.t-new-adviser'
 end

--- a/spec/support/admin/new_adviser_page.rb
+++ b/spec/support/admin/new_adviser_page.rb
@@ -1,0 +1,10 @@
+class Admin::NewAdviserPage < SitePrism::Page
+  set_url '/admin/firms/{firm_id}/advisers/new'
+  set_url_matcher %r{/admin/firms/[0-9]+/advisers(/new)?}
+
+  element :errors, '.t-errors'
+  element :name, '.t-name'
+  element :postcode, '.t-postcode'
+  element :save, '.t-save'
+  element :travel_distance, '.t-travel-distance'
+end


### PR DESCRIPTION
# Summary

Spec from Trello card:

> In some cases, we need to include advisers in the directory who do not have an adviser reference number for us to cross-check against the FCA Register.
>
> This is needed to be able to include equity release advisers who do not have a FCA adviser reference number.
>
> This does not need to be represented in self-service only manual entry by MAS.  This gives us the security that only qualified individuals are being added to directory.

There is a corresponding PR on `mas-rad_core` that this is dependent upon. https://github.com/moneyadviceservice/mas-rad_core/pull/138

# Screen Shots

## Button added to firm#show template

![screen shot 2016-02-10 at 14 16 59](https://cloud.githubusercontent.com/assets/306583/12950256/17a6b13e-d004-11e5-86cf-9630bfffa068.png)

## New form added

![screencapture-localhost-3000-admin-firms-153-advisers-new-1455113806884](https://cloud.githubusercontent.com/assets/306583/12950255/1423fdaa-d004-11e5-86bb-7a3e02394c8f.png)
