### PR TITLE
Tweak the status icon size to work best across all browsers

### DIFF
--- a/app/assets/stylesheets/components/status/_settings.scss
+++ b/app/assets/stylesheets/components/status/_settings.scss
@@ -1,2 +1,2 @@
 $status-icon-padding: 3px;
-$status-icon-size: 27px;
+$status-icon-size: 21px;

--- a/app/views/shared/_svg_icons.html.erb
+++ b/app/views/shared/_svg_icons.html.erb
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;" title="">
-  <symbol id="icon-exclamation">
+  <symbol id="icon-exclamation" viewBox="7 0 6.680000305175781 20">
     <path d="M10.5 20C9.12 20 8 18.882 8 17.5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5c0 1.382-1.12 2.5-2.5 2.5m.428-6.5H9.752c-.83 0-1.5-.672-1.5-1.5L7 1.5C7 .672 7.672 0 8.5 0h3.68c.828 0 1.5.672 1.5 1.5L12.428 12c0 .828-.672 1.5-1.5 1.5z" fill-rule="evenodd"/>
   </symbol>
-  <symbol id="icon-tick">
+  <symbol id="icon-tick" viewBox="0 2 20 16">
     <path d="M6.575 11.69L17.223 2 20 4.678 6.944 18 0 11.51l2.778-2.835 3.797 3.016z" fill-rule="evenodd"/>
   </symbol>
 </svg>


### PR DESCRIPTION
Aligns the status icon size with the line-height (ish) so that other things layout without issues on IE browsers.

![screen shot 2016-03-03 at 11 57 40](https://cloud.githubusercontent.com/assets/306583/13493696/7622f63e-e137-11e5-965e-d298ef6af3dc.png)

![screen shot 2016-03-03 at 11 58 08](https://cloud.githubusercontent.com/assets/306583/13493698/79156372-e137-11e5-9a77-4dc3b4ed1081.png)
 