### PR TITLE
Registration - new onboarding message

### DIFF
--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -46,17 +46,6 @@ module SelfService
         .join(', ')
     end
 
-    def render_onboarding_message
-      return if current_user.principal.onboarded?
-
-      content_for :notifications do
-        render 'shared/notification', name: 'onboarding',
-                                      title: t('self_service.onboarding.title'),
-                                      msg: t('self_service.onboarding.message'),
-                                      test_class: 't-onboarding-message'
-      end
-    end
-
     def first_registered_firm_for(principal)
       principal.main_firm_with_trading_names.registered.first
     end

--- a/app/views/self_service/advisers/edit.html.erb
+++ b/app/views/self_service/advisers/edit.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_adviser_edit) %>
-<% render_onboarding_message %>
 
 <h1>
   <%= t('self_service.adviser_edit.title', adviser_name: @adviser.name) %>

--- a/app/views/self_service/advisers/index.html.erb
+++ b/app/views/self_service/advisers/index.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_advisers) %>
-<% render_onboarding_message %>
 
 
 <div class="l-heading-with-button">

--- a/app/views/self_service/advisers/new.html.erb
+++ b/app/views/self_service/advisers/new.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_adviser_new) %>
-<% render_onboarding_message %>
 
 <h1>
   <%= t('self_service.adviser_new.title', firm_name: @firm.registered_name) %>

--- a/app/views/self_service/firms/_onboarding_message.html.erb
+++ b/app/views/self_service/firms/_onboarding_message.html.erb
@@ -1,0 +1,10 @@
+<div class="panel t-onboarding-message">
+  <p>
+    Welcome. In order for us to display your firm(s) or trading name(s) on the Retirement Adviser Directory (RAD), we need a bit more information. You need to fill out details for at least one firm or trading name, and include at least one office and one adviser.
+  </p>
+  <p>
+    Wherever you see
+    <%= status_icon('exclamation') %>
+    it means there is something that needs more information.
+  </p>
+</div>

--- a/app/views/self_service/firms/edit.html.erb
+++ b/app/views/self_service/firms/edit.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_edit) %>
-<% render_onboarding_message %>
 
 <div class="l-heading-with-inline-links">
   <h1 class="t-firm-name">

--- a/app/views/self_service/firms/index.html.erb
+++ b/app/views/self_service/firms/index.html.erb
@@ -1,5 +1,6 @@
 <% render_breadcrumbs(breadcrumbs_root) %>
-<% render_onboarding_message %>
+
+<%= render 'onboarding_message' unless current_user.principal.onboarded? %>
 
 <h1 class="t-page-title">
   <%= t('self_service.firms_index.title', count: @presenter.total_firms) %>

--- a/app/views/self_service/offices/edit.html.erb
+++ b/app/views/self_service/offices/edit.html.erb
@@ -1,5 +1,4 @@
 <%= render_breadcrumbs(breadcrumbs_firm_office_edit) %>
-<% render_onboarding_message %>
 
 <h1>
   <%= t('self_service.office_edit.title', postcode: @office.address_postcode) %>

--- a/app/views/self_service/offices/index.html.erb
+++ b/app/views/self_service/offices/index.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_offices) %>
-<% render_onboarding_message %>
 
 
 <div class="l-heading-with-button">

--- a/app/views/self_service/offices/new.html.erb
+++ b/app/views/self_service/offices/new.html.erb
@@ -1,5 +1,4 @@
 <%= render_breadcrumbs(breadcrumbs_firm_office_new) %>
-<% render_onboarding_message %>
 
 <h1>
   <%= t('self_service.office_new.title', firm_name: @firm.registered_name) %>

--- a/app/views/self_service/trading_names/edit.html.erb
+++ b/app/views/self_service/trading_names/edit.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_firm_edit) %>
-<% render_onboarding_message %>
 
 <div class="l-heading-with-inline-links">
   <h1 class="t-firm-name">

--- a/app/views/self_service/trading_names/new.html.erb
+++ b/app/views/self_service/trading_names/new.html.erb
@@ -1,5 +1,4 @@
 <% render_breadcrumbs(breadcrumbs_trading_name_new) %>
-<% render_onboarding_message %>
 
 <h1 class="t-firm-name">
   <%= t('self_service.trading_name_new.title', firm_name: @firm.registered_name) %>

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -43,7 +43,3 @@ en:
       breadcrumb: "%{firm_name}"
       title: "Edit: %{firm_name}"
       saved: The trading name has been saved
-
-    onboarding:
-      title: Welcome
-      message: Please enter details about your firm, advisers and offices to add it to the directory

--- a/spec/features/self_service/firms_index_spec.rb
+++ b/spec/features/self_service/firms_index_spec.rb
@@ -132,14 +132,14 @@ RSpec.feature 'The self service firm list page' do
   end
 
   def and_one_of_those_trading_names_is_unpublishable
