### PR TITLE
[DEV APPROVED] Added Website to office form

### DIFF
--- a/app/controllers/self_service/offices_controller.rb
+++ b/app/controllers/self_service/offices_controller.rb
@@ -63,6 +63,7 @@ module SelfService
         :address_postcode,
         :email_address,
         :telephone_number,
+        :website,
         :disabled_access
       )
     end

--- a/app/views/self_service/offices/_form.html.erb
+++ b/app/views/self_service/offices/_form.html.erb
@@ -70,6 +70,14 @@
     <%= f.text_field :telephone_number, class: 't-telephone-number' %>
   <% end %>
 
+  <%= f.form_row :website do %>
+    <%= f.errors_for :website %>
+    <%= f.label :website,
+                Office.human_attribute_name(:website),
+                class: 'form__label-heading' %>
+    <%= f.text_field :website %>
+  <% end %>
+
   <%= f.form_row :disabled_access do %>
     <%= f.errors_for :disabled_access %>
     <label>

--- a/db/migrate/20161216141323_add_website_to_office.rb
+++ b/db/migrate/20161216141323_add_website_to_office.rb
@@ -1,0 +1,5 @@
+class AddWebsiteToOffice < ActiveRecord::Migration
+  def change
+    add_column :offices, :website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160913094015) do
+ActiveRecord::Schema.define(version: 20161216141323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -84,6 +85,27 @@ ActiveRecord::Schema.define(version: 20160913094015) do
     t.text     "result"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "fcaimport_lookup_advisers", force: :cascade do |t|
+    t.string   "reference_number", limit: 20,  null: false
+    t.string   "name",             limit: 255, null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
+
+  create_table "fcaimport_lookup_firms", force: :cascade do |t|
+    t.integer  "fca_number",                               null: false
+    t.string   "registered_name", limit: 255, default: "", null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+  end
+
+  create_table "fcaimport_lookup_subsidiaries", force: :cascade do |t|
+    t.integer  "fca_number",                          null: false
+    t.string   "name",       limit: 255, default: "", null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
   create_table "firms", force: :cascade do |t|
@@ -176,32 +198,53 @@ ActiveRecord::Schema.define(version: 20160913094015) do
     t.string   "cy_name"
   end
 
-  create_table "lookup_advisers", force: :cascade do |t|
+  create_table "last_week_lookup_advisers", force: :cascade do |t|
     t.string   "reference_number", null: false
     t.string   "name",             null: false
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
   end
 
-  add_index "lookup_advisers", ["reference_number"], name: "index_lookup_advisers_on_reference_number", unique: true, using: :btree
+  add_index "last_week_lookup_advisers", ["reference_number"], name: "index_lookup_advisers_on_reference_number", unique: true, using: :btree
 
-  create_table "lookup_firms", force: :cascade do |t|
+  create_table "last_week_lookup_firms", force: :cascade do |t|
     t.integer  "fca_number",                   null: false
     t.string   "registered_name", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "lookup_firms", ["fca_number"], name: "index_lookup_firms_on_fca_number", unique: true, using: :btree
+  add_index "last_week_lookup_firms", ["fca_number"], name: "index_lookup_firms_on_fca_number", unique: true, using: :btree
 
-  create_table "lookup_subsidiaries", force: :cascade do |t|
+  create_table "last_week_lookup_subsidiaries", force: :cascade do |t|
     t.integer  "fca_number",              null: false
     t.string   "name",       default: "", null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
 
-  add_index "lookup_subsidiaries", ["fca_number"], name: "index_lookup_subsidiaries_on_fca_number", using: :btree
+  add_index "last_week_lookup_subsidiaries", ["fca_number"], name: "index_lookup_subsidiaries_on_fca_number", using: :btree
+
+  create_table "lookup_advisers", force: :cascade do |t|
+    t.string   "reference_number", limit: 20,  null: false
+    t.string   "name",             limit: 255, null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
+
+  create_table "lookup_firms", force: :cascade do |t|
+    t.integer  "fca_number",                               null: false
+    t.string   "registered_name", limit: 255, default: "", null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+  end
+
+  create_table "lookup_subsidiaries", force: :cascade do |t|
+    t.integer  "fca_number",                          null: false
+    t.string   "name",       limit: 255, default: "", null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
 
   create_table "offices", force: :cascade do |t|
     t.string   "address_line_one",                 null: false
@@ -217,6 +260,7 @@ ActiveRecord::Schema.define(version: 20160913094015) do
     t.datetime "updated_at",                       null: false
     t.float    "latitude"
     t.float    "longitude"
+    t.string   "website"
   end
 
   create_table "old_passwords", force: :cascade do |t|


### PR DESCRIPTION
[Card 7836](https://moneyadviceservice.tpondemand.com/entity/7836)

User Story: 
As a principal/adviser, I would like to have the option to add my own website under offices so that consumers can get more information about my firm and the type of services we provide.

Depends on [mas-rad_core#155](https://github.com/moneyadviceservice/mas-rad_core/pull/155)

