### PR TITLE
[DEV APPROVED] - 7642 - FCA import email notification

### DIFF
--- a/app/jobs/fca_import_job.rb
+++ b/app/jobs/fca_import_job.rb
@@ -43,34 +43,46 @@ class FcaImportJob < ActiveJob::Base
     @slack ||= Slack::Web::Client.new
   end
 
-  def slack_formatter(outcomes)
-    text = ''
-    if import_successful?(outcomes)
-      text = "<!here> The FCA data have been loaded into RAD. Visit #{admin_lookup_fca_import_index_url} to confirm that the data looks ok" # rubocop:disable all
-    else
-      erroneous = outcomes
-                  .select { |(_, s, _)| s == false }
-                  .map { |(f, _, o)| "Zip file #{f} caused error: #{o}" }
-      erroneous.insert(0, '<!here> Import has failed')
-      erroneous.insert(-1, "You can cancel this import here #{admin_lookup_fca_import_index_url}")
-      text = erroneous.join("\n")
-    end
-
-    logger.info("Notification msg: #{text}")
-    {
-      channel: FCA::Config.notify[:slack][:channel],
-      as_user: true,
-      text:    text
-    }
-  end
-
   def default_url_options
     { host: FCA::Config.hostname }
   end
 
-  def notify(outcomes)
-    slack.chat_postMessage(slack_formatter(outcomes))
+  def notify_slack(text)
+    tries ||= 1
+    slack.chat_postMessage(
+      channel: FCA::Config.notify[:slack][:channel],
+      as_user: true,
+      text:    "<!here> #{text}"
+    )
   rescue
     logger.error 'An error occured while trying to post msg'
+    retry if (tries += 1) <= 3
+  end
+
+  def notify_email(text)
+    FcaImportMailer.notify(
+      FCA::Config.email_recipients,
+      text
+    ).deliver_later
+  end
+
+  def notification_text(outcomes)
+    if import_successful?(outcomes)
+      "The FCA data have been loaded into RAD. Visit #{admin_lookup_fca_import_index_url} to confirm that the data looks ok" # rubocop:disable all
+    else
+      erroneous = outcomes
+                  .select { |(_, s, _)| s == false }
+                  .map { |(f, _, o)| "Zip file #{f} caused error: #{o}" }
+      erroneous.insert(0, 'Import has failed')
+      erroneous.insert(-1, "You can cancel this import here #{admin_lookup_fca_import_index_url}")
+      erroneous.join("\n")
+    end
+  end
+
+  def notify(outcomes)
+    text = notification_text(outcomes)
+    logger.info("Notification msg: #{text}")
+    notify_email(text)
+    notify_slack(text)
   end
 end

--- a/app/mailers/fca_import_mailer.rb
+++ b/app/mailers/fca_import_mailer.rb
@@ -2,9 +2,9 @@ class FcaImportMailer < ApplicationMailer
   default from: 'RADenquiries@moneyadviceservice.org.uk'
   helper_method :protect_against_forgery?
 
-  def notify(users, outcomes)
-    @outcomes = outcomes || []
-    mail(to: users, subject: 'Automated FCA Import Confirmation')
+  def notify(users, text)
+    @text = text
+    mail(to: users, subject: 'Automated FCA Import Notification')
   end
 
   protected

--- a/app/views/fca_import_mailer/notify.html.erb
+++ b/app/views/fca_import_mailer/notify.html.erb
@@ -1,21 +1,2 @@
-<h2>FCA Import result</h2>
-<table>
-    <thead>
-        <tr><th>Table</th><th>Added</th><th>Updated</th><th>Deleted</th></tr>
-    </thead>
-    <tbody>
-        <% @outcomes.each do |(table, added, updated, deleted)| %>
-            <tr>
-                <td><%= table %></td><td><%= added %><%= updated %></td><td><%= deleted %></td>
-            </tr>
-        <% end %>
-        <% if @outcomes.blank? %>
-            <p>Sorry an error occured while importing files.</p>
-            <p>Please contact the development team</p>
-        <% else %>
-            <% form_tag admin_lookup_fca_import_index_url, method: :post do %>
-                <%= submit_tag %>
-            <% end %>
-        <% end %>
-    </tbody>
-</table>
+<h1>FCA Import Notification</h1>
+<div><%= @text %></div>

