### PR TITLE
[DEV APPROVED] 8625 Adds qualifications and accreditations to report

### DIFF
--- a/app/controllers/admin/reports/registered_adviser_controller.rb
+++ b/app/controllers/admin/reports/registered_adviser_controller.rb
@@ -4,8 +4,7 @@ module Admin
       respond_to :html, :csv
 
       def index
-        advisers = Adviser.includes(:qualifications, :accreditations).all
-
+        advisers = Adviser.all
         @registered_advisers = advisers.page(params[:page])
         @registered_advisers_list = AdviserListCsv.new(advisers)
 

--- a/app/controllers/admin/reports/registered_adviser_controller.rb
+++ b/app/controllers/admin/reports/registered_adviser_controller.rb
@@ -4,7 +4,8 @@ module Admin
       respond_to :html, :csv
 
       def index
-        advisers = Adviser.all
+        advisers = Adviser.includes(:qualifications, :accreditations).all
+
         @registered_advisers = advisers.page(params[:page])
         @registered_advisers_list = AdviserListCsv.new(advisers)
 

--- a/lib/adviser_accreditations_lookup.rb
+++ b/lib/adviser_accreditations_lookup.rb
@@ -1,0 +1,11 @@
+class AdviserAccreditationsLookup
+  include AdviserCertificationsLookup
+
+  def table
+    'accreditations_advisers'
+  end
+
+  def type
+    'accreditation'
+  end
+end

