### PR TITLE
7396 principal and user editing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test, :development do
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     builder (3.2.2)
+    byebug (9.0.5)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -187,6 +188,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.4)
@@ -362,6 +366,7 @@ DEPENDENCIES
   oga
   pg
   poltergeist
+  pry-byebug
   pry-rails
   rails (~> 4.2.5.2)
   rails_email_validator
@@ -381,5 +386,8 @@ DEPENDENCIES
   vcr
   webmock
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -8,6 +8,20 @@ class Admin::PrincipalsController < Admin::ApplicationController
     @principal = principal
   end
 
+  def edit
+    @principal = principal
+  end
+
+  def update
+    @principal = principal
+
+    if @principal.update_attributes(principal_params)
+      redirect_to admin_principal_path(@principal)
+    else
+      render 'edit'
+    end
+  end
+
   def destroy
     user = User.find_by(principal: principal)
 
@@ -28,6 +42,12 @@ class Admin::PrincipalsController < Admin::ApplicationController
   end
 
   def principal_params
-    params.require(:principal)
+    params.require(:principal).permit(:first_name,
+                                      :last_name,
+                                      :fca_number,
+                                      :job_title,
+                                      :email_address,
+                                      :telephone_number,
+                                      :confirmed_disclaimer)
   end
 end

--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -6,6 +6,7 @@ class Admin::PrincipalsController < Admin::ApplicationController
 
   def show
     @principal = principal
+    @user = User.find_by(principal_token: principal.token)
   end
 
   def edit

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,13 @@
+class Admin::UserSessionsController < Admin::ApplicationController
+  def create
+    sign_in(:user, user)
+    flash[:notice] = "You are now signed in as #{user.principal.full_name}"
+    redirect_to self_service_root_path
+  end
+
+  private
+
+  def user
+    User.find(params[:user_id])
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,13 +18,6 @@ class Admin::UsersController < Admin::ApplicationController
     end
   end
 
-  def switch_user
-    user = User.find params[:user_id]
-    sign_in(:user, user)
-    flash[:notice] = "You are now signed in as #{user.principal.full_name}"
-    redirect_to self_service_root_path
-  end
-
   private
 
   def user

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,41 @@
 class Admin::UsersController < Admin::ApplicationController
+  def edit
+    @user = user
+  end
+
+  def update
+    @user = user
+
+    if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
+      params[:user].delete(:password)
+      params[:user].delete(:password_confirmation)
+    end
+
+    if @user.update_attributes(user_params)
+      redirect_to admin_principal_path(principal)
+    else
+      render 'edit'
+    end
+  end
+
   def switch_user
     user = User.find params[:user_id]
     sign_in(:user, user)
     flash[:notice] = "You are now signed in as #{user.principal.full_name}"
     redirect_to self_service_root_path
+  end
+
+  private
+
+  def user
+    User.find_by(principal_token: principal.token)
+  end
+
+  def principal
+    Principal.find(params[:principal_id])
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :password, :password_confirmation)
   end
 end

--- a/app/views/admin/principals/edit.html.erb
+++ b/app/views/admin/principals/edit.html.erb
@@ -1,0 +1,56 @@
+<h1>
+  <%= @principal.first_name %> <%= @principal.last_name %>
+  <small>FCA Number <%= @principal.fca_number %></small>
+</h1>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+  <%= form_for([:admin, @principal]) do |f| %>
+    <%= render 'admin/shared/errors', model: @principal %>
+
+    <div class="form-group">
+      <%= f.label :first_name, 'Name' %>
+      <div class="row">
+        <div class="col-sm-3">
+          <%= f.text_field(:first_name, class: 'form-control') %>
+        </div>
+        <div class="col-sm-3">
+          <%= f.text_field(:last_name, class: 'form-control') %>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :fca_number %>
+      <%= f.text_field(:fca_number, class: 'form-control') %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :job_title %>
+      <%= f.text_field(:job_title, class: 'form-control') %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :email_address, 'Email address (as shown in directory)' %>
+      <%= f.text_field(:email_address, class: 'form-control t-email-address') %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :telephone_number %>
+      <%= f.text_field(:telephone_number, class: 'form-control') %>
+    </div>
+
+    <div class="form-group">
+      <h4>Disclaimer</h4>
+      <div class="checkbox">
+        <label for="principal_confirmed_disclaimer">
+          <%= f.check_box :confirmed_disclaimer %>
+          Confirmed disclaimer?
+        </label>
+      </div>
+    </div>
+
+    <%= f.submit 'Save', class: 'btn btn-primary t-save' %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -32,6 +32,11 @@
 <div class="row">
   <div class="col-xs-6">
     <%= render 'admin/shared/sign_in_as_principal', principal: @principal %>
