### PR TITLE
[DEV APPROVED] Bugfix: repair FCA import process

### DIFF
--- a/lib/fca/row.rb
+++ b/lib/fca/row.rb
@@ -20,7 +20,7 @@ module FCA
       @prefix        = options[:prefix]
       @trading_names = Set.new
       @repairs       = YAML.load_file(::File.join(Rails.root, 'lib/fca/repairs.yml'))['repairs']
-      @row           = repair.force_encoding('ISO-8859-1').split(options[:delimeter])
+      @row           = repair.split(options[:delimeter])
     end
 
     def header?


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/10334-rad-advisers-missing-from-the-lookup)

# Background

The FCA import process is triggered manually via the RAD admin screen.
Once started, it retrieves a set of zip files from a remote location,
opens each one individually, and persists the data in each archive
across several tables in a SQL database.

# Problem

This functionality is currently broken. It's unclear how long this bug
has been affecting imports, but at a minimum the last two datasets have
failed. The issue involves any data containing non-ASCII characters, eg
'é' or 'ü'. These are typically found in the names of Advisers. An
encoding error is thrown when attempting to read this data and the
import of that particular zip file fails.

The source of the problem lies in how the encoding of the import data is
being handled. The current implementation does the following:

* Use set_encoding('ISO8859-1') on each zip archive.
* Iterate over each entry in the archive.
* Read each line of data in an entry and write it to a tempfile, for
  eventual transformation into SQL.

This doesn't work because it has no effect on the encoding of the actual
data. When the data is read, it's read as binary. This binary data is
then written out to a tempfile for eventual transformation into SQL.

When we reach the Row class as part of the SQL transformation, a line of
code dealing with data repair calls force_encoding('ISO-8859-1') on the
row data. Again, this has no meaningful impact - force_encoding simply
sets the encoding of the string, it doesn't change how the string is
stored in memory. During the process of generating SQL from the line
data, an encoding error is raised - presumably as a result of trying to
use the unmodified binary data as part of a string interpolation.

# Fix

This patch removes the encoding-related code discussed above and
instead ensures that when reading the zip file contents, the input data
is converted to UTF-8 before writing out to a tempfile.