--- a/lib/adviser_certifications_lookup.rb
+++ b/lib/adviser_certifications_lookup.rb
@@ -1,0 +1,34 @@
+module AdviserCertificationsLookup
+  def initialize(adviser_ids)
+    @adviser_ids = adviser_ids
+  end
+
+  def for(adviser_id)
+    lookup[adviser_id] || []
+  end
+
+  def query
+    ActiveRecord::Base.connection.execute("
+      SELECT adviser_id, #{type}_id
+      FROM #{table}
+      WHERE adviser_id IN (#{@adviser_ids.join(',')})
+    ").to_a
+  end
+
+  def certifications
+    @certifications ||= type.classify.constantize.pluck(:id, :name).to_h
+  end
+
+  def all_certifications
+    certifications.values
+  end
+
+  def lookup
+    @lookup ||= query.each_with_object({}) do |certification, h|
+      adviser_id = certification['adviser_id'].to_i
+      certification_name = certifications[certification["#{type}_id"].to_i]
+      h[adviser_id] ||= []
+      h[adviser_id] << certification_name
+    end
+  end
+end

--- a/lib/adviser_csv_lookup.rb
+++ b/lib/adviser_csv_lookup.rb
@@ -1,31 +1,33 @@
 class AdviserCsvLookup
-  attr_reader :qualifications_lookup, :accreditations_lookup, :firms_lookup
-
   def initialize(advisers)
     @advisers = advisers
   end
 
-  def build!
-    @qualifications_lookup = build_adviser_qualifications
-    @accreditations_lookup = build_adviser_accreditations
-    @firms_lookup          = build_adviser_firms
-  end
-
   def certification_list
-    qualifications.values + accreditations.values
+    all_qualifications + all_accreditations
   end
 
-  def each(&block)
+  def each
     @advisers.each do |adviser|
-      adviser_qualifications = qualifications_lookup[adviser.id] || []
-      adviser_accreditations = accreditations_lookup[adviser.id] || []
-      block.call(
-        adviser: adviser,
-        firm_name: firms_lookup[adviser.firm_id],
-        qualifications: adviser_qualifications,
-        accreditations: adviser_accreditations
-      )
+      adviser_qualifications = qualifications_lookup.for(adviser.id)
+      adviser_accreditations = accreditations_lookup.for(adviser.id)
+      yield(adviser: adviser,
+            firm_name: firms_lookup[adviser.firm_id],
+            qualifications: adviser_qualifications,
+            accreditations: adviser_accreditations)
     end
+  end
+
+  def qualifications_lookup
+    @qualifications_lookup ||= AdviserQualificationsLookup.new(adviser_ids)
+  end
+
+  def accreditations_lookup
+    @accreditations_lookup ||= AdviserAccreditationsLookup.new(adviser_ids)
+  end
+
+  def firms_lookup
+    @firms_lookup ||= Firm.pluck(:id, :registered_name).to_h
   end
 
   private
@@ -34,41 +36,11 @@ class AdviserCsvLookup
     @advisers.map(&:id)
   end
 
-  def build_adviser_qualifications
-    certs = certification_query('advisers_qualifications', 'qualification')
-    aggregate_certificate_names(certs, type: 'qualification')
+  def all_qualifications
+    qualifications_lookup.all_certifications
   end
 
-  def build_adviser_accreditations
-    certs = certification_query('accreditations_advisers', 'accreditation')
-    aggregate_certificate_names(certs, type: 'accreditation')
-  end
-
-  def build_adviser_firms
-    Firm.pluck(:id, :registered_name).to_h
-  end
-
-  def certification_query(table, key)
-    ActiveRecord::Base.connection.execute("
-      SELECT adviser_id, #{key}_id
-      FROM #{table}
-      WHERE adviser_id IN (#{adviser_ids.join(',')})
-    ").to_a
-  end
-
-  def qualifications
-    @qualifications ||= Qualification.pluck(:id, :name).to_h
-  end
-
-  def accreditations
-    @accreditations ||= Accreditation.pluck(:id, :name).to_h
-  end
-
-  def aggregate_certificate_names(adviser_certifications, type:)
-    adviser_certifications.each_with_object({}) do |certification, h|
-      adviser_id = certification['adviser_id'].to_i
-      h[adviser_id] ||= []
-      h[adviser_id] << send(type.pluralize)[certification["#{type}_id"].to_i]
-    end
+  def all_accreditations
+    accreditations_lookup.all_certifications
   end
 end

--- a/lib/adviser_csv_lookup.rb
+++ b/lib/adviser_csv_lookup.rb
@@ -1,0 +1,74 @@
+class AdviserCsvLookup
+  attr_reader :qualifications_lookup, :accreditations_lookup, :firms_lookup
+
+  def initialize(advisers)
+    @advisers = advisers
+  end
+
+  def build!
+    @qualifications_lookup = build_adviser_qualifications
+    @accreditations_lookup = build_adviser_accreditations
+    @firms_lookup          = build_adviser_firms
+  end
+
+  def certification_list
+    qualifications.values + accreditations.values
+  end
+
+  def each(&block)
+    @advisers.each do |adviser|
+      adviser_qualifications = qualifications_lookup[adviser.id] || []
+      adviser_accreditations = accreditations_lookup[adviser.id] || []
+      block.call(
+        adviser: adviser,
+        firm_name: firms_lookup[adviser.firm_id],
+        qualifications: adviser_qualifications,
+        accreditations: adviser_accreditations
+      )
+    end
+  end
+
+  private
+
+  def adviser_ids
+    @advisers.map(&:id)
+  end
+
+  def build_adviser_qualifications
+    certs = certification_query('advisers_qualifications', 'qualification')
+    aggregate_certificate_names(certs, type: 'qualification')
+  end
+
+  def build_adviser_accreditations
+    certs = certification_query('accreditations_advisers', 'accreditation')
+    aggregate_certificate_names(certs, type: 'accreditation')
+  end
+
+  def build_adviser_firms
+    Firm.pluck(:id, :registered_name).to_h
+  end
+
+  def certification_query(table, key)
+    ActiveRecord::Base.connection.execute("
+      SELECT adviser_id, #{key}_id
+      FROM #{table}
+      WHERE adviser_id IN (#{adviser_ids.join(',')})
+    ").to_a
+  end
+
+  def qualifications
+    @qualifications ||= Qualification.pluck(:id, :name).to_h
+  end
+
+  def accreditations
+    @accreditations ||= Accreditation.pluck(:id, :name).to_h
+  end
+
+  def aggregate_certificate_names(adviser_certifications, type:)
+    adviser_certifications.each_with_object({}) do |certification, h|
+      adviser_id = certification['adviser_id'].to_i
+      h[adviser_id] ||= []
+      h[adviser_id] << send(type.pluralize)[certification["#{type}_id"].to_i]
+    end
+  end
+end

--- a/lib/adviser_list_csv.rb
+++ b/lib/adviser_list_csv.rb
@@ -4,7 +4,6 @@ class AdviserListCsv
   end
 
   def to_csv(_ = {})
-    @lookup.build!
     CSV.generate do |csv|
       csv << headings
       @lookup.each do |adviser_data|

--- a/lib/adviser_list_csv.rb
+++ b/lib/adviser_list_csv.rb
@@ -5,13 +5,38 @@ class AdviserListCsv
 
   def to_csv(_ = {})
     CSV.generate do |csv|
-      csv << ['Ref. Number', 'Name', 'Firm']
-
+      csv << headings
       @advisers.each do |adviser|
-        csv << [adviser.reference_number,
-                adviser.name,
-                adviser.firm.registered_name]
+        csv << row(adviser)
       end
     end
+  end
+
+  private
+
+  def headings
+    ['Ref. Number', 'Name', 'Firm'] + all_certifications
+  end
+
+  def row(adviser)
+    [
+      adviser.reference_number,
+      adviser.name,
+      adviser.firm.registered_name
+    ] + certified(adviser)
+  end
+
+  def all_certifications
+    @certifications ||= Accreditation.pluck(:name) + Qualification.pluck(:name)
+  end
+
+  def certified(adviser)
+    all_certifications.map do |certification|
+      certifications_for(adviser).include?(certification) ? 'Y' : 'N'
+    end
+  end
+
+  def certifications_for(adviser)
+    adviser.accreditations.pluck(:name) + adviser.qualifications.pluck(:name)
   end
 end

--- a/lib/adviser_qualifications_lookup.rb
+++ b/lib/adviser_qualifications_lookup.rb
@@ -1,0 +1,11 @@
+class AdviserQualificationsLookup
+  include AdviserCertificationsLookup
+
+  def table
+    'advisers_qualifications'
+  end
+
+  def type
+    'qualification'
+  end
+end

--- a/spec/lib/adviser_accreditations_lookup_spec.rb
+++ b/spec/lib/adviser_accreditations_lookup_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe AdviserAccreditationsLookup do
+  let(:adviser) { FactoryGirl.create(:adviser, adviser_accreditations) }
+
+  let(:accreditations) { Array.new(3) { FactoryGirl.create(:accreditation) } }
+
+  let(:adviser_accreditations) do
+    {
+      accreditations: [accreditations.first, accreditations.last]
+    }
+  end
+
+  let(:subject) { described_class.new([adviser.id]) }
+
+  describe '#for' do
+    it 'returns the accreditations for an adviser' do
+      expect(subject.for(adviser.id)).to eq(
+        [accreditations.first.name, accreditations.last.name]
+      )
+    end
+
+    context 'when adviser has no accreditations' do
+      let(:adviser) { FactoryGirl.create(:adviser, accreditations: []) }
+
+      it 'returns an empty array for that adviser' do
+        expect(subject.for(adviser.id)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/lib/adviser_csv_lookup_spec.rb
+++ b/spec/lib/adviser_csv_lookup_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe AdviserCsvLookup do
+  let(:adviser1) { FactoryGirl.create(:adviser, adviser1_certifications) }
+  let(:adviser2) { FactoryGirl.create(:adviser, adviser2_certifications) }
+  let(:advisers) { [adviser1, adviser2] }
+
+  let(:qualifications) { 3.times.map { FactoryGirl.create(:qualification) } }
+  let(:accreditations) { 3.times.map { FactoryGirl.create(:accreditation) } }
+
+  let(:adviser1_certifications) do
+    {
+      qualifications: [qualifications.first, qualifications.last],
+      accreditations: [accreditations.first]
+    }
+  end
+  let(:adviser2_certifications) do
+    {
+      qualifications: [qualifications.last],
+      accreditations: [accreditations.last]
+    }
+  end
+
+  let(:subject)  { described_class.new(advisers) }
+
+  before do
+    subject.build!
+  end
+
+  describe '#build!' do
+    it 'returns data for qualifications_lookup' do
+      expect(subject.qualifications_lookup).to eq(
+        adviser1.id => [qualifications.first.name, qualifications.last.name],
+        adviser2.id => [qualifications.last.name]
+      )
+    end
+
+    it 'returns data for accreditations_lookup' do
+      expect(subject.accreditations_lookup).to eq(
+        adviser1.id => [accreditations.first.name],
+        adviser2.id => [accreditations.last.name]
+      )
+    end
+
+    it 'returns data for firms_lookup' do
+      expect(subject.firms_lookup).to eq(
+        adviser1.firm_id => adviser1.firm.registered_name,
+        adviser2.firm_id => adviser2.firm.registered_name
+      )
+    end
+  end
+
+  describe '#certifications_list' do
+    let(:expected_qualifications) { qualifications.map(&:name) }
+    let(:expected_accreditations) { accreditations.map(&:name) }
+
+    it 'returns a list of all the certifications' do
+      expect(subject.certification_list).to eq(
+        expected_qualifications + expected_accreditations
+      )
+    end
+  end
+end

--- a/spec/lib/adviser_csv_lookup_spec.rb
+++ b/spec/lib/adviser_csv_lookup_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe AdviserCsvLookup do
   let(:adviser2) { FactoryGirl.create(:adviser, adviser2_certifications) }
   let(:advisers) { [adviser1, adviser2] }
 
-  let(:qualifications) { 3.times.map { FactoryGirl.create(:qualification) } }
-  let(:accreditations) { 3.times.map { FactoryGirl.create(:accreditation) } }
+  let(:qualifications) { Array.new(3) { FactoryGirl.create(:qualification) } }
+  let(:accreditations) { Array.new(3) { FactoryGirl.create(:accreditation) } }
 
   let(:adviser1_certifications) do
     {
@@ -19,32 +19,30 @@ RSpec.describe AdviserCsvLookup do
     }
   end
 
-  let(:subject)  { described_class.new(advisers) }
+  let(:subject) { described_class.new(advisers) }
 
-  before do
-    subject.build!
-  end
-
-  describe '#build!' do
-    it 'returns data for qualifications_lookup' do
-      expect(subject.qualifications_lookup).to eq(
-        adviser1.id => [qualifications.first.name, qualifications.last.name],
-        adviser2.id => [qualifications.last.name]
-      )
+  describe '#each' do
+    let(:expected_adviser_1_data) do
+      {
+        adviser:        adviser1,
+        firm_name:      adviser1.firm.registered_name,
+        qualifications: adviser1.qualifications.map(&:name),
+        accreditations: adviser1.accreditations.map(&:name)
+      }
     end
-
-    it 'returns data for accreditations_lookup' do
-      expect(subject.accreditations_lookup).to eq(
-        adviser1.id => [accreditations.first.name],
-        adviser2.id => [accreditations.last.name]
-      )
+    let(:expected_adviser_2_data) do
+      {
+        adviser:        adviser2,
+        firm_name:      adviser2.firm.registered_name,
+        qualifications: adviser2.qualifications.map(&:name),
+        accreditations: adviser2.accreditations.map(&:name)
+      }
     end
-
-    it 'returns data for firms_lookup' do
-      expect(subject.firms_lookup).to eq(
-        adviser1.firm_id => adviser1.firm.registered_name,
-        adviser2.firm_id => adviser2.firm.registered_name
-      )
+    it 'yields for each adviser with the additional data for that adviser' do
+      expect { |b| subject.each(&b) }
+        .to yield_successive_args(
+          expected_adviser_1_data, expected_adviser_2_data
+        )
     end
   end
 

--- a/spec/lib/adviser_list_csv_spec.rb
+++ b/spec/lib/adviser_list_csv_spec.rb
@@ -1,21 +1,23 @@
 RSpec.describe AdviserListCsv do
   describe '#to_csv' do
+    let(:adviser1) { FactoryGirl.create(:adviser, adviser1_certifications) }
+    let(:adviser2) { FactoryGirl.create(:adviser, adviser2_certifications) }
+    let(:advisers) { [adviser1, adviser2] }
+
     let(:qualifications) { 3.times.map { FactoryGirl.create(:qualification) } }
     let(:accreditations) { 3.times.map { FactoryGirl.create(:accreditation) } }
-    let(:all_certifications) do
-      Accreditation.pluck(:name) + Qualification.pluck(:name)
-    end
 
-    let(:advisers) { [adviser1, adviser2] }
-    let(:adviser1) do
-      FactoryGirl.create(:adviser,
-                         qualifications: [qualifications.first],
-                         accreditations: [accreditations.first])
+    let(:adviser1_certifications) do
+      {
+        qualifications: [qualifications.first, qualifications.last],
+        accreditations: [accreditations.first]
+      }
     end
-    let(:adviser2) do
-      FactoryGirl.create(:adviser,
-                         qualifications: [qualifications.last],
-                         accreditations: [accreditations.last])
+    let(:adviser2_certifications) do
+      {
+        qualifications: [qualifications.last],
+        accreditations: [accreditations.last]
+      }
     end
 
     let(:subject)  { described_class.new(advisers) }
@@ -36,7 +38,7 @@ RSpec.describe AdviserListCsv do
             'Ref. Number',
             'Name',
             'Firm'
-          ] + all_certifications
+          ] + Qualification.pluck(:name) + Accreditation.pluck(:name)
         )
       end
 
@@ -45,7 +47,7 @@ RSpec.describe AdviserListCsv do
           adviser1.reference_number,
           adviser1.name,
           adviser1.firm.registered_name,
-          'Y', 'N', 'N', 'Y', 'N', 'N'
+          'Y', 'N', 'Y', 'Y', 'N', 'N'
         ])
 
         expect(row2).to eq([

--- a/spec/lib/adviser_list_csv_spec.rb
+++ b/spec/lib/adviser_list_csv_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe AdviserListCsv do
     let(:adviser2) { FactoryGirl.create(:adviser, adviser2_certifications) }
     let(:advisers) { [adviser1, adviser2] }
 
-    let(:qualifications) { 3.times.map { FactoryGirl.create(:qualification) } }
-    let(:accreditations) { 3.times.map { FactoryGirl.create(:accreditation) } }
+    let(:qualifications) { Array.new(3) { FactoryGirl.create(:qualification) } }
+    let(:accreditations) { Array.new(3) { FactoryGirl.create(:accreditation) } }
 
     let(:adviser1_certifications) do
       {
@@ -20,14 +20,14 @@ RSpec.describe AdviserListCsv do
       }
     end
 
-    let(:subject)  { described_class.new(advisers) }
+    subject(:adviser_list) { described_class.new(advisers) }
 
     it 'responds to csv conversion' do
       expect(described_class.new([])).to respond_to(:to_csv)
     end
 
     context 'when csv is generated' do
-      let(:table)    { CSV.parse(subject.to_csv) }
+      let(:table)    { CSV.parse(adviser_list.to_csv) }
       let(:headings) { table[0] }
       let(:row1)     { table[1] }
       let(:row2)     { table[2] }
@@ -44,24 +44,18 @@ RSpec.describe AdviserListCsv do
 
       it 'returns data for each adviser' do
         expect(row1).to eq([
-          adviser1.reference_number,
-          adviser1.name,
-          adviser1.firm.registered_name,
-          'Y', 'N', 'Y', 'Y', 'N', 'N'
-        ])
+                             adviser1.reference_number,
+                             adviser1.name,
+                             adviser1.firm.registered_name,
+                             'Y', 'N', 'Y', 'Y', 'N', 'N'
+                           ])
 
         expect(row2).to eq([
-          adviser2.reference_number,
-          adviser2.name,
-          adviser2.firm.registered_name,
-          'N', 'N', 'Y', 'N', 'N', 'Y'
-        ])
-      end
-    end
-
-    context 'Office' do
-      it 'should not respond to csv conversion' do
-        expect(Office).to_not respond_to(:to_csv)
+                             adviser2.reference_number,
+                             adviser2.name,
+                             adviser2.firm.registered_name,
+                             'N', 'N', 'Y', 'N', 'N', 'Y'
+                           ])
       end
     end
   end

