### PR TITLE
Registration - redirects

### DIFF
--- a/app/controllers/self_service/advisers_controller.rb
+++ b/app/controllers/self_service/advisers_controller.rb
@@ -15,7 +15,7 @@ module SelfService
       @adviser = @firm.advisers.build(adviser_params)
       if @adviser.save_with_geocoding
         flash[:notice] = I18n.t('self_service.adviser_edit.saved')
-        redirect_to edit_self_service_firm_adviser_path(@firm, @adviser)
+        redirect_to self_service_firm_advisers_path(@firm)
       else
         render :new
       end
@@ -27,7 +27,7 @@ module SelfService
     def update
       if @adviser.update_with_geocoding(adviser_params)
         flash[:notice] = I18n.t('self_service.adviser_edit.saved')
-        redirect_to edit_self_service_firm_adviser_path(@firm, @adviser)
+        redirect_to self_service_firm_advisers_path(@firm)
       else
         render :edit
       end

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -15,7 +15,7 @@ module SelfService
       @office = @firm.offices.build(office_params)
       if @office.save_with_geocoding
         flash[:notice] = I18n.t('self_service.office_add.saved')
-        redirect_to edit_self_service_firm_office_path(@firm, @office)
+        redirect_to self_service_firm_offices_path(@firm)
       else
         render :new
       end

--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -27,7 +27,7 @@ module SelfService
     def update
       if @office.update_with_geocoding(office_params)
         flash[:notice] = I18n.t('self_service.office_edit.saved')
-        redirect_to edit_self_service_firm_office_path(@firm, @office)
+        redirect_to self_service_firm_offices_path(@firm)
       else
         render :edit
       end

--- a/spec/controllers/selfservice/advisers_controller/create_spec.rb
+++ b/spec/controllers/selfservice/advisers_controller/create_spec.rb
@@ -24,8 +24,8 @@ module SelfService
           expect(assigns(:adviser)).to be_an Adviser
         end
 
-        it 'redirects to the adviser edit page' do
-          redirect_path = edit_self_service_firm_adviser_path(firm, assigns(:adviser).id)
+        it 'redirects to the adviser index page' do
+          redirect_path = self_service_firm_advisers_path(firm)
           expect(response).to redirect_to redirect_path
         end
 

--- a/spec/controllers/selfservice/advisers_controller/update_spec.rb
+++ b/spec/controllers/selfservice/advisers_controller/update_spec.rb
@@ -22,8 +22,8 @@ module SelfService
           expect(flash[:notice]).to eq(I18n.t('self_service.adviser_edit.saved'))
         end
 
-        it 'redirects to the edit page' do
-          redirect_path = edit_self_service_firm_adviser_path(assigns(:firm), assigns(:adviser))
+        it 'redirects to the adviser index page' do
+          redirect_path = self_service_firm_advisers_path(assigns(:firm))
           expect(response).to redirect_to redirect_path
         end
       end

--- a/spec/controllers/selfservice/offices_controller/create_spec.rb
+++ b/spec/controllers/selfservice/offices_controller/create_spec.rb
@@ -1,20 +1,7 @@
 module SelfService
   RSpec.describe SelfService::OfficesController, type: :controller,
-                                                  vcr: vcr_options_for(:features_self_service_offices_add_spec) do
+                                                 vcr: vcr_options_for(:features_self_service_offices_add_spec) do
     include_context 'offices controller'
-
-    let(:address_line_one) { '120 Holborn' }
-    let(:address_line_two) { 'Floor 5' }
-    let(:postcode)         { 'EC1N 2TD' }
-
-    let(:valid_attributes) do
-      FactoryGirl.attributes_for(
-        :office,
-        address_line_one: address_line_one,
-        address_line_two: address_line_two,
-        address_postcode: postcode
-      )
-    end
 
     describe '#create' do
       context 'with valid params' do

