### PR TITLE
Upgrade mas-rad_core from Github master.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', git: 'https://github.com/moneyadviceservice/mas-rad_core.git',
-                    tag: 'v0.1.4'
+gem 'mas-rad_core', '0.1.4'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'letter_opener', group: :development
 gem 'mailjet'
-gem 'mas-rad_core', '0.1.3'
+gem 'mas-rad_core', git: 'https://github.com/moneyadviceservice/mas-rad_core.git',
+                    tag: 'v0.1.4'
 gem 'oga'
 gem 'pg'
 gem 'rails_email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,23 @@ GIT
       rails (>= 3.2)
       sass-rails (~> 4.0.0)
 
+GIT
+  remote: https://github.com/moneyadviceservice/mas-rad_core.git
+  revision: 1dc54b8829a8a8f260bc45bf5dc1ec4405921f07
+  tag: v0.1.4
+  specs:
+    mas-rad_core (0.1.4)
+      active_model_serializers
+      geocoder
+      httpclient
+      language_list
+      pg
+      rails (~> 4.2.10)
+      redis
+      statsd-ruby
+      uk_phone_numbers
+      uk_postcode
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -173,7 +190,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffaker (2.7.0)
-    geocoder (1.4.4)
+    geocoder (1.4.5)
     gherkin (4.1.3)
     gli (2.17.1)
     globalid (0.4.1)
@@ -220,17 +237,6 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-rad_core (0.1.3)
-      active_model_serializers
-      geocoder
-      httpclient
-      language_list
-      pg
-      rails (~> 4.2.10)
-      redis
-      statsd-ruby
-      uk_phone_numbers
-      uk_postcode
     method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -458,7 +464,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core (= 0.1.3)
+  mas-rad_core!
   oga
   pg
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,23 +15,6 @@ GIT
       rails (>= 3.2)
       sass-rails (~> 4.0.0)
 
-GIT
-  remote: https://github.com/moneyadviceservice/mas-rad_core.git
-  revision: 1dc54b8829a8a8f260bc45bf5dc1ec4405921f07
-  tag: v0.1.4
-  specs:
-    mas-rad_core (0.1.4)
-      active_model_serializers
-      geocoder
-      httpclient
-      language_list
-      pg
-      rails (~> 4.2.10)
-      redis
-      statsd-ruby
-      uk_phone_numbers
-      uk_postcode
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -237,6 +220,17 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
+    mas-rad_core (0.1.4)
+      active_model_serializers
+      geocoder
+      httpclient
+      language_list
+      pg
+      rails (~> 4.2.10)
+      redis
+      statsd-ruby
+      uk_phone_numbers
+      uk_postcode
     method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -464,7 +458,7 @@ DEPENDENCIES
   launchy
   letter_opener
   mailjet
-  mas-rad_core!
+  mas-rad_core (= 0.1.4)
   oga
   pg
   poltergeist


### PR DESCRIPTION
The current gem version is broken in production as it uses the no longer available Redis.connect function in the geocoder initialiser.

The changes to mas-rad_core also removes many deprecation warnings which were appearing while running the specs.

Related to https://moneyadviceservice.tpondemand.com/entity/8699-rad-upgrade-rails-and-node-packages