+
+    <h2>Edit</h2>
+    <p>
+      <%= link_to "Edit Principal's directory information", edit_admin_principal_path(@principal), class: 'btn btn-success t-edit-principal' %>
+    </p>
   </div>
   <div class="col-xs-6 text-right">
     <%= button_to 'Delete principal, firm and all related trading names',

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -38,6 +38,6 @@
                   admin_principal_path(@principal.id),
                   class: 't-delete btn btn-danger',
                   method: :delete,
-                  data: { confirm: 'Are you sure you want to delete this principal and all related firm, adviser, office and trading name data?' } %></p>
+                  data: { confirm: 'Are you sure you want to delete this principal and all related firm, adviser, office and trading name data?' } %>
   </div>
 </div>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -21,7 +21,11 @@
       <strong>Phone Number:</strong> <%= @principal.telephone_number %>
     </p>
     <p>
-      <strong>Email:</strong> <%= mail_to @principal.email_address %>
+      <strong>Email:</strong>
+      <%= mail_to @principal.email_address %>
+      <% if @principal.email_address != @user.email %>
+        (login with <%= mail_to @user.email %>)
+      <% end %>
     </p>
     <p>
       <strong>Added:</strong> <%= @principal.created_at.to_s(:long) %>
@@ -36,6 +40,10 @@
     <h2>Edit</h2>
     <p>
       <%= link_to "Edit Principal's directory information", edit_admin_principal_path(@principal), class: 'btn btn-success t-edit-principal' %>
+    </p>
+
+    <p>
+      <%= link_to "Edit Principal's login in credentials", edit_admin_principal_user_path(@principal), class: 'btn btn-success t-edit-user' %>
     </p>
   </div>
   <div class="col-xs-6 text-right">

--- a/app/views/admin/shared/_sign_in_as_principal.html.erb
+++ b/app/views/admin/shared/_sign_in_as_principal.html.erb
@@ -1,8 +1,8 @@
 <% if user_for(principal).present? %>
-  <h2>Edit</h2>
+  <h2>Sign in as Principal</h2>
 
   <%= form_tag(admin_users_sign_in_path) do %>
     <%= hidden_field_tag(:user_id, user_for(principal).id) %>
-    <%= submit_tag "Sign in as #{principal.full_name}", class: 't-sign-in-as-principal' %>
+    <%= submit_tag "Access RAD as #{principal.full_name}", class: 't-sign-in-as-principal' %>
   <% end %>
 <% end %>

--- a/app/views/admin/shared/_sign_in_as_principal.html.erb
+++ b/app/views/admin/shared/_sign_in_as_principal.html.erb
@@ -1,8 +1,7 @@
 <% if user_for(principal).present? %>
   <h2>Sign in as Principal</h2>
 
