### PR TITLE
Add CSV downloads of the 3 new reports in the RAD admin screens

### DIFF
--- a/app/controllers/admin/reports/inactive_advisers_controller.rb
+++ b/app/controllers/admin/reports/inactive_advisers_controller.rb
@@ -7,6 +7,11 @@ module Admin
                                    'ON lookup_advisers.reference_number = advisers.reference_number')
                              .where('lookup_advisers.id' => nil,
                                     'advisers.bypass_reference_number_check' => false)
+
+        respond_to do |format|
+          format.html
+          format.csv
+        end
       end
     end
   end

--- a/app/controllers/admin/reports/inactive_firms_controller.rb
+++ b/app/controllers/admin/reports/inactive_firms_controller.rb
@@ -6,6 +6,11 @@ module Admin
                           .joins('LEFT JOIN lookup_firms ' \
                                  'ON lookup_firms.fca_number = firms.fca_number')
                           .where('lookup_firms.id' => nil, 'parent_id' => nil)
+
+        respond_to do |format|
+          format.html
+          format.csv
+        end
       end
     end
   end

--- a/app/controllers/admin/reports/inactive_trading_names_controller.rb
+++ b/app/controllers/admin/reports/inactive_trading_names_controller.rb
@@ -8,6 +8,11 @@ module Admin
                                          'AND lookup_subsidiaries.name = firms.registered_name')
                                   .where('lookup_subsidiaries.id' => nil)
                                   .where.not('parent_id' => nil)
+
+        respond_to do |format|
+          format.html
+          format.csv
+        end
       end
     end
   end

--- a/app/views/admin/reports/inactive_advisers/show.csv.erb
+++ b/app/views/admin/reports/inactive_advisers/show.csv.erb
@@ -1,0 +1,10 @@
+<%=
+require 'csv'
+
+CSV.generate do |csv|
+  csv << ['Ref Number', 'Name', 'Firm']
+
+  @inactive_advisers.each do |adviser|
+    csv << [adviser.reference_number, adviser.name, adviser.firm.registered_name]
+  end
+end -%>

--- a/app/views/admin/reports/inactive_advisers/show.html.erb
+++ b/app/views/admin/reports/inactive_advisers/show.html.erb
@@ -9,6 +9,10 @@
   can be searched to determine exactly what status change has occurred.
 </p>
 
+<p>
+  <%= link_to 'Download as CSV', admin_reports_inactive_adviser_path(format: :csv), class: 'btn btn-primary' %>
+</p>
+
 <table class="table table-bordered">
   <tr>
     <th>Ref Number</th>

--- a/app/views/admin/reports/inactive_firms/show.csv.erb
+++ b/app/views/admin/reports/inactive_firms/show.csv.erb
@@ -1,0 +1,10 @@
+<%=
+require 'csv'
+
+CSV.generate do |csv|
+  csv << ['FCA Number', 'Registered Name', 'Visible on Directory?']
+
+  @inactive_firms.each do |firm|
+    csv << [firm.fca_number, firm.registered_name, firm.publishable? ? 'Yes' : 'No']
+  end
+end -%>

--- a/app/views/admin/reports/inactive_firms/show.html.erb
+++ b/app/views/admin/reports/inactive_firms/show.html.erb
@@ -9,6 +9,10 @@
   can be searched to determine exactly what status change has occurred.
 </p>
 
+<p>
+  <%= link_to 'Download as CSV', admin_reports_inactive_firm_path(format: :csv), class: 'btn btn-primary' %>
+</p>
+
 <table class="table table-bordered">
   <tr>
     <th>FCA Number</th>

--- a/app/views/admin/reports/inactive_trading_names/show.csv.erb
+++ b/app/views/admin/reports/inactive_trading_names/show.csv.erb
@@ -1,0 +1,10 @@
+<%=
+require 'csv'
+
+CSV.generate do |csv|
+  csv << ['FCA Number', 'Registered Name', 'Visible on Directory?']
+
+  @inactive_trading_names.each do |trading_name|
+    csv << [trading_name.fca_number, trading_name.registered_name, trading_name.publishable? ? 'Yes' : 'No']
+  end
+end -%>

