### PR TITLE
Ensure header displays in IE8

### DIFF
--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,5 +1,6 @@
 .l-header {
   height: $baseline-unit*12;
+  display: block;
 }
 
 .l-header .mas-logo {


### PR DESCRIPTION
The background for the header wasn't appearing in IE8, so it gave the impression the header didn't exist at all. Highlighting the header in the browser reveals that the content is there. However, with it being white, it didn't appear to be visible.

![screen shot 2016-03-09 at 10 23 52](https://cloud.githubusercontent.com/assets/32398/13632471/cc7bdf60-e5e1-11e5-9f5b-da2f5ff3990e.png)

The issue appears to be that IE8 was rendering the `<header>` element with a `display: inline` property, regardless of style being declared `header { display: block; } `. I've not investigated beyond resolving the issue, but I suspect there is perhaps an issue with applying styles to HTML elements which are not natively supported by IE8.

Declaring `display: block` on the class used by the element appears to resolve the issue.

![screen shot 2016-03-09 at 10 24 07](https://cloud.githubusercontent.com/assets/32398/13632473/ce031510-e5e1-11e5-9858-c1936ce177c3.png)