### PR TITLE
Bumping mas-rad_core from 0.0.106 to 0.0.107 and updating schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', '0.0.106'
+gem 'mas-rad_core', '0.0.107'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-rad_core (0.0.106)
+    mas-rad_core (0.0.107)
       active_model_serializers
       geocoder
       httpclient
@@ -358,7 +358,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core (= 0.0.106)
+  mas-rad_core (= 0.0.107)
   oga
   pg
   poltergeist

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160222091312) do
+ActiveRecord::Schema.define(version: 20160317103053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -271,6 +270,16 @@ ActiveRecord::Schema.define(version: 20160222091312) do
     t.datetime "updated_at",             null: false
     t.integer  "order",      default: 0, null: false
   end
+
+  create_table "rad_consumer_sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "rad_consumer_sessions", ["session_id"], name: "index_rad_consumer_sessions_on_session_id", unique: true, using: :btree
+  add_index "rad_consumer_sessions", ["updated_at"], name: "index_rad_consumer_sessions_on_updated_at", using: :btree
 
   create_table "snapshots", force: :cascade do |t|
     t.integer  "firms_with_no_minimum_fee"


### PR DESCRIPTION
This PR is to pull in the latest version of mas-rad_core ([PR](https://github.com/moneyadviceservice/mas-rad_core/pull/151)) which updates the schema and allows rad_consumer ([PR](https://github.com/moneyadviceservice/rad_consumer/pull/289)) to migrate the session from being cookie based to being DB based. 


