### PR TITLE
Display principal email and telephone number in admin screens

### DIFF
--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -8,6 +8,10 @@
     <p>
       <strong>Principal:</strong>
       <%= link_to "#{@firm.principal.first_name} #{@firm.principal.last_name}", admin_principal_path(@firm.principal) %>
+      <ul>
+        <li><strong>Principal Email:</strong> <%= mail_to @firm.principal.email_address %></li>
+        <li><strong>Principal Phone:</strong> <%= @firm.principal.telephone_number %></li>
+      </ul>
     </p>
     <p>
       <strong>FCA Number:</strong> <%= @firm.fca_number %>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -21,6 +21,9 @@
       <strong>Phone Number:</strong> <%= @principal.telephone_number %>
     </p>
     <p>
+      <strong>Email:</strong> <%= mail_to @principal.email_address %>
+    </p>
+    <p>
       <strong>Added:</strong> <%= @principal.created_at.to_s(:long) %>
     </p>
   </div>


### PR DESCRIPTION
# Why?

Previously the principal email was not shown anywhere in the admin screens, leaving the admin team with no choice but to navigate all the way into the self-service area to find it. So now it is displayed.

For maximum convenience the principal phone and email are now also shown on the admin firm screens too.

# Screen shots

## Principal 'show' screen

![screen shot 2016-02-15 at 14 27 39](https://cloud.githubusercontent.com/assets/306583/13052170/3dd27db2-d3f5-11e5-9a57-52ab4e661dd0.png)

## Firm 'show' screen

![screen shot 2016-02-15 at 14 27 59](https://cloud.githubusercontent.com/assets/306583/13052169/3dd122b4-d3f5-11e5-8ac8-26cd5c8d41e1.png)