### PR TITLE
[DEV APPROVED] Registration - status on edit pages

### DIFF
--- a/app/presenters/self_service/status_presenter.rb
+++ b/app/presenters/self_service/status_presenter.rb
@@ -16,7 +16,7 @@ module SelfService
     end
 
     def advisers_icon
-      icon_toggle(remote? || advisers.any?)
+      icon_toggle advisers?
     end
 
     def offices_icon
@@ -57,6 +57,14 @@ module SelfService
       link_to text, path, opts
     end
 
+    def needs_advisers?
+      !advisers?
+    end
+
+    def needs_offices?
+      offices.none?
+    end
+
     private
 
     def icon_toggle(condition_met)
@@ -65,6 +73,10 @@ module SelfService
 
     def remote?
       primary_advice_method == :remote
+    end
+
+    def advisers?
+      remote? || advisers.any?
     end
   end
 end

--- a/app/presenters/self_service/status_presenter.rb
+++ b/app/presenters/self_service/status_presenter.rb
@@ -1,48 +1,44 @@
 module SelfService
-  class StatusPresenter
+  class StatusPresenter < SimpleDelegator
     include Rails.application.routes.url_helpers
     include ActionView::Helpers::UrlHelper
 
-    def initialize(firm)
-      @firm = firm
-    end
-
     def overall_status
-      @firm.publishable? ? 'published' : 'unpublished'
+      publishable? ? 'published' : 'unpublished'
     end
 
     def overall_status_icon
-      icon_toggle @firm.publishable?
+      icon_toggle publishable?
     end
 
     def firm_details_icon
-      icon_toggle @firm.registered?
+      icon_toggle registered?
     end
 
     def advisers_icon
-      icon_toggle(remote? || @firm.advisers.any?)
+      icon_toggle(remote? || advisers.any?)
     end
 
     def offices_icon
-      icon_toggle @firm.offices.any?
+      icon_toggle offices.any?
     end
 
     def firm_details_link(opts = {})
-      path = if @firm.trading_name?
-               edit_self_service_trading_name_path(@firm)
+      path = if trading_name?
+               edit_self_service_trading_name_path(self)
              else
-               edit_self_service_firm_path(@firm)
+               edit_self_service_firm_path(self)
              end
 
       link_to I18n.t('self_service.firms_index.status.edit'), path, opts
     end
 
     def advisers_link(opts = {})
-      if @firm.advisers.present?
-        path = self_service_firm_advisers_path(@firm)
+      if advisers.present?
+        path = self_service_firm_advisers_path(self)
         text = I18n.t('self_service.firms_index.status.edit')
       else
-        path = new_self_service_firm_adviser_path(@firm)
+        path = new_self_service_firm_adviser_path(self)
         text = I18n.t('self_service.firms_index.status.add')
       end
 
@@ -50,23 +46,15 @@ module SelfService
     end
 
     def offices_link(opts = {})
-      if @firm.offices.present?
-        path = self_service_firm_offices_path(@firm)
+      if offices.present?
+        path = self_service_firm_offices_path(self)
         text = I18n.t('self_service.firms_index.status.edit')
       else
-        path = new_self_service_firm_office_path(@firm)
+        path = new_self_service_firm_office_path(self)
         text = I18n.t('self_service.firms_index.status.add')
       end
 
       link_to text, path, opts
-    end
-
-    def advisers_count
-      @firm.advisers.count
-    end
-
-    def offices_count
-      @firm.offices.count
     end
 
     private
@@ -76,7 +64,7 @@ module SelfService
     end
 
     def remote?
-      @firm.primary_advice_method == :remote
+      primary_advice_method == :remote
     end
   end
 end

--- a/app/views/self_service/firms/_status.html.erb
+++ b/app/views/self_service/firms/_status.html.erb
@@ -17,7 +17,7 @@
   <div class="l-2col-main">
     <%= status_icon(presenter.advisers_icon) %>
     <%= t("self_service.firms_index.status.advisers") %>
