### PR TITLE
Prevent Heroku timeout on CSV download

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,5 +1,5 @@
 worker_processes Integer(ENV.fetch('WEB_CONCURRENCY', 3))
-timeout 15
+timeout 30
 preload_app true
 
 before_fork do |server, worker|

--- a/lib/reports/firms_advisers.rb
+++ b/lib/reports/firms_advisers.rb
@@ -12,7 +12,13 @@ class Reports::FirmsAdvisers
     CSV.generate do |csv|
       csv << HEADER_ROW
 
-      Firm.all.each do |firm|
+      Firm.includes(
+        :advisers,
+        :principal,
+        :in_person_advice_methods,
+        :other_advice_methods,
+        :principal
+      ).find_each do |firm|
         csv << row_for_firm(firm)
       end
     end


### PR DESCRIPTION
Heroku was timing out before the file was downloaded. This was partly
because the timeout was set too low, but mostly because I'm an idiot who
forgot to check for n+1 issues with the data fetch query >.<