--- a/spec/lib/adviser_list_csv_spec.rb
+++ b/spec/lib/adviser_list_csv_spec.rb
@@ -1,13 +1,66 @@
 RSpec.describe AdviserListCsv do
   describe '#to_csv' do
+    let(:qualifications) { 3.times.map { FactoryGirl.create(:qualification) } }
+    let(:accreditations) { 3.times.map { FactoryGirl.create(:accreditation) } }
+    let(:all_certifications) do
+      Accreditation.pluck(:name) + Qualification.pluck(:name)
+    end
+
+    let(:advisers) { [adviser1, adviser2] }
+    let(:adviser1) do
+      FactoryGirl.create(:adviser,
+                         qualifications: [qualifications.first],
+                         accreditations: [accreditations.first])
+    end
+    let(:adviser2) do
+      FactoryGirl.create(:adviser,
+                         qualifications: [qualifications.last],
+                         accreditations: [accreditations.last])
+    end
+
+    let(:subject)  { described_class.new(advisers) }
+
     it 'responds to csv conversion' do
       expect(described_class.new([])).to respond_to(:to_csv)
     end
-  end
 
-  context 'Office' do
-    it 'should not respond to csv conversion' do
-      expect(Office).to_not respond_to(:to_csv)
+    context 'when csv is generated' do
+      let(:table)    { CSV.parse(subject.to_csv) }
+      let(:headings) { table[0] }
+      let(:row1)     { table[1] }
+      let(:row2)     { table[2] }
+
+      it 'returns csv headings' do
+        expect(headings).to eq(
+          [
+            'Ref. Number',
+            'Name',
+            'Firm'
+          ] + all_certifications
+        )
+      end
+
+      it 'returns data for each adviser' do
+        expect(row1).to eq([
+          adviser1.reference_number,
+          adviser1.name,
+          adviser1.firm.registered_name,
+          'Y', 'N', 'N', 'Y', 'N', 'N'
+        ])
+
+        expect(row2).to eq([
+          adviser2.reference_number,
+          adviser2.name,
+          adviser2.firm.registered_name,
+          'N', 'N', 'Y', 'N', 'N', 'Y'
+        ])
+      end
+    end
+
+    context 'Office' do
+      it 'should not respond to csv conversion' do
+        expect(Office).to_not respond_to(:to_csv)
+      end
     end
   end
 end

