### PR TITLE
[DEV APPROVED]Allow firms to state if they supply workplace financial advice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', '0.0.107'
+gem 'mas-rad_core', '0.0.108'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-rad_core (0.0.107)
+    mas-rad_core (0.0.108)
       active_model_serializers
       geocoder
       httpclient
@@ -358,7 +358,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core (= 0.0.107)
+  mas-rad_core (= 0.0.108)
   oga
   pg
   poltergeist

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -24,6 +24,7 @@ module SelfService
       :primary_advice_method,
       :ethical_investing_flag,
       :sharia_investing_flag,
+      :workplace_financial_advice_flag,
       :status,
       in_person_advice_method_ids: [],
       other_advice_method_ids: [],

--- a/app/views/self_service/firms/questionnaire/_other_services.html.erb
+++ b/app/views/self_service/firms/questionnaire/_other_services.html.erb
@@ -16,5 +16,11 @@
         <%= t('self_service.firm_form.sharia_investing_label') %>
       </label>
     </div>
+    <div class="form__group-item">
+      <label>
+        <%= f.check_box :workplace_financial_advice_flag, class: "form__input t-workplace-financial-advice-flag" %>
+        <%= t('self_service.firm_form.workplace_financial_advice_label') %>
+      </label>
+    </div>
   <% end %>
 </fieldset>

--- a/config/locales/admin/snapshot_attributes.en.yml
+++ b/config/locales/admin/snapshot_attributes.en.yml
@@ -23,6 +23,7 @@ en:
       firms_providing_wills_and_probate: Firms providing wills & Probate
       firms_providing_ethical_investing: Firms providing ethical investing
       firms_providing_sharia_investing: Firms providing sharia investing
+      firms_providing_workplace_financial_advice: Firms providing workplace financial advice
       firms_offering_languages_other_than_english: Firms providing languages other than English
       offices_with_disabled_access: Offices with disabled access
       registered_advisers: Total number of registered advisers

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -25,6 +25,7 @@ en:
       other_services_heading: Other services provided
       ethical_investing_label: Ethical investing
       sharia_investing_label: Sharia compliant investments
+      workplace_financial_advice_label: Workplace financial advice
 
       ongoing_advice_fee_heading: Ongoing advice
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317103053) do
+ActiveRecord::Schema.define(version: 20160325155550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20160317103053) do
     t.boolean  "sharia_investing_flag",                    default: false, null: false
     t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
+    t.boolean  "workplace_financial_advice_flag",          default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160325155550) do
+ActiveRecord::Schema.define(version: 20160328130032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -341,8 +341,9 @@ ActiveRecord::Schema.define(version: 20160325155550) do
     t.integer  "advisers_part_of_ci_securities_and_investments"
     t.integer  "advisers_part_of_cfa_institute"
     t.integer  "advisers_part_of_chartered_accountants"
-    t.datetime "created_at",                                                 null: false
-    t.datetime "updated_at",                                                 null: false
+    t.datetime "created_at",                                                             null: false
+    t.datetime "updated_at",                                                             null: false
+    t.integer  "firms_providing_workplace_financial_advice",                 default: 0
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Building on the work in this [mas-rad_core PR](https://github.com/moneyadviceservice/mas-rad_core/pull/152)

This PR allows firms to specify if they provide :workplace_financial_advice and also updates the admin metric report to contain this information in the snapshot data.


![screen shot 2016-03-28 at 14 24 44](https://cloud.githubusercontent.com/assets/67151/14079010/5e614194-f4f2-11e5-895b-92cb55dbfa39.png)


In this [rad_consumer PR](https://github.com/moneyadviceservice/rad_consumer/pull/294) the user can filter on the :workplace_financial_advice.