### PR TITLE
Registration - back to firms list link

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -8,6 +8,7 @@
 @import 'states/hidden';
 
 @import 'layouts/2col';
+@import 'layouts/back_link';
 @import 'layouts/constrained';
 @import 'layouts/content';
 @import 'layouts/footer';

--- a/app/assets/stylesheets/layouts/_back_link.scss
+++ b/app/assets/stylesheets/layouts/_back_link.scss
@@ -1,0 +1,3 @@
+.l-back-link {
+  margin-top: $baseline-unit*3;
+}

--- a/app/views/self_service/shared/_header_and_nav.html.erb
+++ b/app/views/self_service/shared/_header_and_nav.html.erb
@@ -1,3 +1,7 @@
+<div class="l-back-link t-back-to-firm-list">
+  <%= link_to '< Back to firm list', self_service_root_path %>
+</div>
+
 <h1 class="t-firm-name">
   <%= firm.registered_name %>
 </h1>

--- a/spec/features/self_service/advisers_index_spec.rb
+++ b/spec/features/self_service/advisers_index_spec.rb
@@ -1,6 +1,18 @@
 RSpec.feature 'The self service adviser list page' do
   let(:advisers_index_page) { SelfService::AdvisersIndexPage.new }
 
+  scenario 'The principal can see a back to firms list link' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in
+    and_i_have_a_firm_with_trading_names_and_advisers
+
+    when_i_am_on_the_advisers_page_for(firm: @principal.firm)
+    then_i_see_a_back_to_firms_list_link
+
+    when_i_am_on_the_advisers_page_for(firm: @principal.firm.trading_names.first)
+    then_i_see_a_back_to_firms_list_link
+  end
+
   scenario 'The principal can see a list of the advisers on their parent firm' do
     given_i_am_a_fully_registered_principal_user
     and_i_am_logged_in
@@ -95,6 +107,10 @@ RSpec.feature 'The self service adviser list page' do
     expect(advisers_index_page).to have_no_advisers_message(
       text: I18n.t('self_service.advisers_index.no_advisers_message'))
     expect(advisers_index_page).to have_add_adviser_link
+  end
+
+  def then_i_see_a_back_to_firms_list_link
+    expect(advisers_index_page).to have_back_to_firms_list_link
   end
 
   private

--- a/spec/features/self_service/firms_edit_spec.rb
+++ b/spec/features/self_service/firms_edit_spec.rb
@@ -17,6 +17,16 @@ RSpec.feature 'The self service firm edit page' do
                       languages: ['fra'])
   end
 
+  scenario 'The principal can see a back to firms list link' do
+    given_i_am_a_fully_registered_principal_user
+    and_i_have_a_firm
+    and_i_am_logged_in
+    when_i_am_on_the_firms_page
+    and_i_click_the_edit_link_for_my_firm
+    then_i_see_the_edit_page_for_my_firm
+    then_i_see_a_back_to_firms_list_link
+  end
+
   scenario 'The principal can edit their firm' do
     given_i_am_a_fully_registered_principal_user
     and_i_have_a_firm
@@ -107,6 +117,10 @@ RSpec.feature 'The self service firm edit page' do
     expect(firm_edit_page.website_address.value).to eq 'clearly_not_a_valid_web_address!'
     @principal.reload
     expect(@principal.firm.website_address).to eq @original_firm_website
+  end
+
+  def then_i_see_a_back_to_firms_list_link
+    expect(firm_edit_page).to have_back_to_firms_list_link
   end
 
   def complete_part_1

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -20,6 +20,14 @@ RSpec.feature 'The self service firm offices list page' do
     then_i_see_the_firm_name_in_the_page_title
   end
 
+  scenario 'The principal can see a back to firms list link' do
+    given_i_am_a_fully_registered_principal_user
+    and_my_firm_has_offices
+    and_i_am_logged_in
+    when_i_navigate_to_the_offices_page_for_my_firm
+    then_i_see_a_back_to_firms_list_link
+  end
+
   scenario 'The page shows the list of offices for the given firm' do
     given_i_am_a_fully_registered_principal_user
     and_my_firm_has_offices
@@ -128,6 +136,10 @@ RSpec.feature 'The self service firm offices list page' do
 
   def then_there_is_one_less_office
     expect(offices_index_page.offices.count).to eq(@num_offices_before - 1)
+  end
+
+  def then_i_see_a_back_to_firms_list_link
+    expect(offices_index_page).to have_back_to_firms_list_link
   end
 
   private

--- a/spec/support/self_service/advisers_index_page.rb
+++ b/spec/support/self_service/advisers_index_page.rb
@@ -3,6 +3,7 @@ module SelfService
     set_url '/self_service/firms/{firm_id}/advisers'
     set_url_matcher %r{/self_service/firms/\d+/advisers}
 
+    element :back_to_firms_list_link, '.t-back-to-firm-list a'
     element :firm_name, '.t-firm-name'
     sections :advisers, AdvisersTableRowSection, '.t-advisers-table-row'
     element :add_adviser_link, '.t-add-adviser-link'

--- a/spec/support/self_service/firm_edit_page.rb
+++ b/spec/support/self_service/firm_edit_page.rb
@@ -6,6 +6,7 @@ module SelfService
     element :flash_message, '.t-flash-message'
     element :validation_summary, '.t-validation-summary'
 
+    element :back_to_firms_list_link, '.t-back-to-firm-list a'
     element :firm_name, '.t-firm-name'
     element :firm_fca_number, '.t-firm-fca-number'
 

--- a/spec/support/self_service/offices_index_page.rb
+++ b/spec/support/self_service/offices_index_page.rb
@@ -5,6 +5,7 @@ module SelfService
     set_url '/self_service/firms/{firm_id}/offices'
     set_url_matcher %r{/self_service/firms/\d+/offices}
 
+    element :back_to_firms_list_link, '.t-back-to-firm-list a'
     element :page_title, '.t-firm-name'
     sections :offices, OfficesTableRowSection, '.t-office-table-row'
     element :add_office_link, '.t-add-office-link'


### PR DESCRIPTION
**N.B. needs the tabs branch to be merged first**

This is a very simple PR, it just adds a [< Back to firms list]() link to the top of the Firm edit, Adviser index and Offices index pages so that the user can easily get back to the firm list page.

![screenshot 2016-02-25 12 00 55](https://cloud.githubusercontent.com/assets/52965/13319136/7613dd3c-dbb7-11e5-8a20-65fdd2d38ee1.png)
