### PR TITLE
Add additional admin search filters

### DIFF
--- a/app/helpers/admin/firms_helper.rb
+++ b/app/helpers/admin/firms_helper.rb
@@ -16,6 +16,14 @@ module Admin::FirmsHelper
     end
   end
 
+  def render_inline_language_list(firm)
+    firm.languages
+      .map(&LanguageList::LanguageInfo.method(:find))
+      .map(&:common_name)
+      .sort
+      .join(', ')
+  end
+
   def user_for(principal)
     User.find_by_principal_token principal.token
   end

--- a/app/views/admin/advisers/index.html.erb
+++ b/app/views/admin/advisers/index.html.erb
@@ -25,10 +25,29 @@
           <%= f.search_field :firm_registered_name_cont, class: 'form-control' %>
         </div>
       <% end %>
-        <div class="form-group">
-          <%= f.label :postcode_cont, 'Search Post Codes' %>
-          <%= f.search_field :postcode_cont, class: 'form-control' %>
-        </div>
+      <div class="form-group">
+        <%= f.label :postcode_cont, 'Search Post Codes' %>
+        <%= f.search_field :postcode_cont, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :accreditations_id_eq, 'Search Accreditations' %>
+        <%= f.collection_select(:accreditations_id_eq,
+                                Accreditation.all,
+                                :id,
+                                :name,
+                                { include_blank: '-- Please select --' },
+                                { class: 'form-control' }) %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :qualifications_id_eq, 'Search Qualifications' %>
+        <%= f.collection_select(:qualifications_id_eq,
+                                Qualification.all,
+                                :id,
+                                :name,
+                                { include_blank: '-- Please select --' },
+                                { class: 'form-control' }) %>
+      </div>
       <div class="form-group">
         <button type="submit" class="btn btn-default">Submit</button>
       </div>

--- a/app/views/admin/advisers/index.html.erb
+++ b/app/views/admin/advisers/index.html.erb
@@ -36,7 +36,7 @@
                                 :id,
                                 :name,
                                 { include_blank: '-- Please select --' },
-                                { class: 'form-control' }) %>
+                                { class: 'form-control t-accreditations-field' }) %>
       </div>
 
       <div class="form-group">
@@ -46,7 +46,7 @@
                                 :id,
                                 :name,
                                 { include_blank: '-- Please select --' },
-                                { class: 'form-control' }) %>
+                                { class: 'form-control t-qualifications-field' }) %>
       </div>
       <div class="form-group">
         <button type="submit" class="btn btn-default t-submit">Submit</button>

--- a/app/views/admin/advisers/index.html.erb
+++ b/app/views/admin/advisers/index.html.erb
@@ -13,21 +13,21 @@
     <%= search_form_for @search, url: [:admin, firm, :advisers], method: :get do |f| %>
       <div class="form-group">
         <%= f.label :reference_number_cont, 'Search Ref Numbers' %>
-        <%= f.search_field :reference_number_cont, class: 'form-control' %>
+        <%= f.search_field :reference_number_cont, class: 'form-control t-reference-number-field' %>
       </div>
       <div class="form-group">
         <%= f.label :name_cont, 'Search Adviser Names' %>
-        <%= f.search_field :name_cont, class: 'form-control' %>
+        <%= f.search_field :name_cont, class: 'form-control t-name-field' %>
       </div>
       <% unless firm.present? %>
         <div class="form-group">
           <%= f.label :firm_registered_name_cont, 'Search Firms Names' %>
-          <%= f.search_field :firm_registered_name_cont, class: 'form-control' %>
+          <%= f.search_field :firm_registered_name_cont, class: 'form-control t-firm-registered-name-field' %>
         </div>
       <% end %>
       <div class="form-group">
         <%= f.label :postcode_cont, 'Search Post Codes' %>
-        <%= f.search_field :postcode_cont, class: 'form-control' %>
+        <%= f.search_field :postcode_cont, class: 'form-control t-postcode-field' %>
       </div>
       <div class="form-group">
         <%= f.label :accreditations_id_eq, 'Search Accreditations' %>
