### PR TITLE
Add RAD to Jenkins CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:17.04
+MAINTAINER development.team@moneyadviceservice.org.uk
+
+ENV BUNDLER_VERSION "1.16.0"
+ENV NODE_VERSION "4.8.4"
+ENV BOWER_VERSION "1.8.2"
+ENV PHANTOMJS_VERSION "2.1.1"
+ENV PATH usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+ENV RAILS_ENV test
+ENV POSTGRES postgres
+ENV BUNDLE_WITHOUT development:build
+ENV DEBIAN_FRONTEND noninteractive
+ENV APT_PACKAGES " \
+  build-essential apt-utils git libfontconfig libpq-dev libssl-dev libsqlite3-dev \
+  libxml2-dev libreadline-dev zlib1g-dev apt-transport-https curl software-properties-common"
+
+#Install Prerequisites
+RUN apt-get -qq update > /dev/null && \
+  apt-get -qq dist-upgrade > /dev/null && \
+  apt-get -qq install --no-install-recommends $APT_PACKAGES > /dev/null && \
+  apt-get -qq clean  > /dev/null && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /tmp
+
+#Install Ruby
+COPY .ruby-version .ruby-version
+RUN curl "https://cache.ruby-lang.org/pub/ruby/ruby-$(cat .ruby-version).tar.gz" | \
+  tar -xz && \
+  cd ruby-$(cat .ruby-version) && \
+  ./configure --enable-shared --disable-install-doc > /dev/null && \
+  make -s -j4 >> install_ruby.log && make -s install > /dev/null && \
+  rm /usr/local/lib/libruby-static.a
+
+#Install Bundler
+RUN gem install -v ${BUNDLER_VERSION} bundler
+
+#Install Node
+RUN curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \
+  | tar -xz -C /usr --strip-components=1
+
+#Install Bower
+RUN npm install bower@${BOWER_VERSION} -g
+
+#Install PhantomJs
+RUN curl -L -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2
+RUN tar jxf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
+  -C /usr/bin --strip-components 2 \
+  phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs
+
+RUN mkdir -p /var/tmp/app
+WORKDIR /var/tmp/app
+
+#Copy Repo
+COPY . /var/tmp/app/

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :test, :development do
 end
 
 group :test do
+  gem 'brakeman', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
@@ -67,6 +68,7 @@ group :test do
   gem 'poltergeist'
   gem 'rspec-collection_matchers'
   gem 'site_prism'
+  gem 'tzinfo-data'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    brakeman (4.1.1)
     builder (3.2.3)
     byebug (9.1.0)
     capybara (2.16.1)
@@ -404,6 +405,8 @@ GEM
       hitimes
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2017.3)
+      tzinfo (>= 1.0.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     uk_phone_numbers (0.1.1)
@@ -438,6 +441,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   bowndler!
+  brakeman
   capybara
   cucumber-rails
   database_cleaner
@@ -476,6 +480,7 @@ DEPENDENCIES
   site_prism
   slack-ruby-client
   timecop
+  tzinfo-data
   uglifier (>= 1.3.0)
   unicorn
   vcr

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent { label "master" }
+
+    stages {
+        stage('test') {
+            steps {
+                sh('./script/docker_compose')
+            }
+        }
+    }
+}

--- a/config/database-jenkins.yml
+++ b/config/database-jenkins.yml
@@ -1,0 +1,10 @@
+test:
+  adapter: postgresql
+  encoding: utf8
+  pool: 5
+  host: postgres
+  port: 5432
+  username: go
+  password: go
+  database: rad_test
+  timeout: 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2.1'
+services:
+  postgres:
+    image: postgres:9.4
+    ports:
+      - 5432
+    environment:
+      - POSTGRES_PASSWORD=go
+      - POSTGRES_USER=go
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 'postgres' -p '5432'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  rails:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ./script/test
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRESHOST=postgres
+      - POSTGRESPASS=go
+      - POSTGRESUSER=go
+    links:
+      - postgres
+volumes:
+  bundle: {}
+  postgres: {}

--- a/script/docker_compose
+++ b/script/docker_compose
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Useful for testing in docker locally
+set -e
+export COMPOSE_PROJECT_NAME=rad
+image_name="rad_rails_1"
+
+docker-compose pull
+docker-compose build --force-rm
+docker-compose up -d
+
+# docker logs will only run until the container exits
+( docker logs --follow "$image_name" )&
+
+exit_code="$( docker wait "$image_name" )"
+docker-compose down
+
+exit "$exit_code"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+export RAILS_ENV=test
+export BUNDLE_WITHOUT=development:build
+
+exit_code=0
+
+function run {
+    declare -a tests_command=("$@")
+
+    echo ''
+    echo "=== Running \`${tests_command[*]}\`"
+    if ! ${tests_command[*]}; then
+        echo "=== These tests failed."
+        exit_code=1
+    fi
+}
+
+run npm install
+run bundle install
+run bundle exec bowndler install --allow-root
+run mv config/database{-jenkins,}.yml
+run mv config/cloud_storage{.example,}.yml
+run bundle exec rake db:setup
+#Tests
+run brakeman -q --no-pager --ensure-latest
+run bundle exec rspec
+run bundle exec ./node_modules/.bin/karma start spec/javascripts/karma.conf.js --single-run
+run bundle exec cucumber
+run bundle exec rubocop -DS
+
+exit "$exit_code"


### PR DESCRIPTION
https://moneyadviceservice.tpondemand.com/entity/8797-add-rad-to-jenkins-for-ci

Changes required to add this repo in Jenkins.

Multiple containers are required for PostGres DB and for the rails application. Docker-compose has been used to achieve this.

In addition;

The test group in Gemfile has been updated: to include tzinfo-data and brakeman gems 