### PR TITLE
Backend App: Upgrade to dough 5.12 and integrate latest frontend CSS from the CDN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,12 @@ gem 'bowndler', github: 'moneyadviceservice/bowndler'
 gem 'devise'
 gem 'devise_invitable'
 gem 'devise_security_extension'
+# Dough assets are loaded from a CDN instead of from the Gem. Do make sure that
+# the CDN version is the same as the Gem version.
 gem 'dough-ruby',
     github: 'moneyadviceservice/dough',
     require: 'dough',
-    ref: '1bba610'
+    tag: 'v5.12.0.267'
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: git://github.com/moneyadviceservice/dough.git
-  revision: 1bba6103b774e93dcfd8a5e7b0a3df38e68b363a
-  ref: 1bba610
+  revision: c27e7846616b0e7965817d97f1432dee9bb49aa8
+  tag: v5.12.0.267
   specs:
     dough-ruby (5.12.0)
       activesupport

--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -1,8 +1,12 @@
 .navigation {
   @extend .unstyled-list;
   float: right;
-  margin-top: 22px;
+  margin-top: $baseline-unit*2.5;
   padding-right: 0.5em;
+
+  @include respond-to($mq-m) {
+    margin-top: $baseline-unit*3;
+  }
 }
 
 %navigation-item {

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,5 +1,5 @@
 .l-header {
-  height: $baseline-unit*12;
+  // Needed to prevent the header disappearing on IE8.
   display: block;
 }
 

--- a/app/views/layouts/_mas_head.html.erb
+++ b/app/views/layouts/_mas_head.html.erb
@@ -2,13 +2,13 @@
 
 <!--[if ( gte IE 7 ) & ( lte IE 8 ) & (!IEMobile) ]>
   <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-dcbb90df70309af8f6ceeaff0db9a5af.css" media="screen" rel="stylesheet" />
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-a29cec672e787c77b507eb06b8793384.css" media="all" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-1cca1e76da0e2d48be990410a432379f.css" media="all" rel="stylesheet" />
   <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-ccc40f0f8bab80e89dfead2f99f6efdf.js"></script>
   <script>var responsiveStyle = false;</script>
 <![endif]-->
 
 <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
-<link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-8ca8df163c8e0afa00849c3bf43f19e8.css" media="only all" rel="stylesheet" />
+<link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-d8208fa73813e571e25d02f662719e85.css" media="only all" rel="stylesheet" />
 <script>var responsiveStyle = true;</script>
 <!--<![endif]-->
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="l-header" role="banner">
-  <div class="l-constrained">
+  <div class="l-constrained l-header__content">
     <div class="mas-logo">
       <a class="mas-logo__link" href="/">
         <img alt="Money Advice Service" class="mas-logo__img" src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/logo-sprite-en-f13de50d8bcd8dbbabfbe56b441a8633.png" />


### PR DESCRIPTION
Brings this app up to date with the frontend and the latest Dough.

* Swaps to using tags to track versions of Dough so it's easy to see the exact version we are referencing.
* Yeast is still configured to track master in bower.json.erb so all fresh deployments naturally get the latest version anyway.
* Updated the URLs for assets we import from frontend via the CDN by looking at the page source for http://www.moneyadviceservice.org.uk today.
* Made changes necessary to integrate the new [mobile sticky header](https://github.com/moneyadviceservice/frontend/pull/1365).

Broadly tested using BrowserStack on:

* IE8, IE11
* iPhone 6, iPad
* Galaxy S6
* FF latest
* Safari latest
* Chrome latest

![screen shot 2016-03-23 at 18 26 19](https://cloud.githubusercontent.com/assets/306583/13996272/dc9db9e2-f124-11e5-92cd-bda14d00fa96.png)

The related change in the consumer application is here: https://github.com/moneyadviceservice/rad_consumer/pull/292