-    (<%= presenter.advisers_count %>)
+    (<%= presenter.advisers.count %>)
   </div>
   <div class="l-2col-side l-2col-side--align-right">
     <%= presenter.advisers_link(class: 'button button--small') %>
@@ -28,7 +28,7 @@
   <div class="l-2col-main">
     <%= status_icon(presenter.offices_icon) %>
     <%= t("self_service.firms_index.status.offices") %>
-    (<%= presenter.offices_count %>)
+    (<%= presenter.offices.count %>)
   </div>
   <div class="l-2col-side l-2col-side--align-right">
     <%= presenter.offices_link(class: 'button button--small') %>

--- a/app/views/self_service/shared/_header_and_nav.html.erb
+++ b/app/views/self_service/shared/_header_and_nav.html.erb
@@ -6,6 +6,8 @@
   <%= firm.registered_name %>
 </h1>
 
+<%= render 'self_service/shared/overall_status_panel', presenter: SelfService::StatusPresenter.new(firm) %>
+
 <div class="tab-selector tab-selector--without-js">
   <div class="tab-selector__triggers-outer">
     <div class="tab-selector__triggers-inner">

--- a/app/views/self_service/shared/_overall_status_panel.html.erb
+++ b/app/views/self_service/shared/_overall_status_panel.html.erb
@@ -1,4 +1,4 @@
-<div class="panel">
+<div class="panel t-overall-status-panel">
   <% if presenter.publishable? %>
     <%= status_icon('tick') %>
     <%= t('self_service.status.published') %>

--- a/app/views/self_service/shared/_overall_status_panel.html.erb
+++ b/app/views/self_service/shared/_overall_status_panel.html.erb
@@ -1,0 +1,20 @@
+<div class="panel">
+  <% if presenter.publishable? %>
+    <%= status_icon('tick') %>
+    Visible on the directory
+  <% end %>
+
+  <% if presenter.needs_advisers? %>
+    <div>
+      <%= status_icon('exclamation') %>
+      You need to add one or more advisers
+    </div>
+  <% end %>
+
+  <% if presenter.needs_offices? %>
+    <div>
+      <%= status_icon('exclamation') %>
+      You need to add one or more offices
+    </div>
+  <% end %>
+</div>

--- a/app/views/self_service/shared/_overall_status_panel.html.erb
+++ b/app/views/self_service/shared/_overall_status_panel.html.erb
@@ -1,20 +1,20 @@
 <div class="panel">
   <% if presenter.publishable? %>
     <%= status_icon('tick') %>
-    Visible on the directory
+    <%= t('self_service.status.published') %>
   <% end %>
 
   <% if presenter.needs_advisers? %>
     <div>
       <%= status_icon('exclamation') %>
-      You need to add one or more advisers
+      <%= t('self_service.status.needs_advisers') %>
     </div>
   <% end %>
 
   <% if presenter.needs_offices? %>
     <div>
       <%= status_icon('exclamation') %>
-      You need to add one or more offices
+      <%= t('self_service.status.needs_offices') %>
     </div>
   <% end %>
 </div>

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -33,6 +33,11 @@ en:
     office_destroy:
       deleted: "The %{postcode} office has been successfully removed."
 
+    status:
+      published: Visible on directory
+      needs_advisers: You need to add one or more advisers
+      needs_offices: You need to add one or more offices
+
     trading_name_destroy:
       deleted: "%{name} has been successfully removed."
 

--- a/spec/features/self_service/advisers_index_spec.rb
+++ b/spec/features/self_service/advisers_index_spec.rb
@@ -13,6 +13,18 @@ RSpec.feature 'The self service adviser list page' do
     then_i_see_a_back_to_firms_list_link
   end
 