--- a/config/initializers/fca.rb
+++ b/config/initializers/fca.rb
@@ -11,4 +11,7 @@ FCA::Config.configure do |config|
   config.hostname  = ENV.fetch('RAD_HOSTNAME') {
     dev_or_test ? 'localhost' : fail('Missing env var `RAD_HOSTNAME`')
   }
+  config.email_recipients  = ENV.fetch('FCA_IMPORT_EMAILS') {
+    dev_or_test ? 'dev@moneyadviceservice.org.uk' : fail('Missing env var `FCA_IMPORT_EMAILS` email1, email2, ...')
+  }
 end

--- a/lib/fca/config.rb
+++ b/lib/fca/config.rb
@@ -6,7 +6,7 @@ module FCA
     class << self
       extend Forwardable
 
-      def_delegators :config, :logger, :notify, :hostname
+      def_delegators :config, :logger, :notify, :hostname, :email_recipients
 
       def configure
         yield config if block_given?
@@ -20,7 +20,7 @@ module FCA
     LOG_LEVEL = %w(UNKNOWN FATAL ERROR WARN INFO DEBUG).freeze
 
     attr_accessor :notify, :hostname
-    attr_writer :log_file, :log_level
+    attr_writer :log_file, :log_level, :email_recipients
 
     def logger
       @logger ||= ::Logger.new(log_file, ::File::APPEND)
@@ -36,6 +36,11 @@ module FCA
     def log_level
       level = LOG_LEVEL.detect { |level| level == @log_level.to_s.upcase.strip } || 'INFO'
       Object.const_get("Logger::#{level}")
+    end
+
+    def email_recipients
+      return @email_recipients if @email_recipients.is_a?(Array)
+      @email_recipients = @email_recipients.split(',').map!(&:strip) if @email_recipients.present?
     end
   end
 end

--- a/spec/lib/fca/config_spec.rb
+++ b/spec/lib/fca/config_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe FCA::Config do
       c.log_file  = file
       c.notify    = slack
       c.hostname  = 'mas.com'
+      c.email_recipients = emails
     end
   end
   let(:slack) { { slack: { channel: '#test' } } }
@@ -12,6 +13,7 @@ RSpec.describe FCA::Config do
   describe 'FCA::Config.configure' do
     let(:file)  { '/tmp/fca_import.log' }
     let(:level) { :debug }
+    let(:emails) { 'user@email.com, foo@email.org.uk' }
 
     it 'saves `log_file` configuration' do
       expect(fca_config.log_file).to eq file
@@ -27,6 +29,10 @@ RSpec.describe FCA::Config do
 
     it 'returns a logger instance' do
       expect(fca_config.logger).to be_a(Logger)
+    end
+
+    it 'returns array of emails' do
+      expect(fca_config.email_recipients).to match_array %w(user@email.com foo@email.org.uk)
     end
 
     context 'default configuration' do

--- a/spec/mailers/fca_import_mailer_spec.rb
+++ b/spec/mailers/fca_import_mailer_spec.rb
@@ -1,20 +1,12 @@
 RSpec.describe FcaImportMailer, type: :mailer do
-  let(:recipient) { 'RADenquiries@moneyadviceservice.org.uk' }
-  let(:subject_line) { 'Automated FCA Import Confirmation' }
-  let(:users) { %w(user1@mas.org.uk user2@mas.org.uk) }
-  let(:outcomes) do
-    [
-      ['advisers',     [], [], []],
-      ['firms',        [], [], []],
-      ['subsidiaries', [], [], []]
-    ]
-  end
+  let(:recipient)    { 'RADenquiries@moneyadviceservice.org.uk' }
+  let(:subject_line) { 'Automated FCA Import Notification' }
+  let(:users)        { %w(user1@mas.org.uk user2@mas.org.uk) }
+  let(:text)         { 'Some text ...' }
 
-  subject { FcaImportMailer.notify(users, outcomes) }
+  subject { FcaImportMailer.notify(users, text) }
 
   specify { expect(subject.to).to match_array(users) }
   specify { expect(subject.subject).to eq(subject_line) }
-  specify { expect(subject.body.encoded).to include('advisers') }
-  specify { expect(subject.body.encoded).to include('firms') }
-  specify { expect(subject.body.encoded).to include('subsidiaries') }
+  specify { expect(subject.body.encoded).to include(text) }
 end


### PR DESCRIPTION
**Feature**
Send an email after import job is finished to notify registered users.
Users can be registered by setting the environment variable `FCA_IMPORT_EMAILS` with a comma separated list of email addresses.
