### PR TITLE
[DEV APPROVED] Revert mailjet use sendgrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'dough-ruby',
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
-gem 'mailjet'
 gem 'mas-rad_core', '0.0.102'
 gem 'oga'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,8 +106,6 @@ GEM
       devise (>= 2.0.0)
       rails (>= 3.1.1)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160216)
-      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
     factory_girl (4.5.0)
@@ -122,8 +120,6 @@ GEM
       activesupport (>= 4.1.0)
     hike (1.2.3)
     hitimes (1.2.2)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     httpclient (2.7.1)
     i18n (0.7.0)
     ice_cube (0.11.1)
@@ -145,10 +141,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailjet (1.3.1)
-      activesupport (>= 3.1.0)
-      rack (>= 1.4.0)
-      rest-client
     mas-rad_core (0.0.102)
       active_model_serializers
       geocoder
@@ -165,7 +157,6 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
-    netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     oga (0.3.4)
@@ -234,10 +225,6 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rollbar (1.5.0)
       multi_json (~> 1.3)
     rspec-collection_matchers (1.1.2)
@@ -317,9 +304,6 @@ GEM
       json (>= 1.8.0)
     uk_phone_numbers (0.1.1)
     uk_postcode (2.1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -357,7 +341,6 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  mailjet
   mas-rad_core (= 0.0.102)
   oga
   pg

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,17 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.delivery_method = :mailjet
+  # Heroku specific configuration
+  config.action_mailer.smtp_settings = {
+    port:      '587',
+    address:   'smtp.mandrillapp.com',
+    user_name: ENV['MANDRILL_USERNAME'],
+    password:  ENV['MANDRILL_APIKEY'],
+    domain:    'heroku.com',
+    authentication: :plain
+  }
+
+  config.action_mailer.delivery_method     = :smtp
   config.action_mailer.default_url_options = { host: ENV['EMAIL_HOST'] }
 
   config.active_job.queue_adapter = :sidekiq

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,11 +78,12 @@ Rails.application.configure do
   # Heroku specific configuration
   config.action_mailer.smtp_settings = {
     port:      '587',
-    address:   'smtp.mandrillapp.com',
-    user_name: ENV['MANDRILL_USERNAME'],
-    password:  ENV['MANDRILL_APIKEY'],
+    address:   'smtp.sendgrid.net',
+    user_name: ENV['SENDGRID_USERNAME'],
+    password:  ENV['SENDGRID_PASSWORD'],
     domain:    'heroku.com',
-    authentication: :plain
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   config.action_mailer.delivery_method     = :smtp

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,7 +1,0 @@
-if Rails.env.production?
-  Mailjet.configure do |config|
-    config.api_key = ENV['MAILJET_API_KEY']
-    config.secret_key = ENV['MAILJET_SECRET_KEY']
-    config.default_from = 'RADenquiries@moneyadviceservice.org.uk'
-  end
-end


### PR DESCRIPTION
## DO NOT MERGE (YET) (MAYBE)

For some reason Mailjet is refusing to send email, even when we directly use their API, even considering their servers assign our email a `Message-ID`.

So for now we've opted to use the free tier of the SendGrid service (which allows up to 12000 emails per day should we ever need that).

We tested this out already and it works, we receive email.

Configured following the docs from https://devcenter.heroku.com/articles/sendgrid#ruby-rails