### PR TITLE
Add metatags to force ie out of compatibility mode

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -2,8 +2,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="MAS Retirement Adviser Directory Administration">
   <meta name="author" content="Team A">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html class="<%= 'dev' if Rails.env.development? %>">
 <head>
   <title>Retirement Adviser Directory</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width">
   <%= csrf_meta_tags %>
 


### PR DESCRIPTION
Requires IE to use the latest version, as per frontend.

See http://twigstechtips.blogspot.co.uk/2010/03/css-ie8-meta-tag-to-disable.html