+  scenario 'The principal can see the overall status panel for the firm' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    and_i_have_a_firm_with_trading_names_and_advisers
+
+    when_i_am_on_the_advisers_page_for(firm: @principal.firm)
+    then_i_can_see_the_overall_status_panel
+
+    when_i_am_on_the_advisers_page_for(firm: @principal.firm.trading_names.first)
+    then_i_can_see_the_overall_status_panel
+  end
+
   scenario 'The principal can see a list of the advisers on their parent firm' do
     given_i_am_a_fully_registered_principal_user
     and_i_am_logged_in
@@ -111,6 +123,10 @@ RSpec.feature 'The self service adviser list page' do
 
   def then_i_see_a_back_to_firms_list_link
     expect(advisers_index_page).to have_back_to_firms_list_link
+  end
+
+  def then_i_can_see_the_overall_status_panel
+    expect(advisers_index_page).to have_overall_status_panel
   end
 
   private

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -27,6 +27,16 @@ RSpec.feature 'The self service firm edit page' do
     then_i_see_a_back_to_firms_list_link
   end
 
+  scenario 'The principal can see the overall status panel of their firm' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_have_a_firm
+    and_i_am_logged_in
+    when_i_am_on_the_firms_page
+    and_i_click_the_edit_link_for_my_firm
+    then_i_see_the_edit_page_for_my_firm
+    then_i_can_see_the_overall_status_panel
+  end
+
   scenario 'The principal can edit their firm' do
     given_i_am_a_fully_registered_principal_user
     and_i_have_a_firm
@@ -121,6 +131,10 @@ RSpec.feature 'The self service firm edit page' do
 
   def then_i_see_a_back_to_firms_list_link
     expect(firm_edit_page).to have_back_to_firms_list_link
+  end
+
+  def then_i_can_see_the_overall_status_panel
+    expect(firm_edit_page).to have_overall_status_panel
   end
 
   def complete_part_1

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -28,6 +28,14 @@ RSpec.feature 'The self service firm offices list page' do
     then_i_see_a_back_to_firms_list_link
   end
 
+  scenario 'The page shows the overall status panel for the given firm' do
+    given_i_am_a_fully_registered_principal_user
+    and_my_firm_has_offices
+    and_i_am_logged_in
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_i_can_see_the_overall_status_panel
+  end
+
   scenario 'The page shows the list of offices for the given firm' do
     given_i_am_a_fully_registered_principal_user
     and_my_firm_has_offices
@@ -140,6 +148,10 @@ RSpec.feature 'The self service firm offices list page' do
 
   def then_i_see_a_back_to_firms_list_link
     expect(offices_index_page).to have_back_to_firms_list_link
+  end
+
+  def then_i_can_see_the_overall_status_panel
+    expect(offices_index_page).to have_overall_status_panel
   end
 
   private

--- a/spec/presenters/self_service/status_presenter_spec.rb
+++ b/spec/presenters/self_service/status_presenter_spec.rb
@@ -210,4 +210,88 @@ RSpec.describe SelfService::StatusPresenter do
       end
     end
   end
