### PR TITLE
[DEV APPROVED] 10498 - Principal unable to sign in (bug)

### DIFF
--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -28,8 +28,10 @@ class Admin::PrincipalsController < Admin::ApplicationController
 
     message = destroy_message(principal)
 
-    user.principal.destroy
-    user.destroy
+    ActiveRecord::Base.transaction do
+      user.principal.destroy!
+      user.destroy!
+    end
 
     redirect_to admin_principals_path, notice: message
   end

--- a/spec/controllers/admin/principals_controller_spec.rb
+++ b/spec/controllers/admin/principals_controller_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Admin::PrincipalsController, type: :controller do
+  before { sign_in(user) }
+
+  let(:user) { FactoryGirl.create(:user, principal: principal) }
+  let(:principal) { FactoryGirl.create(:principal) }
+
+  describe 'DELETE #destroy' do
+    context 'when successful' do
+      it 'removes the principal and the user', :aggregate_failures do
+        expect { delete :destroy, id: principal.id }
+          .to change(Principal, :count).by(-1).and change(User, :count).by(-1)
+
+        expect(flash[:notice]).to match(/Successfully deleted/)
+      end
+    end
+
+    context 'when an exception is raised' do
+      before do
+        Principal.set_callback(:destroy, :around, -> { raise StandardError })
+      end
+
+      after do
+        Principal.reset_callbacks(:destroy)
+      end
+
+      def silence
+        yield
+      rescue StandardError
+        nil
+      end
+
+      it 'does not remove neither the principal nor the user' do
+        aggregate_failures do
+          expect { silence { delete :destroy, id: principal.id } }
+            .to change(Principal, :count).by(0).and change(User, :count).by(0)
+
+          expect(flash[:notice]).not_to match(/Successfully deleted/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 10498](https://moneyadviceservice.tpondemand.com/entity/10498-rad-principal-unable-to-sign-in)

This PR's goal is to prevent the re-occurrence of the bug described above (in short: a principal existed but the associated user did not).

Please find more information attached to the card including the comments and the commit description.