### PR TITLE
Registration - change remove button text

### DIFF
--- a/app/assets/stylesheets/components/_firms_table.scss
+++ b/app/assets/stylesheets/components/_firms_table.scss
@@ -1,7 +1,7 @@
 .firms-table {
   width: 100%;
 
-  .firms-table__frn {
+  .firms-table__frn, .firms-table__action {
     width: 10%;
   }
 

--- a/config/locales/self_service/firms_index.en.yml
+++ b/config/locales/self_service/firms_index.en.yml
@@ -17,7 +17,7 @@ en:
       trading_names_filter_placeholder: e.g. firm name
       available_trading_names_filter_placeholder: e.g. firm name
       new_trading_name_link: Add to directory
-      delete_trading_name_button: Remove from Directory
+      delete_trading_name_button: Remove
       delete_trading_name_confirmation: Are you sure you want to remove %{name} and all associated advisers from the directory?
       status:
         published: Visible on directory


### PR DESCRIPTION
This PR simply changes the text on a button from "Remove from directory" to "Remove" as it was felt that the original text was confusing.

## Before

![screenshot 2016-02-24 15 36 54](https://cloud.githubusercontent.com/assets/52965/13290649/832d5eea-db0c-11e5-895c-76badbcd3580.png)

## After

![screenshot 2016-02-24 15 37 08](https://cloud.githubusercontent.com/assets/52965/13290659/8a927efe-db0c-11e5-83d8-6fdbe0ada562.png)