+
+  describe '#needs_advisers?' do
+    before { allow(firm).to receive(:advisers).and_return(advisers) }
+
+    context 'when the firm has advisers' do
+      let(:advisers) { ['an adviser'] }
+
+      before { allow(firm).to receive(:primary_advice_method).and_return(primary_advice_method) }
+
+      context 'and is local' do
+        let(:primary_advice_method) { :local }
+
+        it 'is false' do
+          expect(presenter.needs_advisers?).to eq(false)
+        end
+      end
+
+      context 'and is remote' do
+        let(:primary_advice_method) { :remote }
+
+        it 'is false' do
+          expect(presenter.needs_advisers?).to eq(false)
+        end
+      end
+
+      context 'and is nil' do
+        let(:primary_advice_method) { nil }
+
+        it 'is false' do
+          expect(presenter.needs_advisers?).to eq(false)
+        end
+      end
+    end
+
+    context 'when the firm has no advisers' do
+      let(:advisers) { [] }
+
+      before { allow(firm).to receive(:primary_advice_method).and_return(primary_advice_method) }
+
+      context 'and is local' do
+        let(:primary_advice_method) { :local }
+
+        it 'is true' do
+          expect(presenter.needs_advisers?).to eq(true)
+        end
+      end
+
+      context 'and is remote' do
+        let(:primary_advice_method) { :remote }
+
+        it 'is false' do
+          expect(presenter.needs_advisers?).to eq(false)
+        end
+      end
+
+      context 'and is nil' do
+        let(:primary_advice_method) { nil }
+
+        it 'provides "exclamation"' do
+          expect(presenter.needs_advisers?).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe '#needs_offices?' do
+    before { allow(firm).to receive(:offices).and_return(offices) }
+
+    context 'when the firm has offices' do
+      let(:offices) { ['an office'] }
+
+      it 'is false' do
+        expect(presenter.needs_offices?).to eq(false)
+      end
+    end
+
+    context 'when the firm has no offices' do
+      let(:offices) { [] }
+
+      it 'is true' do
+        expect(presenter.needs_offices?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/presenters/self_service/status_presenter_spec.rb
+++ b/spec/presenters/self_service/status_presenter_spec.rb
@@ -210,18 +210,4 @@ RSpec.describe SelfService::StatusPresenter do
       end
     end
   end
-
-  describe '#advisers_count' do
-    it 'shows the number of advisers for the given firm' do
-      allow(firm).to receive(:advisers).and_return(%w(adviser_1 adviser_2))
-      expect(presenter.advisers_count).to eq(2)
-    end
-  end
-
-  describe '#offices_count' do
-    it 'shows the number of offices for the given firm' do
-      allow(firm).to receive(:offices).and_return(%w(office_1 office_2 office_3))
-      expect(presenter.offices_count).to eq(3)
-    end
-  end
 end

--- a/spec/support/self_service/advisers_index_page.rb
+++ b/spec/support/self_service/advisers_index_page.rb
@@ -5,6 +5,7 @@ module SelfService
 
     element :back_to_firms_list_link, '.t-back-to-firm-list a'
     element :firm_name, '.t-firm-name'
+    element :overall_status_panel, '.t-overall-status-panel'
     sections :advisers, AdvisersTableRowSection, '.t-advisers-table-row'
     element :add_adviser_link, '.t-add-adviser-link'
     element :edit_link, '.t-edit-link'

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -10,6 +10,8 @@ module SelfService
     element :firm_name, '.t-firm-name'
     element :firm_fca_number, '.t-firm-fca-number'
 
+    element :overall_status_panel, '.t-overall-status-panel'
+
     element :website_address, '.t-website-address'
 
     elements :in_person_advice_methods, '.t-questionnaire__in-person-advice-method-id'

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -7,6 +7,7 @@ module SelfService
 
     element :back_to_firms_list_link, '.t-back-to-firm-list a'
     element :page_title, '.t-firm-name'
+    element :overall_status_panel, '.t-overall-status-panel'
     sections :offices, OfficesTableRowSection, '.t-office-table-row'
     element :add_office_link, '.t-add-office-link'
     element :no_offices_message, '.t-no-offices-message'


### PR DESCRIPTION
**N.B. needs the tabs branch to be merged first**

This PR introduces an overall status panel to the top of the Firm edit, Adviser index Office index pages so that the user can easily see what the current published status is for that firm.

## When a firm is visible on the directory

![screenshot 2016-02-25 11 25 16](https://cloud.githubusercontent.com/assets/52965/13318460/b4c435ea-dbb2-11e5-9af4-5f27d1fdddfb.png)

## When the firm needs more information

![screenshot 2016-02-25 11 25 36](https://cloud.githubusercontent.com/assets/52965/13318463/bb48410e-dbb2-11e5-8d36-fbe1d61f8eae.png)
