### PR TITLE
[DEV APPROVED] Add firms master selection on fca import back

### DIFF
--- a/lib/fca/import.rb
+++ b/lib/fca/import.rb
@@ -48,7 +48,7 @@ module FCA
     def import(file)
       outcomes = River.source(context)
                       .step(&download(file))
-                      .step(&unzip(/^firms2\d+\.ext$/, /^indiv_apprvd2\d+\.ext$/, /^firm_names2\d+\.ext$/))
+                      .step(&unzip(files_to_be_imported))
                       .step(&to_sql(LOOKUP_TABLE_PREFIX))
                       .step(&save)
                       .sink
@@ -61,6 +61,10 @@ module FCA
       end
 
       [file, import_status, outcomes]
+    end
+
+    def files_to_be_imported
+      [/^firms_master_list2\d+\.ext$/, /^indiv_apprvd2\d+\.ext$/, /^firm_names2\d+\.ext$/]
     end
   end
 end

--- a/lib/fca/utils.rb
+++ b/lib/fca/utils.rb
@@ -12,7 +12,7 @@ module FCA
       end
     end
 
-    def unzip(*regexps)
+    def unzip(regexps)
       ignore_file = ->(s) { (regexps.map { |r| s =~ r }).any? }
 
       lambda do |r, w, c|

--- a/spec/lib/fca/import_spec.rb
+++ b/spec/lib/fca/import_spec.rb
@@ -51,4 +51,18 @@ RSpec.describe FCA::Import do
       end
     end
   end
+
+  describe '#files_to_be_imported' do
+    subject(:files_to_be_imported) do
+      described_class.new(files, {}, []).files_to_be_imported
+    end
+
+    it 'returns regexp of the three files' do
+      expect(files_to_be_imported).to eq([
+                                           /^firms_master_list2\d+\.ext$/,
+                                           /^indiv_apprvd2\d+\.ext$/,
+                                           /^firm_names2\d+\.ext$/
+                                         ])
+    end
+  end
 end


### PR DESCRIPTION
[TP 8838](https://moneyadviceservice.tpondemand.com/entity/8838-rad-fca-import-report-shows-wrong)

### Bug

When you try to upload the FCA zip files to import all firms, you will see 0 (zero) firms to be imported.

### Steps to reproduce the bug:
 
Go to https://radsignup.moneyadviceservice.org.uk/admin/lookup/fca_import
Click FCA Import in Look up data
In Lookup_firms showing **after:0**

### The cause of the bug

The PR done on #415 was deleted on the next deploys, perhaps someone did a rebase by accident.
I manage to put it back but seeing the code a second time I moved to a method to make the code cleaner.