### PR TITLE
[DEV APPROVED] TP#8070: Adds ability to download registered advisers as a CSV file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,4 +456,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.12.5
+   1.15.0

--- a/app/controllers/admin/reports/registered_adviser_controller.rb
+++ b/app/controllers/admin/reports/registered_adviser_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  module Reports
+    class RegisteredAdviserController < Admin::ApplicationController
+      respond_to :html, :csv
+
+      def index
+        advisers = Adviser.all
+        @registered_advisers = advisers.page(params[:page])
+        @registered_advisers_list = AdviserListCsv.new(advisers)
+
+        respond_with(@registered_advisers_list, filename: filename)
+      end
+
+      private
+
+      def filename
+        "registered_advisers_#{Time.zone.today}"
+      end
+    end
+  end
+end

--- a/app/views/admin/reports/registered_adviser/index.html.erb
+++ b/app/views/admin/reports/registered_adviser/index.html.erb
@@ -1,0 +1,40 @@
+<h2>Registered Advisers</h2>
+
+<p>
+  This report shows all advisers whose FCA status is still 'Active'.
+</p>
+
+<p>
+  The <a href="https://register.fca.org.uk/">Financial Services Register</a>
+  can be searched to determine exactly what status change has occurred.
+</p>
+
+<% if @registered_advisers.present? %>
+  <p>
+    <%= link_to 'Download as CSV',
+          admin_reports_registered_adviser_index_path(format: :csv),
+          class: 'btn btn-primary' %>
+  </p>
+<% end %>
+
+<table class="table table-bordered">
+  <tr>
+    <th>Ref Number</th>
+    <th>Name</th>
+    <th>Firm</th>
+  </tr>
+  <% if @registered_advisers.present? %>
+    <% @registered_advisers.each do |adviser| %>
+      <tr>
+        <td><%= adviser.reference_number %></td>
+        <td><%= link_to adviser.name, admin_adviser_path(adviser) %></td>
+        <td><%= link_to adviser.firm.registered_name, admin_firm_path(adviser.firm) %></td>
+      </tr>
+    <% end %>
+  <% else %>
+    <tr>
+      <td colspan="3">No advisers to display</td>
+    </tr>
+  <% end %>
+  <%= paginate @registered_advisers %>
+</table>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -31,6 +31,7 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Reports<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <%= active_link_to 'Metrics', admin_reports_metrics_path, wrap_tag: 'li' %>
+            <%= active_link_to 'Registered Advisers', admin_reports_registered_adviser_index_path, wrap_tag: 'li' %>
             <%= active_link_to 'Inactive Advisers', admin_reports_inactive_adviser_path, wrap_tag: 'li' %>
             <%= active_link_to 'Inactive Firms', admin_reports_inactive_firm_path, wrap_tag: 'li' %>
             <%= active_link_to 'Inactive Trading Names', admin_reports_inactive_trading_name_path, wrap_tag: 'li' %>

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,0 +1,9 @@
+require 'csv'
+
+ActionController.add_renderer :csv do |csv, options|
+  filename = options[:filename] || options[:template]
+  data = csv.to_csv(options)
+  send_data data,
+            type: Mime::CSV,
+            disposition: "attachment; filename=#{filename}.csv"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
         end
       end
       resource :inactive_adviser, only: [:show]
+      resources :registered_adviser, only: [:index]
       resource :inactive_firm, only: [:show]
       resource :inactive_trading_name, only: [:show]
       resources :out_of_date_firms, only: [:index, :update]

--- a/lib/adviser_list_csv.rb
+++ b/lib/adviser_list_csv.rb
@@ -1,0 +1,15 @@
+class AdviserListCsv
+  def initialize(advisers)
+    @advisers = advisers
+  end
+
+  def to_csv(_ = {})
+    CSV.generate do |csv|
+      csv << ['Ref. Number', 'Name', 'Firm']
+
+      @advisers.each do |adviser|
+        csv << [adviser.reference_number, adviser.name, adviser.firm.registered_name]
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/reports/registered_adviser_controller_spec.rb
+++ b/spec/controllers/admin/reports/registered_adviser_controller_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Admin::Reports::RegisteredAdviserController, type: :controller do
+  describe '#filename' do
+    context 'timestamp' do
+      let(:date) { Date.new(2017, 05, 29) }
+
+      it 'returns filename with timestamp included' do
+        Timecop.freeze(date)
+        expect(controller.send(:filename)).to eq('registered_advisers_2017-05-29')
+        Timecop.return
+      end
+    end
+  end
+end

