### PR TITLE
Don't show validation errors until registration form submitted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ fca_import_scripts/ext
 fca_import_scripts/sql
 fca_import_scripts/invalid_advisers.csv
 .ruby-env
+.tags

--- a/app/views/self_service/shared/_header_and_nav.html.erb
+++ b/app/views/self_service/shared/_header_and_nav.html.erb
@@ -15,7 +15,7 @@
     <div class="tab-selector__triggers-inner">
       <div class="tab-selector__trigger-container t-firm-details-tab">
         <%= tab_link self_service_firm_details_url(firm), 'tab-selector__trigger' do %>
-          <%= status_icon('exclamation') unless presenter.valid? %>
+          <%= status_icon('exclamation') unless presenter.registered? %>
           Firm details
         <% end %>
       </div>

--- a/app/views/self_service/shared/_overall_status_panel.html.erb
+++ b/app/views/self_service/shared/_overall_status_panel.html.erb
@@ -4,7 +4,7 @@
     <%= t('self_service.status.published') %>
   <% end %>
 
-  <% if presenter.invalid? %>
+  <% unless presenter.registered? %>
     <div class="status__row">
       <%= status_icon('exclamation') %>
       <%= t('self_service.status.needs_firm_details') %>

--- a/spec/features/self_service/registration_status_spec.rb
+++ b/spec/features/self_service/registration_status_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'The registration status' do
     and_i_can_see_the_overall_status_panel
     and_i_see_a_status_item_for_adding_firm_details
     and_i_see_an_exclamation_mark_on_firm_details
+    and_i_do_not_see_validation_errors
   end
 
   scenario 'Firm has filled in details for the selected firm' do
@@ -175,5 +176,9 @@ RSpec.feature 'The registration status' do
 
   def and_i_do_not_see_an_exclamation_mark_on_offices
     expect(firm_edit_page).not_to have_office_exclamation
+  end
+
+  def and_i_do_not_see_validation_errors
+    expect(firm_edit_page).to_not have_validation_summary
   end
 end


### PR DESCRIPTION
![screen shot 2016-03-01 at 11 31 31](https://cloud.githubusercontent.com/assets/271354/13425846/5ada48ba-dfa1-11e5-9491-55c31808df45.png)

We should not call `.valid?` within the view because this will cause validation errors to display before the form has been submitted.

Instead we should use the existing `Firm#registered?` as this will tell us whether the firm record has been completed without triggering validation.