### PR TITLE
Set Travis Ubuntu version to Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   bundler: true
   directories:
     - node_modules
+dist: precise
 rvm:
   - 2.2.2
 before_install: gem update bundler


### PR DESCRIPTION
The build is not working in Travis. This problem appeared previously in `rad_consumer`, and this PR applies the same fix as https://github.com/moneyadviceservice/rad_consumer/pull/326.

**Reason**
Travis is rolling out a newer version of Ubuntu. This is the message for failing builds:
>This job ran on our Trusty environment, which is gradually becoming our default Linux environment. Read all about this [in our blog: Trusty as a default Linux is coming](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default) and take note that you can add `dist: precise` in your .travis.yml file to continue using Precise. 