### PR TITLE
[DEV APPROVED] Upgrade Sprockets & Brakeman gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
-    brakeman (4.2.1)
+    brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.1)
     capybara (2.18.0)
@@ -274,7 +274,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.2)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
@@ -392,7 +392,7 @@ GEM
       gli
       hashie
       websocket-driver
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
CVE-2018-3760 in sprockets 2.12.4
Specially crafted requests can be used to access files that exist on the filesystem that is outside an application's root directory, when the Sprockets server is used in production.

Bump version to 2.12.5

Upgrade Brakeman to latest