-  <%= form_tag(admin_users_sign_in_path) do %>
-    <%= hidden_field_tag(:user_id, user_for(principal).id) %>
+  <%= form_tag(admin_user_session_path(user_for(principal))) do %>
     <%= submit_tag "Access RAD as #{principal.full_name}", class: 't-sign-in-as-principal' %>
   <% end %>
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,29 @@
+<h1>
+  <%= @user.principal.first_name %> <%= @user.principal.last_name %>
+  <small>FCA Number <%= @user.principal.fca_number %></small>
+</h1>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+  <%= form_for @user, url: admin_principal_user_path(@user.principal), method: :put do |f| %>
+    <%= render 'admin/shared/errors', model: @user %>
+
+    <div class="form-group">
+      <%= f.label :email_address, 'Email address (for login only)' %>
+      <%= f.text_field :email, class: 'form-control t-email-address' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control t-password' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :password_confirmation %>
+      <%= f.password_field :password_confirmation, class: 'form-control t-password-confirmation' %>
+    </div>
+
+    <%= f.submit 'Save', class: 'btn btn-primary t-save' %>
+  <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root 'pages#home'
 
-    post '/users/sign_in', to: 'users#switch_user'
+    post '/users/:user_id/sign_in', to: 'user_sessions#create', as: :user_session
 
     resources :advisers, only: [:index, :show, :edit, :update, :destroy]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,9 @@ Rails.application.routes.draw do
       resources :firms, only: :index
       resources :subsidiaries, only: :index
     end
-    resources :principals, except: [:new, :create]
+    resources :principals, except: [:new, :create] do
+      resource :user, only: [:edit, :update]
+    end
 
     namespace :reports do
       resources :metrics, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
       resources :firms, only: :index
       resources :subsidiaries, only: :index
     end
-    resources :principals, only: [:index, :show, :destroy]
+    resources :principals, except: [:new, :create]
 
     namespace :reports do
       resources :metrics, only: [:index, :show] do

--- a/spec/features/admin/access_spec.rb
+++ b/spec/features/admin/access_spec.rb
@@ -27,32 +27,32 @@ RSpec.feature 'Accessing the admin area' do
     when_i_visit_the_admin_home_page
     then_i_am_denied_access
   end
-end
 
-def given_i_am_required_to_authenticate_to_access_admin
-  allow(HttpAuthentication).to receive(:required?) { true }
-end
+  def given_i_am_required_to_authenticate_to_access_admin
+    allow(HttpAuthentication).to receive(:required?) { true }
+  end
 
-def given_i_am_not_required_to_authenticate_to_access_admin
-  allow(HttpAuthentication).to receive(:required?) { false }
-end
+  def given_i_am_not_required_to_authenticate_to_access_admin
+    allow(HttpAuthentication).to receive(:required?) { false }
+  end
 
-def and_i_authenticate_with_valid_credentials
-  page.driver.browser.basic_authorize(username, password)
-end
+  def and_i_authenticate_with_valid_credentials
+    page.driver.browser.basic_authorize(username, password)
+  end
 
-def and_i_authenticate_with_invalid_credentials
-  page.driver.browser.basic_authorize(username, password.reverse)
-end
+  def and_i_authenticate_with_invalid_credentials
+    page.driver.browser.basic_authorize(username, password.reverse)
+  end
 
-def when_i_visit_the_admin_home_page
-  visit(admin_root_path)
-end
+  def when_i_visit_the_admin_home_page
+    visit(admin_root_path)
+  end
 
-def then_i_am_granted_access
-  expect(page.status_code).to eq(200)
-end
+  def then_i_am_granted_access
+    expect(page.status_code).to eq(200)
+  end
 
-def then_i_am_denied_access
-  expect(page.status_code).to eq(401)
+  def then_i_am_denied_access
+    expect(page.status_code).to eq(401)
+  end
 end

--- a/spec/features/admin/delete_adviser_spec.rb
+++ b/spec/features/admin/delete_adviser_spec.rb
@@ -8,24 +8,24 @@ RSpec.feature 'Deleting an adviser from the admin interface' do
     then_the_adviser_is_deleted
     and_i_am_redirected_to_the_adviser_list_page
   end
-end
 
-def given_there_is_an_adviser
-  @adviser = create(:adviser)
-end
+  def given_there_is_an_adviser
+    @adviser = create(:adviser)
+  end
 
