### PR TITLE
add cancel/save to top of form

### DIFF
--- a/app/assets/stylesheets/layouts/_2col.scss
+++ b/app/assets/stylesheets/layouts/_2col.scss
@@ -5,3 +5,7 @@
 .l-2col-side--pull-right {
   float: right;
 }
+
+.l-2col-even--no-left-margin {
+  margin-left: 0;
+}

--- a/app/views/self_service/firms/_form.html.erb
+++ b/app/views/self_service/firms/_form.html.erb
@@ -1,3 +1,4 @@
+
 <p><%= t('self_service.required_fields_message') %></p>
 
 <% if @firm.errors.any? %>
@@ -7,13 +8,25 @@
 <% end %>
 
 <section class="form-section">
-  <h2 class="form-section__heading">
-    <% if f.object.trading_name? %>
-      <%= t('self_service.firm_edit.trading_name_heading') %>
-    <% else %>
-      <%= t('self_service.firm_edit.firm_heading') %>
-    <% end %>
-  </h2>
+  <div class="l-2-col">
+    <div class="l-2col-even l-2col-even--no-left-margin">
+      <h2 class="form-section__heading">
+        <% if f.object.trading_name? %>
+          <%= t('self_service.firm_edit.trading_name_heading') %>
+        <% else %>
+          <%= t('self_service.firm_edit.firm_heading') %>
+        <% end %>
+      </h2>
+    </div>
+
+    <div>
+      <div class="l-self-service-action-row">
+        <%= link_to t('self_service.cancel_button'), self_service_firms_path, class: 'l-self-service-action-row__cancel' %>
+        <%= f.submit t('self_service.save_button'), class: 'button button--primary' %>
+      </div>
+    </div>
+  </div>
+
   <%= render partial: 'self_service/firms/questionnaire/firm_details', locals: {f: f} %>
 </section>
 


### PR DESCRIPTION
There has been feedback from advisers that the save and cancel buttons are easy to miss because they are too far down the page. So advisers tend to navigate away from the page without saving if they don't happen to scroll all the way to the bottom.

This PR simply duplicates the save button to the top of the form to make it a little harder to miss.

![](http://g.recordit.co/95ajE4u3YD.gif)