-    unpublished_trading_name = @principal.firm.trading_names.first
-    unpublished_trading_name.offices = []
-    expect(unpublished_trading_name).not_to be_publishable
+    @unpublished_trading_name = @principal.firm.trading_names.first
+    @unpublished_trading_name.offices = []
+    expect(@unpublished_trading_name).not_to be_publishable
   end
 
   def and_one_of_those_trading_names_is_publishable
-    published_trading_name = @principal.firm.trading_names.first
-    expect(published_trading_name).to be_publishable
+    @published_trading_name = @principal.firm.trading_names.first
+    expect(@published_trading_name).to be_publishable
   end
 
   def and_i_am_logged_in
@@ -254,14 +254,22 @@ RSpec.feature 'The self service firm list page' do
 
   def and_the_trading_name_overall_status_is_unpublished
     expected_text = I18n.t!('self_service.firms_index.status.unpublished')
-    expect(firms_index_page.trading_names.first.overall_status).to have_text(expected_text)
-    expect(firms_index_page.trading_names.first).to have_unpublished
+    trading_name = firms_index_page.trading_names.find do |tn|
+      tn.name.text == @unpublished_trading_name.registered_name
+    end
+
+    expect(trading_name.overall_status).to have_text(expected_text)
+    expect(trading_name).to have_unpublished
   end
 
   def and_the_trading_name_overall_status_is_published
     expected_text = I18n.t!('self_service.firms_index.status.published')
-    expect(firms_index_page.trading_names.first.overall_status).to have_text(expected_text)
-    expect(firms_index_page.trading_names.first).to have_published
+    trading_name = firms_index_page.trading_names.find do |tn|
+      tn.name.text == @published_trading_name.registered_name
+    end
+
+    expect(trading_name.overall_status).to have_text(expected_text)
+    expect(trading_name).to have_published
   end
 
   private

--- a/spec/features/self_service/firms_index_spec.rb
+++ b/spec/features/self_service/firms_index_spec.rb
@@ -49,6 +49,22 @@ RSpec.feature 'The self service firm list page' do
     and_i_can_see_a_success_message
   end
 
+  scenario 'when the principal is not onboarded' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_have_no_publishable_firms
+    when_i_am_logged_in
+    and_i_am_on_the_principals_firms_index_page
+    then_i_can_see_the_onboading_message
+  end
+
+  scenario 'when the principal is onboarded' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_have_publishable_firms
+    when_i_am_logged_in
+    and_i_am_on_the_principals_firms_index_page
+    then_i_can_not_see_the_onboading_message
+  end
+
   scenario 'when the parent firm is not published' do
     given_i_am_a_fully_registered_principal_user
     and_i_have_an_unpublished_firm
@@ -124,12 +140,14 @@ RSpec.feature 'The self service firm list page' do
 
     expect(@firm).to be_publishable
   end
+  alias_method :and_i_have_publishable_firms, :and_i_have_a_published_firm
 
   def and_i_have_an_unpublished_firm
     @firm = @principal.firm
 
     expect(@firm).not_to be_publishable
   end
+  alias_method :and_i_have_no_publishable_firms, :and_i_have_an_unpublished_firm
 
   def and_one_of_those_trading_names_is_unpublishable
     @unpublished_trading_name = @principal.firm.trading_names.first
@@ -270,6 +288,14 @@ RSpec.feature 'The self service firm list page' do
 
     expect(trading_name.overall_status).to have_text(expected_text)
     expect(trading_name).to have_published
+  end
+
+  def then_i_can_see_the_onboading_message
+    expect(firms_index_page).to have_onboarding_message
+  end
+
+  def then_i_can_not_see_the_onboading_message
+    expect(firms_index_page).not_to have_onboarding_message
   end
 
   private

--- a/spec/support/self_service/firms_index_page.rb
+++ b/spec/support/self_service/firms_index_page.rb
@@ -13,5 +13,6 @@ module SelfService
     element :available_trading_names_block, '.t-available-trading-names-block'
     sections :available_trading_names, FirmTableRowSection, '.t-available-trading-name-table-row'
     section :navigation, NavigationSection, '.t-navigation'
+    element :onboarding_message, '.t-onboarding-message'
   end
 end


### PR DESCRIPTION
The original onboarding message was confusing as it looked like a flash message and would sometimes visually conflict with other flash messages being displayed. The onboarding message is now just a flat grey panel and contains more descriptive text.

We also now only show this message on the Firm index page as we have a separate message (being built on another card) on the other pages.

![screenshot 2016-02-24 14 59 11](https://cloud.githubusercontent.com/assets/52965/13289270/58272da2-db07-11e5-8812-793e541203aa.png)
