### PR TITLE
[DEV APPROVED] Remove "Other" accreditation: modify seeds file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mas-rad_core', '0.0.101'
+gem 'mas-rad_core', '0.0.102'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.101)
+    mas-rad_core (0.0.102)
       active_model_serializers
       geocoder
       httpclient
@@ -341,7 +341,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mas-rad_core (= 0.0.101)
+  mas-rad_core (= 0.0.102)
   oga
   pg
   poltergeist

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211161127) do
+ActiveRecord::Schema.define(version: 20160222091312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,7 @@
   'SOLLA',
   'Later Life Academy',
   'ISO 22222',
-  'British Standard in Financial Planning BS8577',
-  'Other'
+  'British Standard in Financial Planning BS8577'
 ].each.with_index(1) { |item, index| Accreditation.find_or_create_by(name: item, order: index) }
 
 [


### PR DESCRIPTION
Related PRs: https://github.com/moneyadviceservice/rad_consumer/pull/271 and https://github.com/moneyadviceservice/mas-rad_core/pull/145

* Removed the "Other" accreditation from the seeds file
* Use latest version of mas-rad_core
* Run `rake db:migrate`

Once the migrations are run I think a `rake firms:index` is needed.