--- a/app/views/admin/reports/inactive_trading_names/show.html.erb
+++ b/app/views/admin/reports/inactive_trading_names/show.html.erb
@@ -9,6 +9,10 @@
   can be searched to determine exactly what status change has occurred.
 </p>
 
+<p>
+  <%= link_to 'Download as CSV', admin_reports_inactive_trading_name_path(format: :csv), class: 'btn btn-primary' %>
+</p>
+
 <table class="table table-bordered">
   <tr>
     <th>FCA Number</th>

--- a/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
@@ -25,5 +25,37 @@ RSpec.describe Admin::Reports::InactiveAdvisersController, type: :controller do
       get :show
       expect(assigns[:inactive_advisers]).to eq([])
     end
+
+    context 'CSV format' do
+      render_views
+
+      it 'renders the csv template' do
+        get :show, format: :csv
+        expect(response).to render_template(:show)
+      end
+
+      it 'sets the content type to "text/csv"' do
+        get :show, format: :csv
+        expect(response.content_type).to eq('text/csv')
+      end
+
+      it 'has the appropriate csv headers' do
+        get :show, format: :csv
+        expect(response.body).to include('Ref Number,Name,Firm')
+      end
+
+      it 'renders inactive adviser content' do
+        firm = FactoryGirl.create(:firm, registered_name: 'Acme Inc.')
+        inactive_adviser = FactoryGirl.build(:adviser,
+                                             create_linked_lookup_advisor: false,
+                                             reference_number: 123456,
+                                             name: 'Amear Pittance',
+                                             firm: firm)
+        inactive_adviser.save!(validate: false)
+
+        get :show, format: :csv
+        expect(response.body).to include('123456,Amear Pittance,Acme Inc.')
+      end
+    end
   end
 end

--- a/spec/controllers/admin/reports/inactive_firms_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_firms_controller_spec.rb
@@ -15,5 +15,31 @@ RSpec.describe Admin::Reports::InactiveFirmsController, type: :controller do
       get :show
       expect(assigns[:inactive_firms]).to eq([inactive_firm])
     end
+
+    context 'CSV format' do
+      render_views
+
+      it 'renders the csv template' do
+        get :show, format: :csv
+        expect(response).to render_template(:show)
+      end
+
+      it 'sets the content type to "text/csv"' do
+        get :show, format: :csv
+        expect(response.content_type).to eq('text/csv')
+      end
+
+      it 'has the appropriate csv headers' do
+        get :show, format: :csv
+        expect(response.body).to include('FCA Number,Registered Name,Visible on Directory?')
+      end
+
+      it 'renders inactive adviser content' do
+        FactoryGirl.create(:firm, fca_number: 789012, registered_name: 'Acme Finance')
+
+        get :show, format: :csv
+        expect(response.body).to include('789012,Acme Finance,Yes')
+      end
+    end
   end
 end

--- a/spec/controllers/admin/reports/inactive_trading_names_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_trading_names_controller_spec.rb
@@ -15,5 +15,32 @@ RSpec.describe Admin::Reports::InactiveTradingNamesController, type: :controller
       get :show
       expect(assigns[:inactive_trading_names]).to eq([inactive_trading_name])
     end
+
+    context 'CSV format' do
+      render_views
+
+      it 'renders the csv template' do
+        get :show, format: :csv
+        expect(response).to render_template(:show)
+      end
+
+      it 'sets the content type to "text/csv"' do
+        get :show, format: :csv
+        expect(response.content_type).to eq('text/csv')
+      end
+
+      it 'has the appropriate csv headers' do
+        get :show, format: :csv
+        expect(response.body).to include('FCA Number,Registered Name,Visible on Directory?')
+      end
+
+      it 'renders inactive adviser content' do
+        firm = FactoryGirl.create(:firm, fca_number: 123456)
+        FactoryGirl.create(:firm, fca_number: 789012, registered_name: 'Acme Finance', parent: firm)
+
+        get :show, format: :csv
+        expect(response.body).to include('789012,Acme Finance,Yes')
+      end
+    end
   end
 end


### PR DESCRIPTION
The admin team manage their data-cleansing workflow and audit trail using spreadsheets so we now provide CSV downloads of the data.

![screen shot 2016-03-10 at 16 41 36](https://cloud.githubusercontent.com/assets/306583/13676834/4ed6a564-e6df-11e5-9ebb-72f802032814.png)
