### PR TITLE
[BUG] rename column registered_name to name on the lookup_subsidiaries table

### DIFF
--- a/lib/fca/query.rb
+++ b/lib/fca/query.rb
@@ -21,7 +21,7 @@ module FCA
       },
       lookup_subsidiaries: {
         fca_number:        'integer NOT NULL,',
-        registered_name:   'varchar(255) NOT NULL DEFAULT \'\',',
+        name:              'varchar(255) NOT NULL DEFAULT \'\',',
         created_at:        'timestamp NOT NULL,',
         updated_at:        'timestamp NOT NULL'
       }

--- a/spec/lib/fca/query_spec.rb
+++ b/spec/lib/fca/query_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe FCA::Query do
     end
   end
 
+  describe 'Temporay table schema' do
+    context 'lookup_subsidiaries' do
+      let(:subsidiares) { FCA::Query::SCHEMA[:lookup_subsidiaries] }
+      it 'has a schema' do
+        expect(subsidiares).to include(fca_number: 'integer NOT NULL,', name: 'varchar(255) NOT NULL DEFAULT \'\',')
+      end
+    end
+  end
+
   describe 'Query.find' do
     let(:query)   { FCA::Query.find(header, options) }
 


### PR DESCRIPTION
**Description**
The FCA import script uses temporary table to load the data. However there was a mistake on the lookup_subsidiaries table schema.

**Solution**
rename registered_name to name on the temp lookup_subsidiaries table