### PR TITLE
Adding password policy to registration and edit account pages

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -36,6 +36,7 @@
 @import 'components/notice/all';
 @import 'components/rad-notification/all';
 @import 'components/offices_table';
+@import 'components/password_policy';
 @import 'components/sign_in_panel';
 @import 'components/status/all';
 

--- a/app/assets/stylesheets/components/_password_policy.scss
+++ b/app/assets/stylesheets/components/_password_policy.scss
@@ -1,0 +1,7 @@
+.password-policy__list {
+  margin-bottom: $baseline-unit;
+}
+
+.password-policy__list_item {
+  @include body(16, 16);
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -25,6 +25,8 @@
     </div>
   </div>
 
+  <%= render 'shared/password_policy' %>
+
   <div class="registration__row">
     <div class="registration__field">
       <%= f.form_row :password do %>

--- a/app/views/principals/new.html.erb
+++ b/app/views/principals/new.html.erb
@@ -78,6 +78,12 @@
 
     <div class="l-identity__row">
       <div class="l-identity__field">
+        <%= render 'shared/password_policy' %>
+      </div>
+    </div>
+
+    <div class="l-identity__row">
+      <div class="l-identity__field">
         <%= f.form_row(:password) do %>
           <%= f.errors_for :password %>
           <%= f.label :password, t('registration.user.password'), class: 'form__label-heading' %>

--- a/app/views/shared/_password_policy.html.erb
+++ b/app/views/shared/_password_policy.html.erb
@@ -1,0 +1,13 @@
+<div class="panel">
+  <div class="panel__heading">
+    <%= t('authentication.password_policy.label') %>
+  </div>
+  <div>
+    <%= t('authentication.password_policy.criteria_intro') %>
+    <ul class="password-policy__list">
+      <% t('authentication.password_policy.criteria').each do |criteria| %>
+        <li class="password-policy__list_item"><%= criteria %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/locales/authentication.en.yml
+++ b/config/locales/authentication.en.yml
@@ -1,5 +1,14 @@
 en:
   authentication:
+    password_policy:
+      label: "Password policy:"
+      criteria_intro: "Passwords must be at least 8 characters long and contain the following:"
+      criteria:
+        - an uppercase character
+        - a lowercase character
+        - a number
+        - and a symbol
+
     password_fields: &password_fields
       password_confirmation: Confirm password
 


### PR DESCRIPTION
This PR is to add password policy info when the user is entering or changing their password, to save them entering a password and that not satisfying the coded policy.

You can see the policy added on the registration page here:
![screen shot 2016-03-02 at 14 14 44](https://cloud.githubusercontent.com/assets/67151/13462875/7be92d56-e081-11e5-9d88-d55081f3c05a.png)

and on the edit account page:
![screen shot 2016-03-02 at 14 14 17](https://cloud.githubusercontent.com/assets/67151/13462889/8509b766-e081-11e5-945c-d25ce3908ac6.png)