--- a/spec/lib/adviser_qualifications_lookup_spec.rb
+++ b/spec/lib/adviser_qualifications_lookup_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe AdviserQualificationsLookup do
+  let(:adviser) { FactoryGirl.create(:adviser, adviser_qualifications) }
+
+  let(:qualifications) { Array.new(3) { FactoryGirl.create(:qualification) } }
+
+  let(:adviser_qualifications) do
+    {
+      qualifications: [qualifications.first, qualifications.last]
+    }
+  end
+
+  let(:subject) { described_class.new([adviser.id]) }
+
+  describe '#for' do
+    it 'returns the qualifications for an advisor' do
+      expect(subject.for(adviser.id)).to eq(
+        [qualifications.first.name, qualifications.last.name]
+      )
+    end
+
+    context 'when adviser has no qualifications' do
+      let(:adviser) { FactoryGirl.create(:adviser, qualifications: []) }
+
+      it 'returns an empty array for that adviser' do
+        expect(subject.for(adviser.id)).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP Story](https://moneyadviceservice.tpondemand.com/entity/8625)

Adds Qualifications and Accreditations to the Registered Advisers report, so that against each advisor there is a new column for each Accreditation and qualification with a Y/N in each field for whether or not the qualification is held.

**EDIT**

Also adds an `AdviserCsvLookup`, which loads all the necessary data from the db into memory before we transform it into the correct state for the CSV. `ActiveRecord`'s built in-caching and preloading was unable to give us anything close to the necessary performance - this speeds up the generation of the CSV file (from about 35s down to about 2s). 