### PR TITLE
[DEV APPROVED] 8860 Bump active_model_serializers from 0.9.x -> 0.10.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ ruby '2.2.2'
 gem 'rails', '4.2.10'
 
 gem 'active_link_to'
-gem 'active_model_serializers', '0.9.4'
+gem 'active_model_serializers', '~> 0.10.1'
 gem 'azure-storage'
 gem 'bootstrap-sass'
 gem 'bowndler', github: 'moneyadviceservice/bowndler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,11 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    active_model_serializers (0.9.4)
-      activemodel (>= 3.2)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -94,6 +97,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
@@ -185,7 +190,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     ice_cube (0.11.1)
     jquery-rails (4.3.1)
@@ -193,6 +198,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    jsonapi-renderer (0.2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -237,7 +243,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     multi_json (1.12.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -436,7 +442,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_link_to
-  active_model_serializers (= 0.9.4)
+  active_model_serializers (~> 0.10.1)
   azure-storage
   better_errors
   binding_of_caller


### PR DESCRIPTION
`mas-rad_core` was bumped to 0.10.x ([this PR](https://github.com/moneyadviceservice/mas-rad_core/pull/164)) - which meant that it didn't need to include `self.root = false` in the serializers.

Unfortunately - bumping the gem does not mean that either `rad` or `rad_consumer` will use that version, and they are both currently on `0.9.x`.

If you do not include `self.root = false` in a serializer, in `active_model_serializers@0.9.x` - the json object returned will include the serialized model inside of a top level key, instead of just returning the serialized model.

E.g.

On 0.9.x: (this was copy pasted from a `rad` production console)
```ruby
irb(main):016:0> FirmSerializer.new(firm).as_json
=> {"firm"=>{:_id=>1306, :registered_name=>"Stafford & Co Ltd", ...
```

On 0.10.x: (from a console in this branch)
```ruby
FirmSerializer.new(firm).as_json
=> {:_id=>4, :registered_name=>"Financial Advice 5 Ltd.", ...
```