### PR TITLE
[DEV APPROVED] 10264 - Create rake task to compare RAD firms with FCA firms

### DIFF
--- a/lib/reports/audit_fca_firms.rb
+++ b/lib/reports/audit_fca_firms.rb
@@ -1,0 +1,66 @@
+module Reports
+  class FcaRow
+    attr_reader :row
+
+    def initialize(row)
+      @row = row
+    end
+
+    def firm_reference_number
+      row[0]
+    end
+
+    def firm_name
+      row[1]
+    end
+
+    def telephone_number
+      [row[13], row[14], row[15]].join(' ').tr(',', ' ')
+    end
+
+    def mobile_number
+      [row[16], row[17], row[18]].join(' ').tr(',', ' ')
+    end
+
+    def address
+      [row[5], row[6], row[9], row[11], row[12]].reject(&:blank?).join(' - ')
+    end
+  end
+
+  class AuditFcaFirms
+    HEADERS = [
+      'Fca Firm Reference number',
+      'Fca Firm name',
+      'Telephone number',
+      'Mobile number',
+      'Fca Address'
+    ].freeze
+    DEFAULT_FILE = '/tmp/audit_fca_firms.csv'.freeze
+
+    def initialize(fca_file:, csv_file: DEFAULT_FILE)
+      @lines = File.read(File.expand_path(fca_file))
+      @csv_file = csv_file
+    end
+
+    def to_csv
+      CSV.open(@csv_file, 'wb') do |csv|
+        csv << HEADERS
+        rows.each do |row|
+          csv << [
+            row.firm_reference_number,
+            row.firm_name,
+            row.telephone_number,
+            row.mobile_number,
+            row.address
+          ]
+        end
+      end
+    end
+
+    def rows
+      @lines.each_line.to_a[1..-1].map do |line|
+        FcaRow.new(line.force_encoding('ISO-8859-1').split('|'))
+      end
+    end
+  end
+end

--- a/lib/reports/audit_rad_firms.rb
+++ b/lib/reports/audit_rad_firms.rb
@@ -1,0 +1,55 @@
+module Reports
+  class AuditRadFirms
+    DEFAULT_FILE = '/tmp/audit_firms.csv'.freeze
+
+    HEADERS = [
+      'RAD Principle contact name',
+      'RAD Firm Reference number',
+      'RAD Firm name',
+      'RAD Address',
+      'RAD email address',
+      'RAD telephone number',
+      'RAD website',
+      'Date firm was added to the MAS directory'
+    ].freeze
+
+    def initialize(csv_file: DEFAULT_FILE)
+      @csv_file = csv_file
+    end
+
+    def to_csv
+      CSV.open(@csv_file, 'wb') do |csv|
+        csv << HEADERS
+
+        Firm.find_each(batch_size: 500) do |firm|
+          csv << row(firm)
+        end
+      end
+    end
+
+    def row(firm)
+      [
+        firm.principal.full_name,
+        firm.fca_number,
+        firm.registered_name,
+        format_address(firm),
+        firm.main_office.try(:email_address),
+        firm.main_office.try(:telephone_number),
+        firm.website_address,
+        I18n.l(firm.created_at, format: :long)
+      ]
+    end
+
+    private
+
+    def format_address(firm)
+      return '' if firm.main_office.blank?
+
+      address = Office::ADDRESS_FIELDS.map do |field|
+        firm.main_office.send(field)
+      end
+
+      address.reject(&:blank?).join(' - ')
+    end
+  end
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,4 +1,10 @@
 namespace 'reports' do
+  desc 'Audit of the firms listed to compare the data against FCA data.'
+  task :audit_firms, [:file] => :environment do |t, args|
+    Reports::AuditRadFirms.new.to_csv
+    Reports::AuditFcaFirms.new(fca_file: args[:file]).to_csv
+  end
+
   desc 'Analyses the differences between the DB and the Index and provides a suggested action to fix'
   task audit_index: :environment do
     Tasks::AuditIndex.analyse

--- a/spec/lib/reports/audit_fca_firms_spec.rb
+++ b/spec/lib/reports/audit_fca_firms_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Reports::AuditFcaFirms do
+  describe '#to_csv' do
+    let(:csv_file) { Tempfile.new('temp_file.csv') }
+    let(:fca_file) { fixture('firms.ext') }
+
+    it 'stores fca firms to csv file' do
+      described_class.new(fca_file: fca_file, csv_file: csv_file).to_csv
+      expect(CSV.read(csv_file, encoding: 'ISO-8859-1').last).to eq(
+        [
+          '131581',
+          'S £ C Limited',
+          '44 01277 231 505',
+          '44 01277 230 572',
+          '151 High Street - Limited - Test - 4SA'
+        ]
+      )
+    end
+  end
+end

--- a/spec/lib/reports/audit_rad_firms_spec.rb
+++ b/spec/lib/reports/audit_rad_firms_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Reports::AuditRadFirms do
+  describe '#to_csv' do
+    let(:principal) do
+      create(
+        :principal,
+        fca_number: 123_456,
+        first_name: 'Bryan',
+        last_name: 'Adams'
+      )
+    end
+    let!(:firm) do
+      create(
+        :firm,
+        registered_name: 'Financial LTDA',
+        fca_number: 123_456,
+        website_address: 'https://financialltda.co.uk',
+        principal: principal,
+        created_at: Time.new(2019, 1, 1).utc
+      )
+    end
+    let(:csv_file) { Tempfile.new('temp_file.csv') }
+
+    before do
+      firm.main_office.update!(
+        address_line_one: 'Suite 3b',
+        address_line_two: 'Beancross Road',
+        address_town: 'Grangemouth',
+        address_county: 'Stirlingshire',
+        address_postcode: 'FK3 8WH',
+        email_address: 'irving_thiel@lind.biz',
+        telephone_number: '07111 333 222'
+      )
+      firm.reload
+    end
+
+    it 'stores rad firms to csv file' do
+      described_class.new(csv_file: csv_file).to_csv
+      expect(CSV.read(csv_file).last).to eq(
+        [
+          'Bryan Adams',
+          '123456',
+          'Financial LTDA',
+          'Suite 3b - Beancross Road - Grangemouth - Stirlingshire - FK3 8WH',
+          'irving_thiel@lind.biz',
+          '07111 333 222',
+          'https://financialltda.co.uk',
+          'January 01, 2019 00:00'
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/10264-rad-pull-data-from-the-tool)

## Context

Due to concerns about the possibility of firms being fraudulently cloned, the RAD admins need to conduct an audit of the firms listed in the tool to compare the data against FCA data.
 
This will help the stakeholders to compare the firms and check which firm on RAD could be a fraud.

## Solution

We receive a FCA file every week. I created a rake task which you can pass a FCA file and then it generates two csv files:

```sh
 $ rake reports:audit_firms[~/archives/firms_master_list20190207.ext]
```

The command above will create two csv files on tmp directory:
```sh
   $ ls /tmp/audit_f*
```
```
      /tmp/audit_fca_firms.csv /tmp/audit_firms.csv
```

## Criteria of done of this work

- [x] Generate the csv and deliver to stakeholders (Theresa) 
- [x] Create this PR 
- [x] Create a documentation page on technical docs explaining where to get the FCA file and how to run the rake task.