-def when_i_visit_an_adviser_page
-  visit(admin_adviser_path(@adviser))
-end
+  def when_i_visit_an_adviser_page
+    visit(admin_adviser_path(@adviser))
+  end
 
-def and_i_click_delete_adviser
-  admin_adviser_page.delete_adviser.click
-end
+  def and_i_click_delete_adviser
+    admin_adviser_page.delete_adviser.click
+  end
 
-def then_the_adviser_is_deleted
-  expect(Adviser.find_by_id(@adviser.id)).to be_nil
-end
+  def then_the_adviser_is_deleted
+    expect(Adviser.find_by_id(@adviser.id)).to be_nil
+  end
 
-def and_i_am_redirected_to_the_adviser_list_page
-  expect(page.current_path).to eq admin_advisers_path
+  def and_i_am_redirected_to_the_adviser_list_page
+    expect(page.current_path).to eq admin_advisers_path
+  end
 end

--- a/spec/features/admin/delete_principal_and_entire_firm_spec.rb
+++ b/spec/features/admin/delete_principal_and_entire_firm_spec.rb
@@ -8,44 +8,44 @@ RSpec.feature 'Deleting principal and all related firm, adviser, office and trad
     then_the_principal_and_all_related_data_is_removed
     and_i_am_redirected_to_the_principal_list_page
   end
-end
 
-def given_there_is_firm
-  @firm = FactoryGirl.create(:firm_with_trading_names, :with_principal)
-  @principal = @firm.principal
-  @principal.update(firm: @firm)
-  @user = FactoryGirl.create(:user, principal: @principal)
+  def given_there_is_firm
+    @firm = FactoryGirl.create(:firm_with_trading_names, :with_principal)
+    @principal = @firm.principal
+    @principal.update(firm: @firm)
+    @user = FactoryGirl.create(:user, principal: @principal)
 
-  expect(User.find_by(principal: @principal)).to eq(@user)
-  expect(@principal).not_to be_nil
-  expect(@firm.offices.count).to be(1)
-  expect(@firm.advisers.count).to be(1)
-  expect(@firm.trading_names.count).to be(3)
+    expect(User.find_by(principal: @principal)).to eq(@user)
+    expect(@principal).not_to be_nil
+    expect(@firm.offices.count).to be(1)
+    expect(@firm.advisers.count).to be(1)
+    expect(@firm.trading_names.count).to be(3)
 
-  @office = @firm.offices[0]
-  @adviser = @firm.advisers[0]
-  @trading_name = @firm.trading_names[0]
-end
+    @office = @firm.offices[0]
+    @adviser = @firm.advisers[0]
+    @trading_name = @firm.trading_names[0]
+  end
 
-def when_i_visit_the_principal_page
-  admin_principal_page.load(principal_token: @principal.id)
-  expect(admin_principal_page).to be_displayed
-end
+  def when_i_visit_the_principal_page
+    admin_principal_page.load(principal_token: @principal.id)
+    expect(admin_principal_page).to be_displayed
+  end
 
-def and_i_click_delete
-  admin_principal_page.delete.click
-end
+  def and_i_click_delete
+    admin_principal_page.delete.click
+  end
 
-def then_the_principal_and_all_related_data_is_removed
-  expect(Principal.exists?(@principal.id)).to be(false)
-  expect(Firm.exists?(@firm.id)).to be(false)
-  expect(User.exists?(@user.id)).to be(false)
-  expect(Office.exists?(@office.id)).to be(false)
-  expect(Adviser.exists?(@adviser.id)).to be(false)
-  expect(Firm.exists?(@trading_name.id)).to be(false)
-end
+  def then_the_principal_and_all_related_data_is_removed
+    expect(Principal.exists?(@principal.id)).to be(false)
+    expect(Firm.exists?(@firm.id)).to be(false)
+    expect(User.exists?(@user.id)).to be(false)
+    expect(Office.exists?(@office.id)).to be(false)
+    expect(Adviser.exists?(@adviser.id)).to be(false)
+    expect(Firm.exists?(@trading_name.id)).to be(false)
+  end
 
