### PR TITLE
[DEV APPROVED] 8604 update fca import

### DIFF
--- a/config/initializers/cloud_storage.rb
+++ b/config/initializers/cloud_storage.rb
@@ -12,6 +12,12 @@ else
   }
 end
 
+if data['provider_name'] == 'azure' && (data['account_name'].blank? || data['shared_key'].blank? || data['container_name'].blank?)
+  $stdout.puts('-' * 80)
+  $stdout.puts("[Warn] - FCA import - When using azure, please make sure the environment variables are set: AZURE_ACCOUNT, AZURE_CONTAINER, AZURE_SHARED_KEY.")
+  $stdout.puts('-' * 80)
+end
+
 Cloud::Storage.configure do |config|
   config.provider_name  = data['provider_name']
   config.account_name   = data['account_name']

--- a/fca_import_scripts/lib/ext_to_sql.rb
+++ b/fca_import_scripts/lib/ext_to_sql.rb
@@ -48,7 +48,7 @@ class ExtToSql
     case row[COLUMNS::HEADER_NAME]
     when 'Individual Details'
       :adviser
-    when 'Firm Authorisation'
+    when 'Firm Authorisation', 'Firms Master List'
       :firm
     when 'Alternative Firm Name'
       :subsidiary
@@ -95,7 +95,7 @@ class ExtToSql
   end
 
   def repair_line(line)
-    line = line.strip
+    line = line.strip.mb_chars.tidy_bytes
     match = repairs.find { |pair| line == pair['line'] }
     if match.nil?
       warn_on_possibly_broken_line line

--- a/lib/fca/import.rb
+++ b/lib/fca/import.rb
@@ -48,7 +48,7 @@ module FCA
     def import(file)
       outcomes = River.source(context)
                  .step(&download(file))
-                 .step(&unzip(/^firms2\d+\.ext$/, /^indiv_apprvd2\d+\.ext$/, /^firm_names2\d+\.ext$/))
+                 .step(&unzip(/^firms_master_list2\d+\.ext$/, /^indiv_apprvd2\d+\.ext$/, /^firm_names2\d+\.ext$/))
                  .step(&to_sql(LOOKUP_TABLE_PREFIX))
                  .step(&save)
                  .sink

--- a/lib/fca/query.rb
+++ b/lib/fca/query.rb
@@ -2,7 +2,7 @@ module FCA
   class Query
     TABLES = {  # keys to this hash works on header line; row field index 1
       'Individual Details'    => :lookup_advisers,
-      'Firm Authorisation'    => :lookup_firms,
+      'Firms Master List'     => :lookup_firms,
       'Alternative Firm Name' => :lookup_subsidiaries
     }.freeze
 

--- a/lib/fca/row.rb
+++ b/lib/fca/row.rb
@@ -7,7 +7,11 @@ module FCA
     FIRM_AUTHORISATION_STATUS_CODE = 19
     SUBSIDIARY_END_DATE = 4
 
-    ACTIVE_FIRM_AUTHORISATION_STATUS_CODES = ['Authorised', 'Registered', 'EEA Authorised'].freeze
+    ACTIVE_FIRM_AUTHORISATION_STATUS_CODES = [
+      'Authorised',
+      'Registered',
+      'EEA Authorised'
+    ].freeze
 
     attr_reader :line, :repairs, :row, :trading_names, :delimeter, :prefix
     def initialize(line, options = {})

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "karma-sinon-chai": "^0.2.0",
     "karma-spec-reporter": "0.0.13",
     "mocha": "~1.15.1",
-    "phantomjs-prebuilt": ">= 1.9",
+    "phantomjs-prebuilt": "2.1.14",
     "requirejs": "2.1.22",
     "sinon": "^1.9.0"
   }

--- a/spec/fca_import_scripts/lib/ext_to_sql_spec.rb
+++ b/spec/fca_import_scripts/lib/ext_to_sql_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe ExtToSql do
       it 'generates the right SQL' do
         expect(subject[0]).to eq 'COPY lookup_firms (fca_number, registered_name, created_at, updated_at) FROM stdin;'
         expect(subject[1]).to start_with '100013	Skipton Financial Services Ltd	'
-        expect(subject[2]).to eq '\.'
+        expect(subject[2]).to start_with "131581\tS £ C Limited"
+        expect(subject[3]).to eq '\.'
       end
     end
 

--- a/spec/fixtures/firms.ext
+++ b/spec/fixtures/firms.ext
@@ -1,2 +1,3 @@
-Header|Firm Authorisation|20141120|2243|
-100013|Skipton Financial Services Ltd|5|1|N|Skipton Financial Services Ltd|The Bailey|||Skipton|N Yorkshire|BD23|1XT|44|01756|694 007|44|01756|694 601|Authorised|20011201|20011201|SKIPTONFINANCIALSERVICESLTD|20141023|
+Header|Firms Master List|20171123|1858|
+100013|Skipton Financial Services Ltd|5|1|N|Skipton Financial Services Ltd|The Bailey|||Skipton|London|BD23|1XT|44|01756|694 007|44|01756|694 601|Authorised|20011201|20011201|SKIPTONFINANCIALSERVICESLTD|20170523|2061788||||
+131581|S £ C Limited|5|1|N|151 High Street||||Limited|London|Test|4SA|44|01277|231 505|44|01277|230 572|Authorised|20090727|20011201|S£CLIMITED|20140201|2181716||||

--- a/spec/lib/fca/query_spec.rb
+++ b/spec/lib/fca/query_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe FCA::Query do
       expect(tables['Individual Details']).to eq :lookup_advisers
     end
 
-    it 'line Header with `Firm Authorisation`' do
-      expect(tables['Firm Authorisation']).to eq :lookup_firms
+    it 'line Header with `Firms Master List`' do
+      expect(tables['Firms Master List']).to eq :lookup_firms
     end
 
     it 'line Header with `Alternative Firm Name`' do


### PR DESCRIPTION
TP: https://moneyadviceservice.tpondemand.com/entity/8604

## Context

The FCA Data Extract team recently made some changes to the files that they will be sending in the future. As of January 2018 we will no longer receive the firms file which, the FCA import automation script is hard-coded to pick up. 

Basically instead of picking the firms file we should be choosing the firms master file.
The firms master file came in different encoding format than the older file but the rest are almost the same.

## References

I opened a PR about documentation of FCA on https://github.com/moneyadviceservice/technical-docs/pull/2/
