### PR TITLE
[DEV APPROVED] change VCR cassette URL

### DIFF
--- a/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_self_service_offices_add_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20Floor%205,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/features_self_service_offices_edit_spec.yml
+++ b/spec/fixtures/vcr_cassettes/features_self_service_offices_edit_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -103,6 +103,6 @@ http_interactions:
            ],
            "status" : "OK"
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 13 Nov 2015 13:43:23 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
[TP#8189 Card](https://moneyadviceservice.tpondemand.com/entity/8189)

The url that was used to record the VCR cassette no longer responds to the API. This PR changes is to use the original working URL for the Google Maps API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/rad/404)
<!-- Reviewable:end -->
