### PR TITLE
[DEV APPROVED] Firm website URL format: adjust validation message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.95'
+gem 'mas-rad_core', '0.0.97'
 gem 'oga'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.95)
+    mas-rad_core (0.0.97)
       active_model_serializers
       geocoder
       httpclient
@@ -331,7 +331,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.95)
+  mas-rad_core (= 0.0.97)
   oga
   pg
   poltergeist
@@ -354,4 +354,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
             in_person_advice_methods:
               blank: "- please select at least one"
             website_address:
-              invalid: " is invalid. The address must be in the format: http://www.example.com"
+              invalid: " is invalid. The address must be in the format: www.example.com"
             primary_advice_method:
               blank: "- please select at least one"
             status:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111132037) do
+ActiveRecord::Schema.define(version: 20160205150033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -31,15 +32,16 @@ ActiveRecord::Schema.define(version: 20151111132037) do
   add_index "accreditations_advisers", ["adviser_id", "accreditation_id"], name: "advisers_accreditations_index", unique: true, using: :btree
 
   create_table "advisers", force: :cascade do |t|
-    t.string   "reference_number",              null: false
-    t.string   "name",                          null: false
-    t.integer  "firm_id",                       null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.string   "postcode",         default: "", null: false
-    t.integer  "travel_distance",  default: 0,  null: false
+    t.string   "reference_number",                              null: false
+    t.string   "name",                                          null: false
+    t.integer  "firm_id",                                       null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.string   "postcode",                      default: "",    null: false
+    t.integer  "travel_distance",               default: 0,     null: false
     t.float    "latitude"
     t.float    "longitude"
+    t.boolean  "bypass_reference_number_check", default: false
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|


### PR DESCRIPTION
> if a firm enter their website address in the following format: www.mywebsite.com an error message displays stating the firm should enter the address using this format: http://www.mywebsite.com
>
> The sign-up process can be simplified by allowing firms to enter their website with this format:
> www.mywebsite.com

Related PRs https://github.com/moneyadviceservice/rad_consumer/pull/263 and https://github.com/moneyadviceservice/mas-rad_core/pull/139

For this repository this simply meant updating to the latest version of rad-core, and removing the protocol from the website address error message.

## Before
![screen shot 2016-02-10 at 16 48 20](https://cloud.githubusercontent.com/assets/219360/12954374/2e2909f4-d016-11e5-9a81-070fa900eae1.png)

## After
![screen shot 2016-02-10 at 16 48 40](https://cloud.githubusercontent.com/assets/219360/12954376/33780540-d016-11e5-976c-6dc3b95c7d79.png)

