### PR TITLE
Use recent bug fix in mas-rad_core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.99'
+gem 'mas-rad_core', '0.0.100'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.99)
+    mas-rad_core (0.0.100)
       active_model_serializers
       geocoder
       httpclient
@@ -339,7 +339,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.99)
+  mas-rad_core (= 0.0.100)
   oga
   pg
   poltergeist


### PR DESCRIPTION
Using the latest version of `mas-rad_core` in order to use a bug fix.