### PR TITLE
Fix svg icons for IE

### DIFF
--- a/app/helpers/self_service/self_service_helper.rb
+++ b/app/helpers/self_service/self_service_helper.rb
@@ -73,7 +73,7 @@ module SelfService
 
     def status_icon(icon_type)
       content_tag :svg, class: "status__icon status__icon--#{icon_type}" do
-        tag :use, 'xlink:href': "#{image_path('icon_spritesheet.svg')}#icon-#{icon_type}"
+        tag :use, 'xlink:href': "#icon-#{icon_type}"
       end
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,7 @@
   </script>
 </head>
 <body>
+<%= render 'shared/svg_icons' %>
 <%= render 'shared/skip_links' %>
 <%= render 'shared/header' %>
 <%= yield :breadcrumbs %>

--- a/app/views/shared/_svg_icons.html.erb
+++ b/app/views/shared/_svg_icons.html.erb
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" title="">
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;" title="">
   <symbol id="icon-exclamation">
     <path d="M10.5 20C9.12 20 8 18.882 8 17.5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5c0 1.382-1.12 2.5-2.5 2.5m.428-6.5H9.752c-.83 0-1.5-.672-1.5-1.5L7 1.5C7 .672 7.672 0 8.5 0h3.68c.828 0 1.5.672 1.5 1.5L12.428 12c0 .828-.672 1.5-1.5 1.5z" fill-rule="evenodd"/>
   </symbol>

--- a/spec/helpers/self_service/self_service_helper_spec.rb
+++ b/spec/helpers/self_service/self_service_helper_spec.rb
@@ -91,7 +91,7 @@ module SelfService
       end
 
       it 'includes the image for the icon type' do
-        expect(helper.status_icon('tick')).to include('icon_spritesheet.svg#icon-tick')
+        expect(helper.status_icon('tick')).to include('#icon-tick')
       end
     end
   end


### PR DESCRIPTION
IE11 does not support loading an SVG spritesheet as an external source.

# Before

![screen shot 2016-03-02 at 12 24 53](https://cloud.githubusercontent.com/assets/306583/13463153/e5033218-e082-11e5-9257-ceadc1235a7a.png)

# After

![screen shot 2016-03-02 at 14 27 46](https://cloud.githubusercontent.com/assets/306583/13463174/f6f538ea-e082-11e5-9803-074bb0ce4979.png)