@@ -49,10 +49,10 @@
                                 { class: 'form-control' }) %>
       </div>
       <div class="form-group">
-        <button type="submit" class="btn btn-default">Submit</button>
+        <button type="submit" class="btn btn-default t-submit">Submit</button>
       </div>
     <% end %>
-    <p>
+    <p class="t-page-entries-info">
       <%= page_entries_info @advisers %>
     </p>
   </div>
@@ -69,13 +69,15 @@
       </tr>
       <% if @advisers.present? %>
           <% @advisers.each do |adviser| %>
-              <tr>
-                <td><%= adviser.reference_number %></td>
-                <td><%= link_to adviser.name, admin_adviser_path(adviser) %></td>
+              <tr class="t-adviser-row">
+                <td class="t-reference-number"><%= adviser.reference_number %></td>
+                <td><%= link_to adviser.name, admin_adviser_path(adviser), class: 't-name' %></td>
                 <% unless firm.present? %>
-                    <td><%= link_to adviser.firm.registered_name, admin_firm_path(adviser.firm) %></td>
+                    <td><%= link_to adviser.firm.registered_name,
+                                    admin_firm_path(adviser.firm),
+                                    class: 't-firm-registered-name' %></td>
                 <% end %>
-                <td><%= adviser.postcode %></td>
+                <td class="t-postcode"><%= adviser.postcode %></td>
                 <td><%= adviser.created_at.to_s(:short) %></td>
               </tr>
           <% end %>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -35,6 +35,11 @@
                             { class: 't-sharia-investing-flag-field' },
                             '1', nil %>Sharia compliant investments
           <% end %>
+          <%= f.label :workplace_financial_advice_flag_true do %>
+            <%= f.check_box :workplace_financial_advice_flag_true,
+                            { class: 't-workplace-financial-advice-flag' },
+                            '1', nil %>Workplace financial advice
+          <% end %>
           <%= f.label :languages_array_present do %>
             <%= f.check_box :languages_array_present,
                             class: 't-languages-field' %>Languages selected

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -15,12 +15,12 @@
       </div>
       <div class="form-group">
         <%= f.label :fca_number_eq, 'Find by FCA Number' %>
-        <%= f.search_field :fca_number_eq, class: 'form-control' %>
+        <%= f.search_field :fca_number_eq, class: 'form-control t-fca-number-field' %>
         <small>Exact matches returned only</small>
       </div>
       <div class="form-group">
         <%= f.label :registered_name_cont, 'Search Firm Names' %>
-        <%= f.search_field :registered_name_cont, class: 'form-control' %>
+        <%= f.search_field :registered_name_cont, class: 'form-control t-registered-name-field' %>
       </div>
       <div class="form-group">
         <label>Filter by Service</label>
@@ -37,10 +37,10 @@
         </div>
       </div>
       <div class="form-group">
-        <button type="submit" class="btn btn-default">Submit</button>
+        <button type="submit" class="btn btn-default t-submit">Submit</button>
       </div>
     <% end %>
-    <p>
+    <p class="t-page-entries-info">
       <%= page_entries_info @firms %>
     </p>
     <p>
@@ -65,7 +65,7 @@
       </tr>
       <% if @firms.present? %>
         <% @firms.each do |firm| %>
-          <tr>
+          <tr class="t-firm-row">
             <td>
               <% if firm.principal.present? %>
                 <%= link_to "#{firm.principal.first_name} #{firm.principal.last_name}", admin_principal_path(firm.principal) %>
@@ -73,9 +73,9 @@
                 N/A
               <% end %>
             </td>
-            <td><%= firm.fca_number %></td>
+            <td class="t-fca-number"><%= firm.fca_number %></td>
             <td>