-def and_i_am_redirected_to_the_principal_list_page
-  expect(page.current_path).to eq admin_principals_path
-  expect(find('.t-flash-message')).to have_text('Successfully deleted')
+  def and_i_am_redirected_to_the_principal_list_page
+    expect(page.current_path).to eq admin_principals_path
+    expect(find('.t-flash-message')).to have_text('Successfully deleted')
+  end
 end

--- a/spec/features/admin/delete_principal_and_entire_firm_spec.rb
+++ b/spec/features/admin/delete_principal_and_entire_firm_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature 'Deleting principal and all related firm, adviser, office and trading name data' do
-  let(:admin_principal_page) { Admin::EditPrincipalPage.new }
+  let(:admin_principal_page) { Admin::PrincipalPage.new }
 
   scenario 'Admin deletes a principal and all related data' do
     given_there_is_firm

--- a/spec/features/admin/edit_principal_spec.rb
+++ b/spec/features/admin/edit_principal_spec.rb
@@ -1,0 +1,47 @@
+RSpec.feature "Editing a principal's details (as shown in the directory)" do
+  let(:admin_principal_page) { Admin::PrincipalPage.new }
+  let(:edit_admin_principal_page) { Admin::EditPrincipalPage.new }
+
+  scenario "Admin edits a Princpal's directory email" do
+    given_there_is_firm
+    when_i_visit_the_principal_page
+    and_i_click_edit_directory_information
+    and_i_change_the_email_address
+    and_i_click_save
+
+    then_the_principals_email_address_should_have_been_updated
+    and_i_am_redirected_to_the_principal_page
+  end
+
+  def given_there_is_firm
+    @firm = FactoryGirl.create(:firm_with_trading_names, :with_principal)
+    @principal = @firm.principal
+    @principal.update(firm: @firm)
+    @user = FactoryGirl.create(:user, principal: @principal)
+  end
+
+  def when_i_visit_the_principal_page
+    admin_principal_page.load(principal_token: @principal.id)
+  end
+
+  def and_i_click_edit_directory_information
+    admin_principal_page.edit_directory_information.click
+  end
+
+  def and_i_change_the_email_address
+    @new_email_address = Faker::Internet.email
+    edit_admin_principal_page.email_address.set @new_email_address
+  end
+
+  def and_i_click_save
+    edit_admin_principal_page.save.click
+  end
+
+  def then_the_principals_email_address_should_have_been_updated
+    expect(@principal.reload.email_address).to eq @new_email_address
+  end
+
+  def and_i_am_redirected_to_the_principal_page
+    expect(page.current_path).to eq admin_principal_path(@principal)
+  end
+end

