### PR TITLE
[DEV APPROVED]Add non uk residents support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', '0.0.108'
+gem 'mas-rad_core', '0.0.109'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-rad_core (0.0.108)
+    mas-rad_core (0.0.109)
       active_model_serializers
       geocoder
       httpclient
@@ -358,7 +358,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core (= 0.0.108)
+  mas-rad_core (= 0.0.109)
   oga
   pg
   poltergeist

--- a/app/controllers/self_service/abstract_firms_controller.rb
+++ b/app/controllers/self_service/abstract_firms_controller.rb
@@ -25,6 +25,7 @@ module SelfService
       :ethical_investing_flag,
       :sharia_investing_flag,
       :workplace_financial_advice_flag,
+      :non_uk_residents_flag,
       :status,
       in_person_advice_method_ids: [],
       other_advice_method_ids: [],

--- a/app/views/self_service/firms/questionnaire/_other_services.html.erb
+++ b/app/views/self_service/firms/questionnaire/_other_services.html.erb
@@ -22,5 +22,11 @@
         <%= t('self_service.firm_form.workplace_financial_advice_label') %>
       </label>
     </div>
+    <div class="form__group-item">
+      <label>
+        <%= f.check_box :non_uk_residents_flag, class: "form__input t-non-uk-residents-flag" %>
+        <%= t('self_service.firm_form.non_uk_residents_label') %>
+      </label>
+    </div>
   <% end %>
 </fieldset>

--- a/config/locales/admin/snapshot_attributes.en.yml
+++ b/config/locales/admin/snapshot_attributes.en.yml
@@ -24,6 +24,7 @@ en:
       firms_providing_ethical_investing: Firms providing ethical investing
       firms_providing_sharia_investing: Firms providing sharia investing
       firms_providing_workplace_financial_advice: Firms providing workplace financial advice
+      firms_providing_non_uk_residents: Firms providing non UK resident advice
       firms_offering_languages_other_than_english: Firms providing languages other than English
       offices_with_disabled_access: Offices with disabled access
       registered_advisers: Total number of registered advisers

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -26,7 +26,7 @@ en:
       ethical_investing_label: Ethical investing
       sharia_investing_label: Sharia compliant investments
       workplace_financial_advice_label: Workplace financial advice
-      non_uk_residents_label: Advice to expatriates and/or non-UK residents
+      non_uk_residents_label: Advice to UK expatriates
 
       ongoing_advice_fee_heading: Ongoing advice
 

--- a/config/locales/self_service/firm_form.en.yml
+++ b/config/locales/self_service/firm_form.en.yml
@@ -26,6 +26,7 @@ en:
       ethical_investing_label: Ethical investing
       sharia_investing_label: Sharia compliant investments
       workplace_financial_advice_label: Workplace financial advice
+      non_uk_residents_label: Advice to expatriates and/or non-UK residents
 
       ongoing_advice_fee_heading: Ongoing advice
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160328130032) do
+ActiveRecord::Schema.define(version: 20160329110348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160328130032) do
     t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
     t.boolean  "workplace_financial_advice_flag",          default: false, null: false
+    t.boolean  "non_uk_residents_flag",                    default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree
@@ -344,6 +345,7 @@ ActiveRecord::Schema.define(version: 20160328130032) do
     t.datetime "created_at",                                                             null: false
     t.datetime "updated_at",                                                             null: false
     t.integer  "firms_providing_workplace_financial_advice",                 default: 0
+    t.integer  "firms_providing_non_uk_residents",                           default: 0
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Building on the work in this [mas-rad_core PR](https://github.com/moneyadviceservice/mas-rad_core/pull/153)

This PR allows firms to specify if they support :non_uk_residents and also updates the admin metric report to contain this information in the snapshot data.

![screen shot 2016-03-29 at 14 38 18](https://cloud.githubusercontent.com/assets/67151/14110688/76daf102-f5bf-11e5-862a-103acc3306f4.png)