-              <%= link_to firm.registered_name, admin_firm_path(firm) %>
+              <%= link_to firm.registered_name, admin_firm_path(firm), class: 't-registered-name' %>
               <% if firm.subsidiary? %>
                 <br />
                 <em>subsidiary of <%= link_to firm.parent.registered_name, admin_firm_path(firm.parent) %></em>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -36,7 +36,8 @@
                             '1', nil %>Sharia compliant investments
           <% end %>
           <%= f.label :languages_array_present do %>
-            <%= f.check_box :languages_array_present %>Languages selected
+            <%= f.check_box :languages_array_present,
+                            class: 't-languages-field' %>Languages selected
           <% end %>
         </div>
       </div>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -23,6 +23,20 @@
         <%= f.search_field :registered_name_cont, class: 'form-control' %>
       </div>
       <div class="form-group">
+        <label>Filter by Service</label>
+        <div class="checkbox">
+          <%= f.label :ethical_investing_flag_true do %>
+            <%= f.check_box :ethical_investing_flag_true, {}, '1', nil %>Ethical investments
+          <% end %>
+          <%= f.label :sharia_investing_flag_true do %>
+            <%= f.check_box :sharia_investing_flag_true, {}, '1', nil %>Sharia compliant investments
+          <% end %>
+          <%= f.label :languages_array_present do %>
+            <%= f.check_box :languages_array_present %>Languages selected
+          <% end %>
+        </div>
+      </div>
+      <div class="form-group">
         <button type="submit" class="btn btn-default">Submit</button>
       </div>
     <% end %>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -26,10 +26,14 @@
         <label>Filter by Service</label>
         <div class="checkbox">
           <%= f.label :ethical_investing_flag_true do %>
-            <%= f.check_box :ethical_investing_flag_true, {}, '1', nil %>Ethical investments
+            <%= f.check_box :ethical_investing_flag_true,
+                            { class: 't-ethical-investing-flag-field' },
+                            '1', nil %>Ethical investments
           <% end %>
           <%= f.label :sharia_investing_flag_true do %>
-            <%= f.check_box :sharia_investing_flag_true, {}, '1', nil %>Sharia compliant investments
+            <%= f.check_box :sharia_investing_flag_true,
+                            { class: 't-sharia-investing-flag-field' },
+                            '1', nil %>Sharia compliant investments
           <% end %>
           <%= f.label :languages_array_present do %>
             <%= f.check_box :languages_array_present %>Languages selected

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -84,7 +84,10 @@
          :allowed_payment_methods,
          :minimum_fixed_fee,
          *t('self_service.firm_form.business_split_options').keys,
-         :investment_sizes
+         :investment_sizes,
+         :ethical_investing_flag,
+         :sharia_investing_flag,
+         :workplace_financial_advice_flag,
        ].each do |attribute|
     %>
       <li>
@@ -92,5 +95,10 @@
         <%= render_questionnaire_response(@firm, attribute) %>
       </li>
     <% end %>
+
+    <li>
+      <strong>Languages:</strong>
+      <%= render_inline_language_list(@firm) %>
+    </li>
   </ul>
 <% end %>

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,43 @@
+# Customisation for the Ransack Gem
+Ransack.configure do |config|
+  PG_EMPTY_ARRAY = '{}'.freeze
+
+  # Custom predicates.
+  # See: https://github.com/activerecord-hackery/ransack/wiki/Custom-Predicates
+
+  # Ransack does not support predicates for PostgreSQL array fields by default.
+  # This defines a custom predicate that allows us to put a checkbox on the
+  # Ransack based forms in the admin area, that when checked returns all
+  # records with a non-empty array field.
+  #
+  # E.g. on the form definition we can specifiy
+  #
+  # ```
+  # <%= f.check_box :languages_array_present %>
+  # ```
+  config.add_predicate('array_present', {
+    # Specify what non-compound ARel predicate to use.
+    #
+    # We want to say != '{}' so we use the not_eq predicate
+    arel_predicate: Ransack::Constants::NOT_EQ,
+
+    # Format incoming values from the form.
+    #
+    # We always want to compare the field with the PG empty array constant so
+    # we ignore the actual value from the form and return PG_EMPTY_ARRAY
+    formatter: proc { |_v| PG_EMPTY_ARRAY },
+
+    # Validate a value. An "invalid" value won't be used in a search.
+    #
+    # We only want this filter to be active when the checkbox is checked so we
+    # only consider 'true' values as valid.
+    validator: proc { |v| Ransack::Constants::TRUE_VALUES.include?(v) },
+
+    # Should compounds be created? Will use the compound (any/all) version
+    # of the arel_predicate to create a corresponding any/all version of
+    # your predicate. (Default: true)
+    #
+    # We don't accept multiple values so setting this to false.
+    compounds: false,
+  })
+end