--- a/spec/features/admin/export_advisers_list_spec.rb
+++ b/spec/features/admin/export_advisers_list_spec.rb
@@ -1,0 +1,96 @@
+# Feature: Advisors list export
+#  As the person maintaining the RAD database.
+#  In order to get rid of unwanted advisors.
+#  I need to be able to cross reference a large list (4k) of unauthorised advisers against records in the RAD database.
+#  The list needs to be cleared up so customers do not get sent to unapproved advisers and RAD maintain it's credibility.
+#
+
+RSpec.feature 'registered advisors report' do
+  let(:admin_page) { Admin::IndexPage.new }
+  let(:registered_adviser_show_page) { Admin::RegisteredAdviserShowPage.new }
+
+  before do
+    given_i_am_a_fully_registered_principal_user
+    and_i_am_logged_in_as_an_admin
+  end
+
+  scenario 'no registered advisers' do
+    and_there_are_no_registered_advisers
+    when_i_visit_the_registered_adviser_page
+    then_i_should_not_see_any_registered_advisers
+  end
+
+  scenario 'has registered advisers' do
+    and_there_exists_registered_advisors
+    when_i_visit_the_registered_adviser_page
+    then_i_should_see_all_registered_advisers
+  end
+
+  scenario 'blocks download as CSV' do
+    and_there_are_no_registered_advisers
+    when_i_visit_the_registered_adviser_page
+    then_i_should_not_be_able_to_download
+  end
+
+  scenario 'permits download as CSV' do
+    Timecop.freeze Date.new(2017, 05, 30) do
+      and_there_exists_registered_advisors
+      when_i_visit_the_registered_adviser_page
+      and_click_on_download_as_csv_button
+      then_i_should_have_a_file_with_all_registered_advisers
+    end
+  end
+
+  def given_i_am_a_fully_registered_principal_user
+    @principal = FactoryGirl.create :principal
+    @user = FactoryGirl.create :user, principal: @principal
+  end
+
+  def and_i_am_logged_in_as_an_admin
+    login_as(@user, scope: :admin)
+    admin_page.load
+    expect(page).to have_content 'RAD Administration'
+  end
+
+  def when_i_visit_the_registered_adviser_page
+    registered_adviser_show_page.load
+  end
+
+  def and_there_are_no_registered_advisers
+    Adviser.delete_all
+  end
+
+  def then_i_should_not_see_any_registered_advisers
+    expect(registered_adviser_show_page).to have_content('No advisers to display')
+  end
+
+  def and_there_exists_registered_advisors
+    firm = FactoryGirl.create(:firm, registered_name: 'James Andrews Investment PLC')
+    FactoryGirl.create(:adviser,
+                       name: 'James Andrews',
+                       reference_number: 'ABC12345',
+                       firm: firm)
+  end
+
+  def then_i_should_see_all_registered_advisers
+    expect(registered_adviser_show_page).to have_content('ABC12345')
+    expect(registered_adviser_show_page).to have_content('James Andrews')
+    expect(registered_adviser_show_page).to have_content('James Andrews Investment PLC')
+  end
+
+  def and_click_on_download_as_csv_button
+    click_on 'Download as CSV'
+  end
+
+  def then_i_should_have_a_file_with_all_registered_advisers
+    filename = 'registered_advisers_2017-05-30.csv'
+
+    expect(registered_adviser_show_page.response_headers['Content-Type']).to eq('text/csv')
+    expect(registered_adviser_show_page.response_headers['Content-Disposition']).to eq("attachment; filename=#{filename}")
+    expect(registered_adviser_show_page).to_not have_content('Registered Advisers')
+  end
+
+  def then_i_should_not_be_able_to_download
+    expect(registered_adviser_show_page).to_not have_content('Download as CSV')
+  end
+end

--- a/spec/lib/adviser_list_csv_spec.rb
+++ b/spec/lib/adviser_list_csv_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe AdviserListCsv do
+  describe '#to_csv' do
+    it 'responds to csv conversion' do
+      expect(described_class.new []).to respond_to(:to_csv)
+    end
+  end
+
+  context 'Office' do
+    it 'should not respond to csv conversion' do
+      expect(Office).to_not respond_to(:to_csv)
+    end
+  end
+end

--- a/spec/support/admin/active_adviser_show_page.rb
+++ b/spec/support/admin/active_adviser_show_page.rb
@@ -1,0 +1,5 @@
+module Admin
+  class RegisteredAdviserShowPage < SitePrism::Page
+    set_url '/admin/reports/registered_adviser'
+  end
+end

--- a/spec/support/admin/index_page_spec.rb
+++ b/spec/support/admin/index_page_spec.rb
@@ -1,0 +1,5 @@
+module Admin
+  class IndexPage < SitePrism::Page
+    set_url '/admin'
+  end
+end


### PR DESCRIPTION
[Card TP#8070: Registered Advisers Export List](https://moneyadviceservice.tpondemand.com/entity/8070)

![yj6onbvdbp](https://cloud.githubusercontent.com/assets/591781/26490202/4c26a5ba-4202-11e7-9d4b-3bf591143575.gif)
