### PR TITLE
Ensure new advisers without reference numbers are geocoded when created

### DIFF
--- a/app/controllers/admin/advisers_controller.rb
+++ b/app/controllers/admin/advisers_controller.rb
@@ -18,7 +18,7 @@ class Admin::AdvisersController < Admin::ApplicationController
     @adviser.reference_number = 'NOREF'
     @adviser.bypass_reference_number_check = true
 
-    if @adviser.save
+    if @adviser.save_with_geocoding
       redirect_to admin_firm_path(firm)
     else
       render :new

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -1,4 +1,5 @@
-RSpec.feature 'Add a new adviser without an FCA number' do
+RSpec.feature 'Add a new adviser without an FCA number',
+              vcr: vcr_options_for(:features_admin_advisers_add_spec) do
   let(:firm_page) { Admin::FirmPage.new }
   let(:new_adviser_page) { Admin::NewAdviserPage.new }
 
@@ -17,6 +18,7 @@ RSpec.feature 'Add a new adviser without an FCA number' do
 
     then_i_am_on_the_firm_page
     and_i_can_see_1_adviser
+    and_they_have_been_geocoded
   end
 
   scenario 'Adding an adviser after we fail once' do
@@ -85,6 +87,10 @@ RSpec.feature 'Add a new adviser without an FCA number' do
 
   def and_i_can_see_1_adviser
     expect(firm_page.advisers.count).to eq(1)
+  end
+
+  def and_they_have_been_geocoded
+    expect(@firm.advisers.first).to be_geocoded
   end
 
   def then_no_errors_are_displayed_on(the_page:)

--- a/spec/fixtures/vcr_cassettes/features_admin_advisers_add_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_admin_advisers_add_spec.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH1%202AS,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 09 Mar 2016 12:02:26 GMT
+      Expires:
+      - Thu, 10 Mar 2016 12:02:26 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '512'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH1 2AS",
+                       "short_name" : "EH1 2AS",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Rutland Square",
+                       "short_name" : "Rutland Square",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Rutland Square, Edinburgh, Edinburgh EH1 2AS, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9489386,
+                          "lng" : -3.2079256
+                       },
+                       "southwest" : {
+                          "lat" : 55.9481028,
+                          "lng" : -3.2091377
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9486454,
+                       "lng" : -3.20845
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9498696802915,
+                          "lng" : -3.207182669708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.94717171970851,
+                          "lng" : -3.209880630291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJwaJxwaLHh0gRo361f5omYsw",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 09 Mar 2016 12:02:26 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This fixes an issue we noted where creating new advisers with this new admin-only form added them to the Postgres database but they didn't show up in ElasticSearch.