### PR TITLE
Provide a way for MAS admins to delete an entire firm

### DIFF
--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -10,10 +10,15 @@ class Admin::PrincipalsController < Admin::ApplicationController
 
   def destroy
     user = User.find_by(principal: principal)
+
+    message = "Successfully deleted #{principal.full_name}, " \
+              "#{principal.firm.registered_name} and " \
+              "#{principal.firm.trading_names.count} related trading names."
+
     user.principal.destroy
     user.destroy
 
-    redirect_to admin_principals_path
+    redirect_to admin_principals_path, notice: message
   end
 
   private

--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -8,6 +8,14 @@ class Admin::PrincipalsController < Admin::ApplicationController
     @principal = principal
   end
 
+  def destroy
+    user = User.find_by(principal: principal)
+    user.principal.destroy
+    user.destroy
+
+    redirect_to admin_principals_path
+  end
+
   private
 
   def principal

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -29,4 +29,15 @@
   </div>
 </div>
 
-<%= render 'admin/shared/sign_in_as_principal', principal: @principal %>
+<div class="row">
+  <div class="col-xs-6">
+    <%= render 'admin/shared/sign_in_as_principal', principal: @principal %>
+  </div>
+  <div class="col-xs-6 text-right">
+    <%= button_to 'Delete principal and entire firm',
+                  admin_principal_path(@principal.id),
+                  class: 't-delete btn btn-danger',
+                  method: :delete,
+                  data: { confirm: 'Are you sure you want to delete this principal and all related firm, adviser, office and trading name data?' } %></p>
+  </div>
+</div>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -34,7 +34,7 @@
     <%= render 'admin/shared/sign_in_as_principal', principal: @principal %>
   </div>
   <div class="col-xs-6 text-right">
-    <%= button_to 'Delete principal and entire firm',
+    <%= button_to 'Delete principal, firm and all related trading names',
                   admin_principal_path(@principal.id),
                   class: 't-delete btn btn-danger',
                   method: :delete,

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -42,6 +42,12 @@
 </nav>
 
 <div class="container">
+  <% if flash.notice %>
+    <div class="t-flash-message alert alert-warning" role="alert">
+      <%= flash.notice %>
+    </div>
+  <% end %>
+
   <%= yield %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
       resources :firms, only: :index
       resources :subsidiaries, only: :index
     end
-    resources :principals, only: [:index, :show]
+    resources :principals, only: [:index, :show, :destroy]
     resources :metrics, only: [:index, :show] do
       member do
         get :download

--- a/spec/features/admin/delete_principal_and_entire_firm_spec.rb
+++ b/spec/features/admin/delete_principal_and_entire_firm_spec.rb
@@ -47,4 +47,5 @@ end
 
 def and_i_am_redirected_to_the_principal_list_page
   expect(page.current_path).to eq admin_principals_path
+  expect(find('.t-flash-message')).to have_text('Successfully deleted')
 end

--- a/spec/features/admin/delete_principal_and_entire_firm_spec.rb
+++ b/spec/features/admin/delete_principal_and_entire_firm_spec.rb
@@ -1,0 +1,50 @@
+RSpec.feature 'Deleting principal and all related firm, adviser, office and trading name data' do
+  let(:admin_principal_page) { Admin::EditPrincipalPage.new }
+
+  scenario 'Admin deletes a principal and all related data' do
+    given_there_is_firm
+    when_i_visit_the_principal_page
+    and_i_click_delete
+    then_the_principal_and_all_related_data_is_removed
+    and_i_am_redirected_to_the_principal_list_page
+  end
+end
+
+def given_there_is_firm
+  @firm = FactoryGirl.create(:firm_with_trading_names, :with_principal)
+  @principal = @firm.principal
+  @principal.update(firm: @firm)
+  @user = FactoryGirl.create(:user, principal: @principal)
+
+  expect(User.find_by(principal: @principal)).to eq(@user)
+  expect(@principal).not_to be_nil
+  expect(@firm.offices.count).to be(1)
+  expect(@firm.advisers.count).to be(1)
+  expect(@firm.trading_names.count).to be(3)
+
+  @office = @firm.offices[0]
+  @adviser = @firm.advisers[0]
+  @trading_name = @firm.trading_names[0]
+end
+
+def when_i_visit_the_principal_page
+  admin_principal_page.load(principal_token: @principal.id)
+  expect(admin_principal_page).to be_displayed
+end
+
+def and_i_click_delete
+  admin_principal_page.delete.click
+end
+
+def then_the_principal_and_all_related_data_is_removed
+  expect(Principal.exists?(@principal.id)).to be(false)
+  expect(Firm.exists?(@firm.id)).to be(false)
+  expect(User.exists?(@user.id)).to be(false)
+  expect(Office.exists?(@office.id)).to be(false)
+  expect(Adviser.exists?(@adviser.id)).to be(false)
+  expect(Firm.exists?(@trading_name.id)).to be(false)
+end
+
+def and_i_am_redirected_to_the_principal_list_page
+  expect(page.current_path).to eq admin_principals_path
+end

--- a/spec/support/admin/edit_principal_page.rb
+++ b/spec/support/admin/edit_principal_page.rb
@@ -1,0 +1,6 @@
+class Admin::EditPrincipalPage < SitePrism::Page
+  set_url '/admin/principals/{principal_token}'
+  set_url_matcher %r{/admin/principals/[a-z0-9]+}
+
+  element :delete, '.t-delete'
+end


### PR DESCRIPTION
# What?

Adds a button to the private MAS admin UI that allows deletion of a firm and all related trading names from the directory.

**Note** Counter-intuitively this is done by deleting the principal as the principal object "owns" the parent firm and trading names so deleting that cascades through correctly.

# Why?

Whenever firms disappear from the FCA register or ask to be taken off of the directory we need a way to delete them. IIRC the frequency has been about 2 or 3 a month.

Until now, firm deletion has been a BAU task done on the Rails console whenever it was necessary.

# Screenshots

![screen shot 2016-02-26 at 15 24 22](https://cloud.githubusercontent.com/assets/306583/13356800/1d2f42cc-dc9f-11e5-8161-4af5d339eebb.png)

![screen shot 2016-02-26 at 15 18 47](https://cloud.githubusercontent.com/assets/306583/13356805/216ef83c-dc9f-11e5-827b-15b8e3515b44.png)
