### PR TITLE
[DEV APPROVED]Bug Fix: Controller couldn't find Admin::Reports::FirmsAdvisers

### DIFF
--- a/app/controllers/admin/firms_controller.rb
+++ b/app/controllers/admin/firms_controller.rb
@@ -15,7 +15,7 @@ class Admin::FirmsController < Admin::ApplicationController
   end
 
   def adviser_report
-    data = Reports::FirmsAdvisers.data
+    data = ::Reports::FirmsAdvisers.data
     time_string = Time.zone.now.to_formatted_s(:number)
     respond_to do |format|
       format.csv { send_data data, filename: "firms-advisers-#{time_string}.csv" }

--- a/spec/controllers/admin/firms_controller_spec.rb
+++ b/spec/controllers/admin/firms_controller_spec.rb
@@ -43,28 +43,35 @@ RSpec.describe Admin::FirmsController, type: :controller do
   end
 
   describe 'GET adviser_report' do
-    before :each do
-      allow(Reports::FirmsAdvisers).to receive(:data)
+    context 'contents' do
+      before :each do
+        allow(Reports::FirmsAdvisers).to receive(:data)
 
-      Timecop.freeze(Time.zone.parse('2016-05-04 00:00:00'))
+        Timecop.freeze(Time.zone.parse('2016-05-04 00:00:00'))
 
-      get :adviser_report, format: :csv
+        get :adviser_report, format: :csv
+      end
+
+      after :each do
+        Timecop.return
+      end
+
+      it 'gets data from the Firms report' do
+        expect(Reports::FirmsAdvisers).to have_received(:data)
+      end
+
+      it 'provides it as a CSV' do
+        expect(response.header['Content-Type']).to eq('text/csv')
+      end
+
+      it 'has a timestamped filename' do
+        expect(response.header['Content-Disposition']).to eq('attachment; filename="firms-advisers-20160504000000.csv"')
+      end
     end
+  end
 
-    after :each do
-      Timecop.return
-    end
-
-    it 'gets data from the Firms report' do
-      expect(Reports::FirmsAdvisers).to have_received(:data)
-    end
-
-    it 'provides it as a CSV' do
-      expect(response.header['Content-Type']).to eq('text/csv')
-    end
-
-    it 'has a timestamped filename' do
-      expect(response.header['Content-Disposition']).to eq('attachment; filename="firms-advisers-20160504000000.csv"')
-    end
+  it 'responds succesfully' do
+    get :adviser_report, format: :csv
+    expect(response).to be_success
   end
 end


### PR DESCRIPTION
The class `Reports::FirmsAdvisers` is defined in `/lib/reports`.  Previously it was used in `Admin::FirmsController` without incident.

Recently the module `Admin::Reports` was introduced, causing `Reports::FirmsAdvisers` to be resolved to `Admin::Reports::FirmsAdvisers` within `Admin::FirmsController`.

This fixes the issue by explicitly specifying the `Reports` module in the root namespace, ie with `::Reports::FirmsAdvisers`.