--- a/spec/controllers/selfservice/offices_controller/create_spec.rb
+++ b/spec/controllers/selfservice/offices_controller/create_spec.rb
@@ -1,0 +1,46 @@
+module SelfService
+  RSpec.describe SelfService::OfficesController, type: :controller,
+                                                  vcr: vcr_options_for(:features_self_service_offices_add_spec) do
+    include_context 'offices controller'
+
+    let(:address_line_one) { '120 Holborn' }
+    let(:address_line_two) { 'Floor 5' }
+    let(:postcode)         { 'EC1N 2TD' }
+
+    let(:valid_attributes) do
+      FactoryGirl.attributes_for(
+        :office,
+        address_line_one: address_line_one,
+        address_line_two: address_line_two,
+        address_postcode: postcode
+      )
+    end
+
+    describe '#create' do
+      context 'with valid params' do
+        before { post :create, firm_id: firm.id, office: valid_attributes }
+
+        it 'creates a new office' do
+          expect(assigns(:office)).to be_valid
+          expect(assigns(:office)).to be_an Office
+        end
+
+        it 'redirects to the office index page' do
+          redirect_path = self_service_firm_offices_path(firm)
+          expect(response).to redirect_to redirect_path
+        end
+
+        it 'adds a success flash message' do
+          expect(flash[:notice]).to eq(I18n.t('self_service.office_add.saved'))
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders the office new page' do
+          post :create, firm_id: firm.id, office: { rubbish: 666 }
+          expect(response).to render_template :new
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/selfservice/offices_controller/edit_spec.rb
+++ b/spec/controllers/selfservice/offices_controller/edit_spec.rb
@@ -1,0 +1,19 @@
+module SelfService
+  RSpec.describe SelfService::OfficesController, type: :controller do
+    include_context 'offices controller'
+
+    describe '#edit' do
+      before do
+        get :edit, firm_id: firm.id, id: office.id
+      end
+
+      it 'provides the firm to the view' do
+        expect(assigns(:firm)).to eq(firm)
+      end
+
+      it 'provides the office to the view' do
+        expect(assigns(:office)).to eq(office)
+      end
+    end
+  end
+end

--- a/spec/controllers/selfservice/offices_controller/new_spec.rb
+++ b/spec/controllers/selfservice/offices_controller/new_spec.rb
@@ -1,0 +1,22 @@
+module SelfService
+  RSpec.describe SelfService::OfficesController, type: :controller do
+    include_context 'offices controller'
+
+    describe '#new' do
+      before { get :new, firm_id: firm.id }
+
+      it 'provides the firm to the view' do
+        expect(assigns(:firm)).to eq firm
+      end
+
+      it 'provides a newly built office to the view' do
+        expect(assigns(:office)).to be_a Office
+        expect(assigns(:office)).to_not be_persisted
+      end
+
+      it 'assigns the newly built office to the firm' do
+        expect(assigns(:office).firm).to eq firm
+      end
+    end
+  end
+end

--- a/spec/controllers/selfservice/offices_controller/update_spec.rb
+++ b/spec/controllers/selfservice/offices_controller/update_spec.rb
@@ -1,0 +1,36 @@
+module SelfService
+  RSpec.describe SelfService::OfficesController, type: :controller,
+                                                 vcr: vcr_options_for(:features_self_service_offices_add_spec) do
+    include_context 'offices controller'
+
+    describe '#update' do
+      context 'with valid params' do
+        let(:email_change) { { email_address: 'bobby@example.com' } }
+
+        before do
+          patch :update, firm_id: firm.id, id: office.id, office: valid_attributes.merge(email_change)
+        end
+
+        it 'updates the model' do
+          expect(office.reload.email_address).to eq('bobby@example.com')
+        end
+
+        it 'adds a success message after successfully updating the adviser' do
+          expect(flash[:notice]).to eq(I18n.t('self_service.office_edit.saved'))
+        end
+
+        it 'redirects to the adviser index page' do
+          redirect_path = self_service_firm_offices_path(assigns(:firm))
+          expect(response).to redirect_to redirect_path
+        end
+      end
+
+      context 'with invalid params' do
+        it 'renders the office edit page' do
+          patch :update, firm_id: firm.id, id: office.id, office: { address_line_one: '' }
+          expect(response).to render_template :edit
+        end
+      end
+    end
+  end
+end

