### PR TITLE
[8218] - Bugfix: Show nearest office website when viewing a firm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', '0.0.111'
+gem 'mas-rad_core', '0.1.2'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     ffaker (2.2.0)
-    geocoder (1.4.1)
+    geocoder (1.4.4)
     gherkin (4.0.0)
     gli (2.14.0)
     globalid (0.3.6)
@@ -177,7 +177,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
-    language_list (1.1.0)
+    language_list (1.2.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.3.0)
@@ -192,7 +192,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-rad_core (0.0.111)
+    mas-rad_core (0.1.2)
       active_model_serializers
       geocoder
       httpclient
@@ -363,7 +363,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    statsd-ruby (1.3.0)
+    statsd-ruby (1.4.0)
     systemu (2.6.5)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -425,7 +425,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core (= 0.0.111)
+  mas-rad_core (= 0.1.2)
   oga
   pg
   poltergeist


### PR DESCRIPTION
## Explanation

When you're viewing a firm that has N offices, and one of the offices has a website, the office website should appear on the firm website address.

## What happened

The website was not displaying the right office website. After further investigation we understood that *if we reindex the elastic search* the problem was solved. But *if you update the office on rad admin the bug comes back*.

## Solution

Investigating deeper more we understood that on rad admin everytime that you save an office, the app sent data to elastic search without the "website" node. 

**The code that sends to elastic search all the nodes is on master and was added on mas-rad_core version 0.1.2 but the version that was on rad was 0.0.111. Updating the version solves the problem.**

You can see the code that does this now on master (0.1.2 version) here:

1) https://github.com/moneyadviceservice/mas-rad_core/blob/master/app/models/office.rb#L43
2) https://github.com/moneyadviceservice/mas-rad_core/blob/master/app/models/office.rb#L46
3) https://github.com/moneyadviceservice/mas-rad_core/blob/master/lib/mas/firm_indexer.rb#L30
4) https://github.com/moneyadviceservice/mas-rad_core/blob/master/lib/mas/firm_repository.rb#L4
5) https://github.com/moneyadviceservice/mas-rad_core/blob/master/app/serializers/office_serializer.rb#L6