### PR TITLE
Add edit principal link to the top navigation

### DIFF
--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,3 +1,7 @@
 .l-header {
   height: $baseline-unit*12;
 }
+
+.l-header .mas-logo {
+  width: 30%;
+}

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -11,11 +11,14 @@
       <li class='navigation__item'>
         <%= link_to t('self_service.navigation.root'), self_service_root_path, class: 'navigation__link t-navigation-link' %>
       </li>
-      <li class='navigation__item'>
-        <%= link_to t('authentication_sign_out'), destroy_user_session_path, class: 'navigation__link t-sign-out' %>
+      <li class='navigation__item--desktop-only'>
+        <%= link_to t('self_service.navigation.edit_principal'), edit_self_service_principal_path(@current_user.principal), class: 'navigation__link t-navigation-link' %>
       </li>
       <li class='navigation__item--desktop-only'>
         <%= link_to t('authentication.edit_account'), edit_user_registration_path, class: 'navigation__link' %>
+      </li>
+      <li class='navigation__item'>
+        <%= link_to t('authentication_sign_out'), destroy_user_session_path, class: 'navigation__link t-sign-out' %>
       </li>
     <% end %>
   </ul>

--- a/config/locales/self_service.en.yml
+++ b/config/locales/self_service.en.yml
@@ -10,6 +10,7 @@ en:
     navigation: # name according to route name
       root: Home
       firms: Firms
+      edit_principal: Edit principal
 
     adviser_edit:
       breadcrumb: "%{adviser_name}"


### PR DESCRIPTION
In order to make it easier to find, we've moved the [Edit principal]() link to the top navigation links.

## Before

![screenshot 2016-02-25 12 32 25](https://cloud.githubusercontent.com/assets/52965/13325363/67020e28-dbd9-11e5-96eb-68e6b9f58990.png)

## After

![screenshot 2016-02-25 16 29 26](https://cloud.githubusercontent.com/assets/52965/13326232/f63a2e9c-dbdc-11e5-8e2f-055ea3d0da93.png)