--- a/spec/features/self_service/offices_add_spec.rb
+++ b/spec/features/self_service/offices_add_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'The self service office add page', vcr: vcr_options_for(:features
   let(:office_edit_page) { SelfService::OfficeEditPage.new }
 
   let(:address_line_one) { '120 Holborn' }
-  let(:address_town) { 'London' }
+  let(:address_line_two) { 'Floor 5' }
+  let(:address_town)     { 'London' }
   let(:address_postcode) { 'EC1N 2TD' }
 
   let(:principal) { FactoryGirl.create(:principal) }
@@ -12,7 +13,7 @@ RSpec.feature 'The self service office add page', vcr: vcr_options_for(:features
   let(:office) do
     FactoryGirl.attributes_for(:office,
                                address_line_one: address_line_one,
-                               address_line_two: '',
+                               address_line_two: address_line_two,
                                address_town: address_town,
                                address_county: '',
                                address_postcode: address_postcode)
@@ -31,11 +32,9 @@ RSpec.feature 'The self service office add page', vcr: vcr_options_for(:features
 
     when_i_fill_out_the_form
     and_i_click_save
-    the_i_see(the_page: office_edit_page)
-    then_no_errors_are_displayed_on(the_page: office_edit_page)
+    the_i_see(the_page: offices_index_page)
+    then_no_errors_are_displayed_on(the_page: offices_index_page)
     then_i_see_a_success_notice
-
-    when_i_am_on_the_offices_page
     then_the_new_office_is_listed
   end
 

--- a/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20Floor%205,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -103,6 +103,6 @@ http_interactions:
            ],
            "status" : "OK"
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 13 Nov 2015 13:18:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/support/contexts/offices_controller.rb
+++ b/spec/support/contexts/offices_controller.rb
@@ -5,8 +5,21 @@ RSpec.shared_context 'offices controller' do
     principal.firm.update_attributes(firm_attrs)
     principal.firm
   end
-  let(:office) { firm.offices.first }
+  let(:office) { FactoryGirl.create :office, firm: firm }
   let(:user)   { FactoryGirl.create :user, principal: principal }
 
   before { sign_in(user) }
+
+  let(:address_line_one) { '120 Holborn' }
+  let(:address_line_two) { 'Floor 5' }
+  let(:postcode)         { 'EC1N 2TD' }
+
+  let(:valid_attributes) do
+    FactoryGirl.attributes_for(
+      :office,
+      address_line_one: address_line_one,
+      address_line_two: address_line_two,
+      address_postcode: postcode
+    )
+  end
 end

--- a/spec/support/contexts/offices_controller.rb
+++ b/spec/support/contexts/offices_controller.rb
@@ -1,0 +1,12 @@
+RSpec.shared_context 'offices controller' do
+  let(:principal) { FactoryGirl.create(:principal) }
+  let(:firm) do
+    firm_attrs = FactoryGirl.attributes_for(:firm_with_trading_names, fca_number: principal.fca_number)
+    principal.firm.update_attributes(firm_attrs)
+    principal.firm
+  end
+  let(:office) { firm.offices.first }
+  let(:user)   { FactoryGirl.create :user, principal: principal }
+
+  before { sign_in(user) }
+end


### PR DESCRIPTION
The way the existing site redirects users is confusing. For example, successfully editing an Adviser lands you back on the Edit page. This makes the following adjustments:

1) Successfully creating/updating an Adviser redirects to the Adviser index page.
2) Successfully creating/updating an Office redirects to the Office index page.
3) The Firm still redirects to the Edit page as there is another change coming through which requires this behaviour.