### PR TITLE
[DEV APPROVED] Update the year in the admin footer

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -65,7 +65,7 @@
 
 <footer class="footer">
   <div class="container">
-    <p class="text-muted">Money Advice Service 2015</p>
+    <p class="text-muted">Money Advice Service <%= DateTime.now.year %></p>
   </div>
 </footer>
 


### PR DESCRIPTION
The year in the footer of the admin section displays as '2015'. This pr sets they date dynamically so it always displays as the current year.