--- a/spec/features/admin/adviser_search_spec.rb
+++ b/spec/features/admin/adviser_search_spec.rb
@@ -1,0 +1,95 @@
+RSpec.feature 'Searching for advisers on the admin interface' do
+  let(:the_page) { Admin::AdvisersIndexPage.new }
+
+  before do
+    given_there_are_advisers
+    given_i_am_on_the_admin_advisers_index_page
+    then_i_see_all_advisers
+  end
+
+  scenario 'Filtering by Ref number' do
+    when_i_filter_by reference_number: 'CHP12345'
+    then_i_see_n_results(1)
+    then_i_only_see_advisers_with reference_number: 'CHP12345'
+
+    when_i_clear_all_filters
+    then_i_see_all_advisers
+  end
+
+  scenario 'Filtering by adviser name' do
+    when_i_filter_by name: 'Wes Montgomery'
+    then_i_see_n_results(1)
+    then_i_only_see_advisers_with name: 'Wes Montgomery'
+
+    when_i_clear_all_filters
+    then_i_see_all_advisers
+  end
+
+  scenario 'Filtering by firm name' do
+    when_i_filter_by firm_registered_name: 'W. Montgomery Financial'
+    then_i_see_n_results(2)
+    then_i_only_see_advisers_with firm_registered_name: 'W. Montgomery Financial'
+
+    when_i_clear_all_filters
+    then_i_see_all_advisers
+  end
+
+  scenario 'Filtering by postcode' do
+    when_i_filter_by postcode: 'EH3 1DY'
+    then_i_see_n_results(1)
+    then_i_only_see_advisers_with postcode: 'EH3 1DY'
+
+    when_i_clear_all_filters
+    then_i_see_all_advisers
+  end
+
+  def given_i_am_on_the_admin_advisers_index_page
+    the_page.load
+    expect(the_page).to be_displayed
+    expect_no_errors
+  end
+
+  def given_there_are_advisers
+    FactoryGirl.create(:firm_without_advisers, registered_name: 'W. Montgomery Financial') do |f|
+      FactoryGirl.create(:adviser, firm: f, name: 'Wes Montgomery')
+      FactoryGirl.create(:adviser, firm: f, postcode: 'EH3 1DY')
+    end
+
+    FactoryGirl.create(:adviser, reference_number: 'CHP12345')
+
+    @advisers = Adviser.all.to_a
+  end
+
+  def when_i_clear_all_filters
+    the_page.clear_form
+    submit_the_form
+  end
+
+  def when_i_filter_by(field_values)
+    the_page.fill_out_form(field_values)
+    submit_the_form
+  end
+
+  def then_i_see_n_results(expected_count)
+    expect(the_page.total_advisers).to eq(expected_count)
+  end
+
+  def then_i_only_see_advisers_with(expected_common_attrs)
+    expect(the_page.advisers).to rspec_all(have_attributes(expected_common_attrs))
+  end
+
+  def then_i_see_all_advisers
+    expect(the_page.total_advisers).to eq(@advisers.count)
+    expect(the_page.advisers.count).to eq(@advisers.count)
+  end
+
+  def expect_no_errors
+    return unless status_code == 500
+    expect(the_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
+  end
+
+  def submit_the_form
+    the_page.submit.click
+    expect_no_errors
+  end
+end

--- a/spec/features/admin/firm_search_spec.rb
+++ b/spec/features/admin/firm_search_spec.rb
@@ -25,6 +25,24 @@ RSpec.feature 'Searching for firms on the admin interface' do
     then_i_see_all_firms
   end
 
+  scenario 'Filtering by services' do
+    when_i_filter_by ethical_investing_flag: true
+    then_i_see_n_results(2)
+    then_i_only_see_firms 'Ethical & sharia', 'Only ethical'
+
+    when_i_filter_by sharia_investing_flag: true
+    then_i_see_n_results(2)
+    then_i_only_see_firms 'Ethical & sharia', 'Only sharia'
+
+    when_i_filter_by ethical_investing_flag: true, sharia_investing_flag: true
+    then_i_see_n_results(1)
+    then_i_only_see_firms 'Ethical & sharia'
+
+    when_i_clear_all_filters
+    then_i_see_all_firms
+  end
+
+
   def given_i_am_on_the_admin_firms_index_page
     the_page.load
     expect(the_page).to be_displayed
@@ -35,7 +53,14 @@ RSpec.feature 'Searching for firms on the admin interface' do
     @firms = [
       FactoryGirl.create(:firm, registered_name: 'Acme Finance'),
       FactoryGirl.create(:firm, fca_number: '123456'),
-      FactoryGirl.create(:firm, fca_number: '123456')
+      FactoryGirl.create(:firm, fca_number: '123456'),
+
+      FactoryGirl.create(:firm, registered_name: 'Ethical & sharia',
+                                ethical_investing_flag: true, sharia_investing_flag: true),
+      FactoryGirl.create(:firm, registered_name: 'Only ethical',
+                                ethical_investing_flag: true, sharia_investing_flag: false),
+      FactoryGirl.create(:firm, registered_name: 'Only sharia',
+                                ethical_investing_flag: false, sharia_investing_flag: true),
     ]
   end
 
@@ -45,6 +70,7 @@ RSpec.feature 'Searching for firms on the admin interface' do
   end
 
   def when_i_filter_by(field_values)
+    the_page.clear_form
     the_page.fill_out_form(field_values)
     submit_the_form
   end
@@ -55,6 +81,10 @@ RSpec.feature 'Searching for firms on the admin interface' do
 
   def then_i_only_see_firms_with(expected_common_attrs)
     expect(the_page.firms).to rspec_all(have_attributes(expected_common_attrs))
+  end
+
+  def then_i_only_see_firms(*expected_firm_names)
+    expect(the_page.firms.map(&:registered_name)).to match_array(expected_firm_names)
   end
 
   def then_i_see_all_firms

--- a/spec/features/admin/firm_search_spec.rb
+++ b/spec/features/admin/firm_search_spec.rb
@@ -1,5 +1,6 @@
 RSpec.feature 'Searching for firms on the admin interface' do
   let(:the_page) { Admin::FirmsIndexPage.new }
+  let(:example_language) { Languages::AVAILABLE_LANGUAGES[0].iso_639_3 }
 
   before do
     given_there_are_firms
@@ -25,7 +26,7 @@ RSpec.feature 'Searching for firms on the admin interface' do
     then_i_see_all_firms
   end
 
-  scenario 'Filtering by services' do
+  scenario 'Filtering by ethical & sharia investing services' do
     when_i_filter_by ethical_investing_flag: true
     then_i_see_n_results(2)
     then_i_only_see_firms 'Ethical & sharia', 'Only ethical'
@@ -42,6 +43,18 @@ RSpec.feature 'Searching for firms on the admin interface' do
     then_i_see_all_firms
   end
 
+  scenario 'Filtering for firms that have selected languages' do
+    when_i_filter_by languages: true
+    then_i_see_n_results(2)
+    then_i_only_see_firms_with fca_number: '234567'
+
+    when_i_filter_by languages: true, registered_name: 'With languages 1'
+    then_i_see_n_results(1)
+    then_i_only_see_firms_with registered_name: 'With languages 1', fca_number: '234567'
+
+    when_i_clear_all_filters
+    then_i_see_all_firms
+  end
 
   def given_i_am_on_the_admin_firms_index_page
     the_page.load
@@ -61,6 +74,11 @@ RSpec.feature 'Searching for firms on the admin interface' do
                                 ethical_investing_flag: true, sharia_investing_flag: false),
       FactoryGirl.create(:firm, registered_name: 'Only sharia',
                                 ethical_investing_flag: false, sharia_investing_flag: true),