--- a/spec/features/admin/edit_user_spec.rb
+++ b/spec/features/admin/edit_user_spec.rb
@@ -1,0 +1,69 @@
+RSpec.feature "Editing a user (i.e. a Principal's login credentials)" do
+  let(:admin_principal_page) { Admin::PrincipalPage.new }
+  let(:edit_admin_principal_user_page) { Admin::EditPrincipalUserPage.new }
+
+  scenario "Admin edits a Princpal's login email" do
+    given_there_is_firm
+    when_i_visit_the_principal_page
+    and_i_click_edit_login_credentials
+    and_i_change_the_email_address
+    and_i_click_save
+
+    then_the_users_email_address_should_have_been_updated
+    and_i_am_redirected_to_the_principal_page
+  end
+
+  scenario "Admin resets a Princpal's password" do
+    given_there_is_firm
+    when_i_visit_the_principal_page
+    and_i_click_edit_login_credentials
+    and_i_enter_a_new_password_and_confirmation
+    and_i_click_save
+
+    then_the_users_password_should_have_been_updated
+    and_i_am_redirected_to_the_principal_page
+  end
+
+  def given_there_is_firm
+    @firm = FactoryGirl.create(:firm_with_trading_names, :with_principal)
+    @principal = @firm.principal
+    @principal.update(firm: @firm)
+    @user = FactoryGirl.create(:user, principal: @principal)
+  end
+
+  def when_i_visit_the_principal_page
+    admin_principal_page.load(principal_token: @principal.id)
+  end
+
+  def and_i_click_edit_login_credentials
+    admin_principal_page.edit_login_credentials.click
+  end
+
+  def and_i_change_the_email_address
+    @new_email_address = Faker::Internet.email
+    edit_admin_principal_user_page.email_address.set @new_email_address
+  end
+
+  def and_i_enter_a_new_password_and_confirmation
+    # Faker can't generate a password that meets our requirements
+    @new_password = 'aBcD1234+-_.'.split('').shuffle.join
+    edit_admin_principal_user_page.password.set @new_password
+    edit_admin_principal_user_page.password_confirmation.set @new_password
+  end
+
+  def and_i_click_save
+    edit_admin_principal_user_page.save.click
+  end
+
+  def then_the_users_email_address_should_have_been_updated
+    expect(@user.reload.email).to eq @new_email_address
+  end
+
+  def then_the_users_password_should_have_been_updated
+    expect(@user.reload).to be_valid_password(@new_password)
+  end
+
+  def and_i_am_redirected_to_the_principal_page
+    expect(page.current_path).to eq admin_principal_path(@principal)
+  end
+end

--- a/spec/support/admin/edit_principal_page.rb
+++ b/spec/support/admin/edit_principal_page.rb
@@ -1,0 +1,7 @@
+class Admin::EditPrincipalPage < SitePrism::Page
+  set_url '/admin/principals/{principal_token}/edit'
+  set_url_matcher %r{/admin/principals/[a-z0-9]+/edit}
+
+  element :email_address, '.t-email-address'
+  element :save, '.t-save'
+end

--- a/spec/support/admin/edit_principal_user_page.rb
+++ b/spec/support/admin/edit_principal_user_page.rb
@@ -1,0 +1,9 @@
+class Admin::EditPrincipalUserPage < SitePrism::Page
+  set_url '/admin/principals/{principal_token}/user/edit'
+  set_url_matcher %r{/admin/principals/[a-z0-9]+/user/edit}
+
+  element :email_address, '.t-email-address'
+  element :password, '.t-password'
+  element :password_confirmation, '.t-password-confirmation'
+  element :save, '.t-save'
+end

--- a/spec/support/admin/principal_page.rb
+++ b/spec/support/admin/principal_page.rb
@@ -1,4 +1,4 @@
-class Admin::EditPrincipalPage < SitePrism::Page
+class Admin::PrincipalPage < SitePrism::Page
   set_url '/admin/principals/{principal_token}'
   set_url_matcher %r{/admin/principals/[a-z0-9]+}
 

--- a/spec/support/admin/principal_page.rb
+++ b/spec/support/admin/principal_page.rb
@@ -2,5 +2,6 @@ class Admin::PrincipalPage < SitePrism::Page
   set_url '/admin/principals/{principal_token}'
   set_url_matcher %r{/admin/principals/[a-z0-9]+}
 
+  element :edit_directory_information, '.t-edit-principal'
   element :delete, '.t-delete'
 end

--- a/spec/support/admin/principal_page.rb
+++ b/spec/support/admin/principal_page.rb
@@ -3,5 +3,6 @@ class Admin::PrincipalPage < SitePrism::Page
   set_url_matcher %r{/admin/principals/[a-z0-9]+}
 
   element :edit_directory_information, '.t-edit-principal'
+  element :edit_login_credentials, '.t-edit-user'
   element :delete, '.t-delete'
 end


### PR DESCRIPTION
Admins currently can only modify such information by using the 'login as principal' functionality, which works for most things, but will not permit them to reset their password.

This PR resolves this issue by adding a real back for managing a principal's main directory details and their login credentials (the `User` model).

Additionally I found that a bunch of features had their step methods defined in the global scope, causing overlap, so I fixed those up. Plus a few other bits of tidying.