### PR TITLE
Exclude advisers added outside of the ref checking process from invalid adviser report

### DIFF
--- a/app/controllers/admin/reports/inactive_advisers_controller.rb
+++ b/app/controllers/admin/reports/inactive_advisers_controller.rb
@@ -5,7 +5,8 @@ module Admin
         @inactive_advisers = Adviser
                              .joins('LEFT JOIN lookup_advisers ' \
                                    'ON lookup_advisers.reference_number = advisers.reference_number')
-                             .where('lookup_advisers.id' => nil)
+                             .where('lookup_advisers.id' => nil,
+                                    'advisers.bypass_reference_number_check' => false)
       end
     end
   end

--- a/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
@@ -13,5 +13,17 @@ RSpec.describe Admin::Reports::InactiveAdvisersController, type: :controller do
       get :show
       expect(assigns[:inactive_advisers]).to eq([inactive_adviser])
     end
+
+    it 'excludes advisers that have skipped the reference number check' do
+      FactoryGirl.create(:adviser)
+      noref_adviser = FactoryGirl.build(:adviser,
+                                        bypass_reference_number_check: true,
+                                        create_linked_lookup_advisor: false)
+
+      noref_adviser.save!(validate: false)
+
+      get :show
+      expect(assigns[:inactive_advisers]).to eq([])
+    end
   end
 end


### PR DESCRIPTION
There is functionality to add advisers to the application without having to verify a reference number for the person. These records should not appear in the invalid advisers report.

__Before: 9 records, 3 are 'NOREF'__
![screen shot 2016-03-09 at 15 57 27](https://cloud.githubusercontent.com/assets/32398/13641375/1b1e48dc-e610-11e5-93c8-135796d32f45.png)

__After: 6 records__
![screen shot 2016-03-09 at 15 57 42](https://cloud.githubusercontent.com/assets/32398/13641376/1b1ece06-e610-11e5-869e-24b192a1ed45.png)

