### PR TITLE
[DEV APPROVED] Downgrade `redis` to 3.3.5

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "vendor/assets/bower_components"
+  "directory": "vendor/assets/bower_components",
+  "registry": "https://registry.bower.io"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /tmp
 COPY .ruby-version .ruby-version
 
 #Download RVM as root
-RUN \curl -#LO https://rvm.io/mpapis.asc && gpg --import mpapis.asc && \
+RUN \gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
   \curl -sSL https://get.rvm.io | bash -s stable
 
 #Install RVM requirements

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,12 @@ gem 'pg', '0.21.0'
 gem 'rails_email_validator'
 gem 'rake', '~> 11'
 gem 'ransack'
+# Adding `redis` as a direct dependency to highlight the fact that `sidekiq` in
+# version `3.3.4` has a very loose lock for `redis`, which causes the bug
+# described at: https://github.com/antirez/redis/issues/4272
+# N.B.: it will possibly need to be removed as soon as we bump `sidekiq` to the
+# latest version
+gem 'redis', '~> 3.3.5'
 gem 'rollbar'
 gem 'rubyzip'
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.3.2)
-    redis (4.0.1)
+    redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     responders (2.4.0)
@@ -473,6 +473,7 @@ DEPENDENCIES
   rails_email_validator
   rake (~> 11)
   ransack
+  redis (~> 3.3.5)
   rollbar
   rspec-collection_matchers
   rspec-rails
@@ -496,4 +497,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
[TP 10053](https://moneyadviceservice.tpondemand.com/entity/10053-rad-sidekiq-web-500)

As the title says, this PR downgrades `redis`, which was bumped to 4.0.1 with #418, as a "loose" dependency from `sidekiq` [here](https://github.com/mperham/sidekiq/blob/v3.3.4/sidekiq.gemspec#L17).

**This allows the sidekiq web interface to be rendered properly instead of returning 500.**

### More details
When used with `sidekiq` 3.x, any `redis` 4.x version seems to be causing the following:
https://github.com/antirez/redis/issues/4272

```
Redis::CommandError - ERR Syntax error, try CLIENT (LIST | KILL | GETNAME | SETNAME | PAUSE | REPLY):
```

Worth mentioning that the latest `sidekiq` 3.x added a tighter lock [here](https://github.com/mperham/sidekiq/blob/d547c2a8fc66ff3f973d69336ad15a4ebc13d159/sidekiq.gemspec#L18), but I am not willing to bump `sidekiq` at the moment.  

EDIT: I have tried to bump `sidekiq` but it broke the `sidetiq` dependency, which is not maintained anymore. Not the way to go for the time being.

### Extras

We use a quite ancient version of `bower` through a forked heroku buildpack, the upstream of which is not maintained anymore, which means the deployment fails. Official way to fix it for legacy versions is to specify the new registry in the `.bowerrc` file.