### PR TITLE
add inactive trading names report

### DIFF
--- a/app/controllers/admin/reports/inactive_trading_names_controller.rb
+++ b/app/controllers/admin/reports/inactive_trading_names_controller.rb
@@ -1,0 +1,14 @@
+module Admin
+  module Reports
+    class InactiveTradingNamesController < Admin::ApplicationController
+      def show
+        @inactive_trading_names = Firm
+                                  .joins('LEFT JOIN lookup_subsidiaries ' \
+                                         'ON lookup_subsidiaries.fca_number = firms.fca_number ' \
+                                         'AND lookup_subsidiaries.name = firms.registered_name')
+                                  .where('lookup_subsidiaries.id' => nil)
+                                  .where.not('parent_id' => nil)
+      end
+    end
+  end
+end

--- a/app/views/admin/reports/inactive_trading_names/show.html.erb
+++ b/app/views/admin/reports/inactive_trading_names/show.html.erb
@@ -1,0 +1,31 @@
+<h2>Inactive Trading Names</h2>
+
+<p>
+  This report shows all trading names whose FCA status is no longer considered 'Current'.
+</p>
+
+<p>
+  The <a href="https://register.fca.org.uk/">Financial Services Register</a>
+  can be searched to determine exactly what status change has occurred.
+</p>
+
+<table class="table table-bordered">
+  <tr>
+    <th>FCA Number</th>
+    <th>Registered Name</th>
+    <th>Visible on Directory?</th>
+  </tr>
+  <% if @inactive_trading_names.present? %>
+    <% @inactive_trading_names.each do |trading_name| %>
+      <tr>
+        <td><%= trading_name.fca_number %></td>
+        <td><%= link_to trading_name.registered_name, admin_firm_path(trading_name) %></td>
+        <td><%= trading_name.publishable? ? 'Yes' : 'No' %></td>
+      </tr>
+    <% end %>
+  <% else %>
+    <tr>
+      <td colspan="3">No trading names to display</td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -32,6 +32,7 @@
           <ul class="dropdown-menu" role="menu">
             <%= active_link_to 'Metrics', admin_reports_metrics_path, wrap_tag: 'li' %>
             <%= active_link_to 'Inactive Advisers', admin_reports_inactive_adviser_path, wrap_tag: 'li' %>
+            <%= active_link_to 'Inactive Trading Names', admin_reports_inactive_trading_name_path, wrap_tag: 'li' %>
             <%= active_link_to 'Out of Date Firms', admin_reports_out_of_date_firm_path, wrap_tag: 'li' %>
           </ul>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
         end
       end
       resource :inactive_adviser, only: [:show]
+      resource :inactive_trading_name, only: [:show]
       resource :out_of_date_firm, only: [:show]
     end
   end

--- a/spec/controllers/admin/reports/inactive_trading_names_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_trading_names_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Admin::Reports::InactiveTradingNamesController, type: :controller do
+  describe '#show' do
+    it 'successfully renders' do
+      get :show
+      expect(response).to be_success
+    end
+
+    it 'assigns a list of inactive trading names' do
+      firm = FactoryGirl.create(:firm, fca_number: 123456)
+
+      FactoryGirl.create(:lookup_subsidiary, name: 'Acme', fca_number: 123456)
+      FactoryGirl.create(:firm, registered_name: 'Acme', fca_number: 123456, parent: firm)
+      inactive_trading_name = FactoryGirl.create(:firm, registered_name: 'Not Acme', fca_number: 123456, parent: firm)
+
+      get :show
+      expect(assigns[:inactive_trading_names]).to eq([inactive_trading_name])
+    end
+  end
+end


### PR DESCRIPTION
Adds a report to view inactive trading names.

![screen shot 2016-03-07 at 11 46 18](https://cloud.githubusercontent.com/assets/32398/13568611/51543dce-e45a-11e5-9017-59cb1d085f16.png)