+
+      FactoryGirl.create(:firm, registered_name: 'With languages 1',
+                                fca_number: '234567', languages: [example_language]),
+      FactoryGirl.create(:firm, registered_name: 'With languages 2',
+                                fca_number: '234567', languages: [example_language])
     ]
   end
 

--- a/spec/features/admin/firm_search_spec.rb
+++ b/spec/features/admin/firm_search_spec.rb
@@ -56,6 +56,15 @@ RSpec.feature 'Searching for firms on the admin interface' do
     then_i_see_all_firms
   end
 
+  scenario 'Filtering for firms that offer Workplace Financial Advice' do
+    when_i_filter_by workplace_financial_advice_flag: true
+    then_i_see_n_results(1)
+    then_i_only_see_firms_with registered_name: 'Acme Finance'
+
+    when_i_clear_all_filters
+    then_i_see_all_firms
+  end
+
   def given_i_am_on_the_admin_firms_index_page
     the_page.load
     expect(the_page).to be_displayed
@@ -64,7 +73,7 @@ RSpec.feature 'Searching for firms on the admin interface' do
 
   def given_there_are_firms
     @firms = [
-      FactoryGirl.create(:firm, registered_name: 'Acme Finance'),
+      FactoryGirl.create(:firm, registered_name: 'Acme Finance', workplace_financial_advice_flag: true),
       FactoryGirl.create(:firm, fca_number: '123456'),
       FactoryGirl.create(:firm, fca_number: '123456'),
 

--- a/spec/features/admin/firm_search_spec.rb
+++ b/spec/features/admin/firm_search_spec.rb
@@ -1,0 +1,74 @@
+RSpec.feature 'Searching for firms on the admin interface' do
+  let(:the_page) { Admin::FirmsIndexPage.new }
+
+  before do
+    given_there_are_firms
+    given_i_am_on_the_admin_firms_index_page
+    then_i_see_all_firms
+  end
+
+  scenario 'Filtering by FCA number' do
+    when_i_filter_by fca_number: '123456'
+    then_i_see_n_results(2)
+    then_i_only_see_firms_with fca_number: '123456'
+
+    when_i_clear_all_filters
+    then_i_see_all_firms
+  end
+
+  scenario 'Filtering by firm name' do
+    when_i_filter_by registered_name: 'Acme Finance'
+    then_i_see_n_results(1)
+    then_i_only_see_firms_with registered_name: 'Acme Finance'
+
+    when_i_clear_all_filters
+    then_i_see_all_firms
+  end
+
+  def given_i_am_on_the_admin_firms_index_page
+    the_page.load
+    expect(the_page).to be_displayed
+    expect_no_errors
+  end
+
+  def given_there_are_firms
+    @firms = [
+      FactoryGirl.create(:firm, registered_name: 'Acme Finance'),
+      FactoryGirl.create(:firm, fca_number: '123456'),
+      FactoryGirl.create(:firm, fca_number: '123456')
+    ]
+  end
+
+  def when_i_clear_all_filters
+    the_page.clear_form
+    submit_the_form
+  end
+
+  def when_i_filter_by(field_values)
+    the_page.fill_out_form(field_values)
+    submit_the_form
+  end
+
+  def then_i_see_n_results(expected_count)
+    expect(the_page.total_firms).to eq(expected_count)
+  end
+
+  def then_i_only_see_firms_with(expected_common_attrs)
+    expect(the_page.firms).to rspec_all(have_attributes(expected_common_attrs))
+  end
+
+  def then_i_see_all_firms
+    expect(the_page.total_firms).to eq(@firms.count)
+    expect(the_page.firms.count).to eq(@firms.count)
+  end
+
+  def expect_no_errors
+    return unless status_code == 500
+    expect(the_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
+  end
+
+  def submit_the_form
+    the_page.submit.click
+    expect_no_errors
+  end
+end

--- a/spec/support/admin/advisers_index_page.rb
+++ b/spec/support/admin/advisers_index_page.rb
@@ -26,19 +26,37 @@ class Admin::AdvisersIndexPage < SitePrism::Page
   end
 
   element :page_entries_info, '.t-page-entries-info'
+
   element :reference_number_field, '.t-reference-number-field'
   element :name_field, '.t-name-field'
   element :firm_registered_name_field, '.t-firm-registered-name-field'
   element :postcode_field, '.t-postcode-field'
-  sections :advisers, RowSection, '.t-adviser-row'
+  element :qualifications_field, '.t-qualifications-field'
+  element :accreditations_field, '.t-accreditations-field'
   element :submit, '.t-submit'
 
+  sections :advisers, RowSection, '.t-adviser-row'
+
   def fill_out_form(field_values)
-    field_values.each { |field, value| public_send("#{field}_field").set(value) }
+    field_values.each do |field, value|
+      element = public_send("#{field}_field")
+
+      case field
+      when :qualifications, :accreditations
+        element.select(value)
+      else
+        element.set(value)
+      end
+    end
   end
 
   def clear_form
-    fill_out_form(reference_number: '', name: '', firm_registered_name: '', postcode: '')
+    fill_out_form(reference_number: '',
+                  name: '',
+                  firm_registered_name: '',
+                  postcode: '',
+                  accreditations: '-- Please select --',
+                  qualifications: '-- Please select --')
   end
 
   def total_advisers

--- a/spec/support/admin/advisers_index_page.rb
+++ b/spec/support/admin/advisers_index_page.rb
@@ -1,0 +1,49 @@
+class Admin::AdvisersIndexPage < SitePrism::Page
+  set_url '/admin/advisers'
+  set_url_matcher %r{/admin/advisers}
+
+  class RowSection < SitePrism::Section
+    element :reference_number_elem, '.t-reference-number'
+    element :name_elem, '.t-name'
+    element :firm_registered_name_elem, '.t-firm-registered-name'
+    element :postcode_elem, '.t-postcode'
+
+    def reference_number
+      reference_number_elem.text
+    end
+
+    def name
+      name_elem.text
+    end
+
+    def firm_registered_name
+      firm_registered_name_elem.text
+    end
+
+    def postcode
+      postcode_elem.text
+    end
+  end
+
+  element :page_entries_info, '.t-page-entries-info'
+  element :reference_number_field, '.t-reference-number-field'
+  element :name_field, '.t-name-field'
+  element :firm_registered_name_field, '.t-firm-registered-name-field'
+  element :postcode_field, '.t-postcode-field'
+  sections :advisers, RowSection, '.t-adviser-row'
+  element :submit, '.t-submit'
+
+  def fill_out_form(field_values)
+    field_values.each { |field, value| public_send("#{field}_field").set(value) }
+  end
+
+  def clear_form
+    fill_out_form(reference_number: '', name: '', firm_registered_name: '', postcode: '')
+  end
+
+  def total_advisers
+    page_entries_info.text.match(%r{Displaying( all)? (\d) advisers?}) do |match_data|
+      match_data[2].to_i
+    end
+  end
+end

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -21,6 +21,7 @@ class Admin::FirmsIndexPage < SitePrism::Page
   element :registered_name_field, '.t-registered-name-field'
   element :ethical_investing_flag_field, '.t-ethical-investing-flag-field'
   element :sharia_investing_flag_field, '.t-sharia-investing-flag-field'
+  element :workplace_financial_advice_flag_field, '.t-workplace-financial-advice-flag'
   element :languages_field, '.t-languages-field'
   element :submit, '.t-submit'
 
@@ -35,6 +36,7 @@ class Admin::FirmsIndexPage < SitePrism::Page
                   registered_name: '',
                   ethical_investing_flag: false,
                   sharia_investing_flag: false,
+                  workplace_financial_advice_flag: false,
                   languages: false)
   end
 

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -1,0 +1,37 @@
+class Admin::FirmsIndexPage < SitePrism::Page
+  set_url '/admin/firms'
+  set_url_matcher %r{/admin/firms}
+
+  class RowSection < SitePrism::Section
+    element :fca_number_elem, '.t-fca-number'
+    element :registered_name_elem, '.t-registered-name'
+
+    def fca_number
+      fca_number_elem.text
+    end
+
+    def registered_name
+      registered_name_elem.text
+    end
+  end
+
+  element :page_entries_info, '.t-page-entries-info'
+  element :fca_number_field, '.t-fca-number-field'
+  element :registered_name_field, '.t-registered-name-field'
+  sections :firms, RowSection, '.t-firm-row'
+  element :submit, '.t-submit'
+
+  def fill_out_form(field_values)
+    field_values.each { |field, value| public_send("#{field}_field").set(value) }
+  end
+
+  def clear_form
+    fill_out_form(fca_number: '', registered_name: '')
+  end
+
+  def total_firms
+    page_entries_info.text.match(%r{Displaying( all)? (\d) firms?}) do |match_data|
+      match_data[2].to_i
+    end
+  end
+end

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -16,17 +16,24 @@ class Admin::FirmsIndexPage < SitePrism::Page
   end
 
   element :page_entries_info, '.t-page-entries-info'
+
   element :fca_number_field, '.t-fca-number-field'
   element :registered_name_field, '.t-registered-name-field'
-  sections :firms, RowSection, '.t-firm-row'
+  element :ethical_investing_flag_field, '.t-ethical-investing-flag-field'
+  element :sharia_investing_flag_field, '.t-sharia-investing-flag-field'
   element :submit, '.t-submit'
+
+  sections :firms, RowSection, '.t-firm-row'
 
   def fill_out_form(field_values)
     field_values.each { |field, value| public_send("#{field}_field").set(value) }
   end
 
   def clear_form
-    fill_out_form(fca_number: '', registered_name: '')
+    fill_out_form(fca_number: '',
+                  registered_name: '',
+                  ethical_investing_flag: false,
+                  sharia_investing_flag: false)
   end
 
   def total_firms

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -21,6 +21,7 @@ class Admin::FirmsIndexPage < SitePrism::Page
   element :registered_name_field, '.t-registered-name-field'
   element :ethical_investing_flag_field, '.t-ethical-investing-flag-field'
   element :sharia_investing_flag_field, '.t-sharia-investing-flag-field'
+  element :languages_field, '.t-languages-field'
   element :submit, '.t-submit'
 
   sections :firms, RowSection, '.t-firm-row'
@@ -33,7 +34,8 @@ class Admin::FirmsIndexPage < SitePrism::Page
     fill_out_form(fca_number: '',
                   registered_name: '',
                   ethical_investing_flag: false,
-                  sharia_investing_flag: false)
+                  sharia_investing_flag: false,
+                  languages: false)
   end
 
   def total_firms


### PR DESCRIPTION
# What?

Adds new filters to the admin screens.

None of these screens are customer facing.

# Why?

This will help the RAD admin team match up the numbers they see in the metrics with actual data they can look at and inspect.

# Screen shots

![screen shot 2016-03-29 at 16 55 17](https://cloud.githubusercontent.com/assets/306583/14115388/ad5cc4b8-f5d2-11e5-9154-f7b347df4175.png)
![screen shot 2016-03-29 at 16 55 49](https://cloud.githubusercontent.com/assets/306583/14115387/ad5c7c1a-f5d2-11e5-952a-d6e8c2047584.png)
![screen shot 2016-03-29 at 16 49 28](https://cloud.githubusercontent.com/assets/306583/14115391/b20c49b6-f5d2-11e5-98d8-40c2077cccf2.png)