### PR TITLE
[DEV APPROVED] 9238 Make adviser details mandatory for remote firms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test, :development do
   gem 'ffaker'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rb-readline'
   gem 'rspec-rails'
   gem 'rubocop', '0.54.0'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,7 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.3.2)
+    rb-readline (0.5.5)
     redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -513,6 +514,7 @@ DEPENDENCIES
   rails_email_validator
   rake (~> 11)
   ransack
+  rb-readline
   redis (~> 3.3.5)
   rollbar
   rspec-collection_matchers

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -193,7 +193,7 @@ class Firm < ActiveRecord::Base
   end
 
   def missing_advisers?
-    (primary_advice_method == :local) && advisers.empty?
+    advisers.empty?
   end
 
   private

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -189,11 +189,7 @@ class Firm < ActiveRecord::Base
   end
 
   def publishable?
-    registered? && offices.any? && !missing_advisers?
-  end
-
-  def missing_advisers?
-    advisers.empty?
+    registered? && offices.any? && advisers.any?
   end
 
   private

--- a/app/presenters/self_service/status_presenter.rb
+++ b/app/presenters/self_service/status_presenter.rb
@@ -82,7 +82,7 @@ module SelfService
     end
 
     def advisers?
-      remote? || advisers.any?
+      advisers.any?
     end
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -164,40 +164,9 @@ RSpec.describe Firm do
     end
 
     context 'when the firm has no advisers' do
-      before { allow(firm).to receive(:missing_advisers?).and_return(true) }
+      before { allow(firm).to receive(:advisers).and_return([]) }
 
       it { is_expected.to be_falsey }
-    end
-  end
-
-  describe '#missing_advisers?' do
-    let(:factory) { :firm }
-    subject { FactoryGirl.create(factory, advisers_count: advisers_count).missing_advisers? }
-
-    context 'when the firm offers face-to-face advice' do
-      context 'when the firm has advisers' do
-        let(:advisers_count) { 1 }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when the firm has no advisers' do
-        let(:advisers_count) { 0 }
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    context 'when the firm offers remote advice' do
-      let(:factory) { :firm_with_remote_advice }
-
-      context 'when the firm has advisers' do
-        let(:advisers_count) { 1 }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when the firm has no advisers' do
-        let(:advisers_count) { 0 }
-        it { is_expected.to be_truthy }
-      end
     end
   end
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Firm do
     let(:firm) { FactoryGirl.create(:firm) }
     subject { firm.publishable? }
 
-    context 'when the firm is valid, has a main office and is not missing advisers' do
+    context 'when the firm is valid, has a main office and has at least 1 adviser' do
       it { is_expected.to be_truthy }
     end
 
@@ -163,7 +163,7 @@ RSpec.describe Firm do
       it { is_expected.to be_falsey }
     end
 
-    context 'when the firm is missing advisers' do
+    context 'when the firm has no advisers' do
       before { allow(firm).to receive(:missing_advisers?).and_return(true) }
 
       it { is_expected.to be_falsey }
@@ -196,7 +196,7 @@ RSpec.describe Firm do
 
       context 'when the firm has no advisers' do
         let(:advisers_count) { 0 }
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
       end
     end
   end

--- a/spec/presenters/self_service/status_presenter_spec.rb
+++ b/spec/presenters/self_service/status_presenter_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe SelfService::StatusPresenter do
         let(:primary_advice_method) { :remote }
 
         it 'provides "tick"' do
-          expect(presenter.advisers_icon).to eq('tick')
+          expect(presenter.advisers_icon).to eq('exclamation')
         end
       end
 
@@ -283,7 +283,7 @@ RSpec.describe SelfService::StatusPresenter do
         let(:primary_advice_method) { :remote }
 
         it 'is false' do
-          expect(presenter.needs_advisers?).to eq(false)
+          expect(presenter.needs_advisers?).to eq(true)
         end
       end
 

--- a/spec/presenters/self_service/status_presenter_spec.rb
+++ b/spec/presenters/self_service/status_presenter_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe SelfService::StatusPresenter do
       context 'and is remote' do
         let(:primary_advice_method) { :remote }
 
-        it 'provides "tick"' do
+        it 'provides "exclamation"' do
           expect(presenter.advisers_icon).to eq('exclamation')
         end
       end
@@ -282,7 +282,7 @@ RSpec.describe SelfService::StatusPresenter do
       context 'and is remote' do
         let(:primary_advice_method) { :remote }
 
-        it 'is false' do
+        it 'is true' do
           expect(presenter.needs_advisers?).to eq(true)
         end
       end


### PR DESCRIPTION
[TP 9328](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/9238)

### PROBLEM
Currently, when a firm only provides phone or online advice, it is not required to enter any advisers. 

![image](https://user-images.githubusercontent.com/3481059/52564915-3cb54800-2dfd-11e9-8f71-0dbd522836d9.png)

### SOLUTION
There is now a requirement for these firms to have at least 1 adviser. The first instalment of this requirement is to show a warning and highlight where there are no advisers.

<img width="1192" alt="firm prompted to enter details" src="https://user-images.githubusercontent.com/3481059/52626372-edc5ec00-2eaa-11e9-82cd-4e0ab6b65996.png">
