### PR TITLE
[DEV APPROVED] - Sidekiq concurrency and retries tuning

### DIFF
--- a/app/jobs/update_algolia_index_job.rb
+++ b/app/jobs/update_algolia_index_job.rb
@@ -2,7 +2,7 @@ class UpdateAlgoliaIndexJob < ActiveJob::Base
   include Sidekiq::Worker
 
   queue_as :default
-  sidekiq_options retry: 15, backtrace: true, unique: :until_executed
+  sidekiq_options retry: 25, backtrace: true, unique: :until_executed
 
   def perform(klass, id, firm_id = nil)
     AlgoliaIndex.handle_update(klass: klass, id: id, firm_id: firm_id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 ---
+:concurrency: 10
 :queues:
   - default
   - mailers

--- a/spec/jobs/update_algolia_index_job_spec.rb
+++ b/spec/jobs/update_algolia_index_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe UpdateAlgoliaIndexJob do
   describe 'sidekiq settings' do
     it { is_expected.to be_processed_in :default }
-    it { is_expected.to be_retryable 15 }
+    it { is_expected.to be_retryable 25 }
     it { is_expected.to save_backtrace }
   end
 


### PR DESCRIPTION
This PR is related to #442 and changes a couple of `sidekiq` settings to solve some sporadic 500s in staging and prevent some issues with the retries in the future.

Further details are available in the commit history.

There is no ticket related as it's still part of [TP 10269](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/10269).