### PR TITLE
Change move advisers button color

### DIFF
--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -65,3 +65,7 @@ code {
 .adviser__actions__edit {
   @include make-xs-column(6);
 }
+
+.firm__move-advisers {
+  display: inline;
+}

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -64,7 +64,7 @@
     <% end %>
   </ul>
 
-  <%= link_to 'Move advisers', new_admin_move_adviser_path, class: 'btn btn-default t-move-advisers', method: :get %>
+  <%= button_to 'Move advisers', new_admin_move_adviser_path, class: 't-move-advisers', method: :get, form_class: 'firm__move-advisers' %>
 <% else %>
   <p>No advisers registered.</p>
 <% end %>


### PR DESCRIPTION
This PR is to change the move advisers button colour to match the 'Sign in as...' button.

'Sign in as...' is an input button with the browsers default styling.
Previously 'Move advisers' was a bootstrap styled link, so we flipped that to `button_to` to look the same as 'Sign in as...'

Before:
![screen shot 2016-03-09 at 16 06 50](https://cloud.githubusercontent.com/assets/271354/13639424/f86b2124-e610-11e5-8b52-a9406a20d244.png)

After:
![screen_shot_2016-03-09_at_15 53 27_360](https://cloud.githubusercontent.com/assets/271354/13639401/dae634a4-e610-11e5-9822-578c63982ac1.png)
