### PR TITLE
[WIP] - 10527 Verify FCA number using the FCA API

### DIFF
--- a/app/controllers/admin/firms_controller.rb
+++ b/app/controllers/admin/firms_controller.rb
@@ -25,7 +25,8 @@ class Admin::FirmsController < Admin::ApplicationController
   end
 
   def approve
-    Firm.find(params[:firm_id]).approve!
-    redirect_to :back
+    @firm = Firm.find(params[:firm_id])
+    @firm.approve!
+    redirect_to admin_firm_path(@firm.id)
   end
 end

--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -36,6 +36,14 @@ class Admin::PrincipalsController < Admin::ApplicationController
     redirect_to admin_principals_path, notice: message
   end
 
+  def verify_fca_number
+    @principal = Principal.find(params[:principal_id])
+    @principal.verify_fca!
+    @firm = @principal.firm
+
+    redirect_to admin_firm_path(@firm.id)
+  end
+
   private
 
   def principal

--- a/app/helpers/admin/firms_helper.rb
+++ b/app/helpers/admin/firms_helper.rb
@@ -28,6 +28,15 @@ module Admin::FirmsHelper
     User.find_by(principal_token: principal.token)
   end
 
+  def fca_verified_text(principal)
+    principal.fca_verified? ? 'FCA verified' : 'Not FCA verified'
+  end
+
+  def fca_verified_class(principal)
+    return if principal.fca_verified?
+    'alert alert-warning'
+  end
+
   private
 
   def render_literal_or_fee_or_percentage(value, attribute_name)

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -3,7 +3,7 @@ class Principal < ActiveRecord::Base
 
   before_create :generate_token
   after_create  :associate_firm
-  after_create :verify_fca_number
+  after_commit :verify_fca_number, on: :create
 
   has_one :firm,
           -> { where(parent_id: nil) },
@@ -91,9 +91,11 @@ class Principal < ActiveRecord::Base
   end
 
   def verify_fca_number
-    unless fca_authorised_firm?(fca_number)
-      true
-    end
+    verify_fca! if fca_authorised_firm?(fca_number)
+  end
+
+  def verify_fca!
+    update_attribute(fca_verifed: true)
   end
 
   def fca_authorised_firm?(fca_number)

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -74,6 +74,10 @@ class Principal < ActiveRecord::Base
     main_firm_with_trading_names.any?(&:publishable?)
   end
 
+  def verify_fca!
+    update_attribute(:fca_verified, true)
+  end
+
   private
 
   def find_subsidiary(subsidiary)
@@ -92,10 +96,6 @@ class Principal < ActiveRecord::Base
 
   def verify_fca_number
     verify_fca! if fca_authorised_firm?(fca_number)
-  end
-
-  def verify_fca!
-    update_attribute(fca_verifed: true)
   end
 
   def fca_authorised_firm?(fca_number)

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -76,7 +76,7 @@
       </tr>
       <% if @firms.present? %>
         <% @firms.each do |firm| %>
-          <tr class="t-firm-row">
+          <tr class="t-firm-row <%= fca_verified_class(firm.principal) %>">
             <td>
               <% if firm.principal.present? %>
                 <%= link_to "#{firm.principal.first_name} #{firm.principal.last_name}", admin_principal_path(firm.principal) %>

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -5,6 +5,9 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
+    <% unless @firm.principal.fca_verified? %>
+      <div class="alert alert-warning"><%= fca_verified_text(@firm.principal) %></div>
+    <% end %>
     <p>
       <strong>Principal:</strong>
       <%= link_to "#{@firm.principal.first_name} #{@firm.principal.last_name}", admin_principal_path(@firm.principal) %>
@@ -15,6 +18,15 @@
     </p>
     <p>
       <strong>FCA Number:</strong> <%= @firm.fca_number %>
+      <% unless @firm.principal.fca_verified? %>
+        <span>
+          <%= button_to('Verify FCA reference',
+                        admin_principal_verify_fca_number_path(@firm.principal.id),
+                        class: 'btn btn-success',
+                        method: :post)
+           %>
+        </span>
+      <% end %>
     </p>
     <p>
       <strong>Registered Name:</strong> <%= @firm.registered_name %>
@@ -28,7 +40,7 @@
     <p>
       <strong>Approved:</strong> <%= @firm.approved_at&.to_s(:long) || 'Not approved' %>
     </p>
-    <% if @firm.approved_at.blank? %>
+    <% if @firm.approved_at.blank? && @firm.principal.fca_verified? %>
       <p>
         <%= button_to('Approve Firm',
                       admin_firm_approve_path(@firm.id),

--- a/app/views/admin/principals/index.html.erb
+++ b/app/views/admin/principals/index.html.erb
@@ -44,7 +44,7 @@
       </tr>
       <% if @principals.present? %>
         <% @principals.each do |principal| %>
-          <tr>
+          <tr class= "<%= fca_verified_class(principal) %>">
             <td><%= link_to principal.firm.registered_name, admin_firm_path(principal.firm) %></td>
             <td><%= principal.fca_number %></td>
             <td><%= link_to "#{principal.first_name} #{principal.last_name}", admin_principal_path(principal) %></td>

--- a/app/views/admin/principals/show.html.erb
+++ b/app/views/admin/principals/show.html.erb
@@ -5,11 +5,23 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
+    <% unless @principal.fca_verified? %>
+      <div class="alert alert-warning"><%= fca_verified_text(@principal) %></div>
+    <% end %>
     <p>
       <strong>Firm:</strong> <%= link_to @principal.firm.registered_name, admin_firm_path(@principal.firm) %>
     </p>
     <p>
       <strong>FCA Number:</strong> <%= @principal.fca_number %>
+      <% unless @principal.fca_verified? %>
+        <span>
+          <%= button_to('Verify FCA reference',
+                        admin_principal_verify_fca_number_path(@principal.id),
+                        class: 'btn btn-success',
+                        method: :post)
+           %>
+        </span>
+      <% end %>
     </p>
     <p>
       <strong>Name:</strong> <%= "#{@principal.first_name} #{@principal.last_name}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,11 @@ Rails.application.routes.draw do
         end
       end
     end
+
+    resources :principals, only: [:show] do
+      post :verify_fca_number
+    end
+
     namespace :lookup do
       resources :advisers, only: :index
       resources :firms, only: :index

--- a/db/migrate/20190614154743_add_fca_verified_to_principals.rb
+++ b/db/migrate/20190614154743_add_fca_verified_to_principals.rb
@@ -1,0 +1,18 @@
+class AddFcaVerifiedToPrincipals < ActiveRecord::Migration
+  def up
+    add_column :principals, :fca_verified, :boolean, default: false
+    add_index :principals, :fca_verified
+
+    db.execute "UPDATE principals SET fca_verified = true"
+  end
+
+  def down
+    remove_column :principals, :fca_verified
+  end
+
+  private
+
+  def db
+    ActiveRecord::Base.connection
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190606111937) do
+ActiveRecord::Schema.define(version: 20190614154743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -258,9 +258,11 @@ ActiveRecord::Schema.define(version: 20190606111937) do
     t.boolean  "confirmed_disclaimer", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "fca_verified",         default: false
   end
 
   add_index "principals", ["fca_number"], name: "index_principals_on_fca_number", unique: true, using: :btree
+  add_index "principals", ["fca_verified"], name: "index_principals_on_fca_verified", using: :btree
   add_index "principals", ["token"], name: "index_principals_on_token", unique: true, using: :btree
 
   create_table "professional_standings", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       - POSTGRESHOST=postgres
       - POSTGRESPASS=go
       - POSTGRESUSER=go
+      - FCA_API_DOMAIN=https://register.fca.org.uk
+      - FCA_API_EMAIL=email
+      - FCA_API_KEY=api_key
+      - FCA_API_MAX_RETRIES=5
+      - FCA_API_TIMEOUT=10
     links:
       - postgres
 volumes:

--- a/spec/factories/principal.rb
+++ b/spec/factories/principal.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     job_title { Faker::Name.title }
     telephone_number '07111 333 222'
     confirmed_disclaimer true
+    fca_verified false
 
     after(:build) { |p| create(:lookup_firm, fca_number: p.fca_number) }
   end

--- a/spec/features/admin/delete_adviser_spec.rb
+++ b/spec/features/admin/delete_adviser_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Deleting an adviser from the admin interface', :inline_job_queue 
     @adviser_first = create(:adviser)
     @firm = @adviser_first.firm
     @adviser_second = create(:adviser, firm: @firm)
+    [@adviser_first, @adviser_second].each {|adviser| adviser.run_callbacks(:commit)}
   end
 
   def and_the_advisers_are_present_in_the_directory
@@ -33,6 +34,7 @@ RSpec.feature 'Deleting an adviser from the admin interface', :inline_job_queue 
 
   def and_i_click_delete_adviser
     admin_adviser_page.delete_adviser.click
+    @adviser_first.run_callbacks(:commit)
   end
 
   def then_the_adviser_is_deleted

--- a/spec/features/admin/delete_principal_and_entire_firm_spec.rb
+++ b/spec/features/admin/delete_principal_and_entire_firm_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'Deleting principal and all related firm, adviser, office and trad
   end
 
   def and_the_firm_adviser_and_office_are_present_in_the_directory
+    @firm.offices.each{|office| office.run_callbacks(:commit)}
     expect(firm_advisers_in_directory(@firm).size).to eq 1
     expect(firm_offices_in_directory(@firm).size).to eq 1
     expect(firm_advisers_in_directory(@firm).first['objectID']).to eq @adviser.id
@@ -56,6 +57,8 @@ RSpec.feature 'Deleting principal and all related firm, adviser, office and trad
   end
 
   def and_the_firm_adviser_and_office_get_removed_from_the_directory
+    @firm.advisers.each{|adviser| adviser.run_callbacks(:commit)}
+    @firm.offices.each{|office| office.run_callbacks(:commit)}
     expect(firm_advisers_in_directory(@firm)).to be_empty
     expect(firm_offices_in_directory(@firm)).to be_empty
   end

--- a/spec/features/admin/firm_index_spec.rb
+++ b/spec/features/admin/firm_index_spec.rb
@@ -1,0 +1,40 @@
+RSpec.feature 'Viewing firms on the admin interface' do
+  let(:the_page) { Admin::FirmsIndexPage.new }
+
+  before do
+    given_there_are_firms
+    given_i_am_on_the_admin_firms_index_page
+    then_i_see_all_firms
+  end
+
+  scenario 'Identifying firms with unverified fca numbers' do
+    then_i_see_firms_with_unverified_fca_numbers
+  end
+
+  def given_i_am_on_the_admin_firms_index_page
+    the_page.load
+    expect(the_page).to be_displayed
+    expect_no_errors
+  end
+
+  def given_there_are_firms
+    @verified_principals = 4.times.map{|n| FactoryGirl.create(:principal, fca_verified: true) }
+    @un_verified_principals = 4.times.map{|n| FactoryGirl.create(:principal) }
+  end
+
+  def then_i_see_all_firms
+    total_firms = (@verified_principals + @un_verified_principals).map(&:firm)
+
+    expect(the_page.total_firms).to eq(total_firms.count)
+    expect(the_page.firms.count).to eq(total_firms.count)
+  end
+
+  def expect_no_errors
+    return unless status_code == 500
+    expect(the_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
+  end
+
+  def then_i_see_firms_with_unverified_fca_numbers
+    expect(the_page.fca_unverified_firms.count).to eq(@un_verified_principals.count)
+  end
+end

--- a/spec/features/admin/move_advisers_spec.rb
+++ b/spec/features/admin/move_advisers_spec.rb
@@ -65,6 +65,7 @@ RSpec.feature 'Move advisers between firms', :inline_job_queue do
   end
 
   def and_adviser_is_associated_to_firm_in_the_directory(adviser, firm)
+    firm.advisers.each{|adviser| adviser.run_callbacks(:commit)}
     directory_adviser = advisers_in_directory.find do |elem|
       elem['objectID'] == adviser.id
     end

--- a/spec/features/admin/new_adviser_spec.rb
+++ b/spec/features/admin/new_adviser_spec.rb
@@ -94,6 +94,7 @@ RSpec.feature 'Add a new adviser without an FCA number', :inline_job_queue do
   end
 
   def and_i_can_see_1_adviser
+    @firm.advisers.each{|adviser| adviser.run_callbacks(:commit)}
     expect(firm_page.advisers.count).to eq(1)
   end
 

--- a/spec/features/admin/verify_firm_fca_number_spec.rb
+++ b/spec/features/admin/verify_firm_fca_number_spec.rb
@@ -1,0 +1,45 @@
+RSpec.feature 'Verify a firm\'s fca number' do
+  let(:admin_firm_page) { Admin::FirmPage.new }
+  let(:admin_firm_index_page) { Admin::FirmsIndexPage.new }
+
+  scenario 'Admin verifies the fca reference number' do
+    given_there_is_firm
+    when_i_visit_the_firm_page
+    when_i_see_the_fca_not_verified_message
+    then_i_dont_see_the_approve_button
+    when_i_click_verify_fca_reference    
+    then_the_firm_should_be_fca_verified
+    then_i_see_the_approve_button
+  end
+
+  def given_there_is_firm
+    @principal = FactoryGirl.create(:principal)
+    @firm = @principal.firm
+    @user = FactoryGirl.create(:user, principal: @principal)
+  end
+
+  def when_i_visit_the_firm_page
+    admin_firm_page.load(firm_id: @firm.id)
+  end
+
+  def when_i_see_the_fca_not_verified_message
+    expect(admin_firm_page).to have_fca_not_verified_warning
+  end
+
+  def when_i_click_verify_fca_reference
+    admin_firm_page.verify_fca_reference_button.click
+  end
+
+  def then_the_firm_should_be_fca_verified
+    expect(admin_firm_page).to_not have_fca_not_verified_warning
+    expect(admin_firm_page).to_not have_verify_fca_reference_button
+  end
+
+  def then_i_dont_see_the_approve_button
+    expect(admin_firm_page).not_to have_approve_button
+  end
+
+  def then_i_see_the_approve_button
+    expect(admin_firm_page).to have_approve_button
+  end
+end

--- a/spec/features/principal_provides_identifying_information_spec.rb
+++ b/spec/features/principal_provides_identifying_information_spec.rb
@@ -21,13 +21,6 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
     then_i_am_on_the_self_service_home_page
   end
 
-  scenario 'My FCA number cannot be matched' do
-    given_i_have_passed_the_pre_qualification_step
-    when_i_provide_a_valid_but_unmatched_fca_number
-    then_i_am_told_my_firms_details_are_not_present
-    and_i_am_asked_to_contact_admin_if_i_have_any_queries
-  end
-
   scenario 'I provide invalid information' do
     given_i_have_passed_the_pre_qualification_step
     when_i_provide_incorrect_or_invalid_information
@@ -51,22 +44,6 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
 
   def then_i_am_told_which_fields_are_incorrect_and_why
     expect(identification_page).to have_validation_summaries
-  end
-
-  def when_i_provide_a_valid_but_unmatched_fca_number
-    identification_page.tap do |p|
-      p.reference_number.set '654321'
-      p.email.set 'ben@example.com'
-      p.register.click
-    end
-  end
-
-  def then_i_am_told_my_firms_details_are_not_present
-    expect(identification_page).to be_firm_unmatched
-  end
-
-  def and_i_am_asked_to_contact_admin_if_i_have_any_queries
-    expect(identification_page).to be_errored
   end
 
   def when_i_provide_my_firms_fca_reference_number

--- a/spec/features/self_service/advisers_edit_spec.rb
+++ b/spec/features/self_service/advisers_edit_spec.rb
@@ -96,6 +96,7 @@ RSpec.feature 'The self service firm edit page', :inline_job_queue do
 
   def and_the_information_is_changed
     @adviser.reload
+    @adviser.run_callbacks(:commit)
     expect(@adviser.postcode).to eq updated_postcode
     expect(@adviser.travel_distance).to eq 250
     expect(@adviser.accreditations).to include(Accreditation.last)

--- a/spec/features/self_service/advisers_index_spec.rb
+++ b/spec/features/self_service/advisers_index_spec.rb
@@ -74,12 +74,14 @@ RSpec.feature 'The self service adviser list page', :inline_job_queue do
   end
 
   def and_the_firm_advisers_are_present_in_the_directory
+    @principal.firm.advisers.each{|adviser| adviser.run_callbacks(:commit)}
     @original_firm_advisers_in_dir = firm_advisers_in_directory(@principal.firm)
     expect(@original_firm_advisers_in_dir.size)
       .to eq @principal.firm.advisers.size
   end
 
   def and_the_deleted_adviser_gets_removed_from_the_directory
+    @principal.firm.advisers.each{|adviser| adviser.run_callbacks(:commit)}
     expect(firm_advisers_in_directory(@principal.firm).size)
       .to eq(@original_firm_advisers_in_dir.size - 1)
   end

--- a/spec/features/self_service/offices_add_spec.rb
+++ b/spec/features/self_service/offices_add_spec.rb
@@ -127,6 +127,7 @@
 
   def and_the_principal_firm_has_an_adviser_but_no_office
     firm.update!(advisers: [FactoryGirl.create(:adviser, firm: firm)])
+    firm.run_callbacks(:commit)
     expect(firm_advisers_in_directory(firm).size).to eq 1
     expect(firm_total_advisers_in_directory(firm)).to eq 1
     expect(firm_offices_in_directory(firm).size).to eq 0
@@ -134,6 +135,7 @@
   end
 
   def and_the_new_office_is_present_in_the_directory
+    firm.offices.each{|office| office.run_callbacks(:commit)}
     expect(firm_offices_in_directory(firm).size).to eq 1
 
     directory_office = firm_offices_in_directory(firm).first

--- a/spec/features/self_service/offices_edit_spec.rb
+++ b/spec/features/self_service/offices_edit_spec.rb
@@ -124,6 +124,7 @@ RSpec.feature 'The self service office edit page', :inline_job_queue do
   end
 
   def and_the_office_information_is_updated_in_the_directory
+    office.run_callbacks(:commit)
     directory_office = offices_in_directory.find do |elem|
       elem['objectID'] == office.id
     end

--- a/spec/features/self_service/offices_index_spec.rb
+++ b/spec/features/self_service/offices_index_spec.rb
@@ -158,6 +158,7 @@ RSpec.feature 'The self service firm offices list page', :inline_job_queue do
   end
 
   def and_the_firm_offices_are_present_in_the_directory
+    firm.offices.each{|office| office.run_callbacks(:commit)}
     @original_firm_total_offices_in_dir =
       firm_total_offices_in_directory(firm)
     @original_firm_offices_in_dir = firm_offices_in_directory(firm)
@@ -170,6 +171,7 @@ RSpec.feature 'The self service firm offices list page', :inline_job_queue do
   end
 
   def and_the_deleted_office_gets_removed_from_the_directory
+    firm.offices.each{|office| office.run_callbacks(:commit)}
     expect(firm_offices_in_directory(firm).size)
       .to eq(@original_firm_offices_in_dir.size - 1)
   end

--- a/spec/helpers/admin/firms_helper_spec.rb
+++ b/spec/helpers/admin/firms_helper_spec.rb
@@ -1,0 +1,21 @@
+module Admin
+  RSpec.describe FirmsHelper, type: :helper do
+    describe '#fca_verified_text' do
+      let(:principal) { create(:principal, fca_number: '123456', fca_verified: fca_status) }
+
+      context 'when the fca number has been verified' do
+        let(:fca_status) { true }
+        it 'returns "fca verified"' do
+          expect(helper.fca_verified_text(principal)).to eq 'FCA verified'
+        end
+      end
+
+      context 'when the fca number has NOT been verified' do
+        let(:fca_status) { false }
+        it 'returns "NOT fca verified"' do
+          expect(helper.fca_verified_text(principal)).to eq 'Not FCA verified'
+        end
+      end
+    end
+  end
+end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -438,21 +438,23 @@ RSpec.describe Firm do
 
   describe 'after_commit' do
     it 'saving a new firm calls notify_indexer' do
-      firm = FactoryGirl.build(:firm)
+      firm = FactoryGirl.create(:firm)
       expect(firm).to receive(:notify_indexer)
-      firm.save
+      firm.run_callbacks(:commit)
     end
 
     it 'updating a firm calls notify_indexer' do
       firm = FactoryGirl.create(:firm)
       expect(firm).to receive(:notify_indexer)
       firm.update_attributes(registered_name: 'A new name')
+      firm.run_callbacks(:commit)
     end
 
     it 'destroying a firm calls notify_indexer' do
       firm = FactoryGirl.create(:firm)
       expect(firm).to receive(:notify_indexer)
       firm.destroy
+      firm.run_callbacks(:commit)
     end
   end
 

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -24,19 +24,21 @@ RSpec.describe Office do
 
   describe 'after_commit' do
     it 'saving a new office calls notify_indexer' do
-      office = FactoryGirl.build(:office, firm: firm)
+      office = FactoryGirl.create(:office, firm: firm)
       expect(office).to receive(:notify_indexer)
-      office.save
+      office.run_callbacks(:commit)
     end
 
     it 'updating an office calls notify_indexer' do
       expect(office).to receive(:notify_indexer)
       office.update_attributes(address_line_one: 'A new street')
+      office.run_callbacks(:commit)
     end
 
     it 'destroying an office calls notify_indexer' do
       expect(office).to receive(:notify_indexer)
       office.destroy
+      office.run_callbacks(:commit)
     end
   end
 

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Principal do
+
   let(:principal) { create(:principal) }
   let(:trading_name) { create(:firm, parent: principal.firm, fca_number: principal.fca_number) }
 
@@ -232,12 +233,11 @@ RSpec.describe Principal do
   end
 
   describe '#create' do 
-    context 'when the fca number is verified' do
+    context 'when the fca number is verified' do 
       include_context 'fca api ok response'
-
       it 'sets the verification flag to true' do
         principal = create(:principal)
-        principal.run_callbacks :create
+        principal.run_callbacks :commit
         expect(principal.fca_verified).to be_truthy
       end
     end

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Principal do
   let(:principal) { create(:principal) }
   let(:trading_name) { create(:firm, parent: principal.firm, fca_number: principal.fca_number) }
 
+  include_context 'fca api ok response'
+
   describe '#firm' do
     let(:parent_firm) { Firm.find_by(fca_number: principal.fca_number, parent: nil) }
 
@@ -81,12 +83,6 @@ RSpec.describe Principal do
           p.fca_number = 12_345
           expect(p).to_not be_valid
         end
-      end
-
-      it 'must match a `Lookup::Firm`' do
-        Lookup::Firm.find_by(fca_number: principal.fca_number).destroy
-
-        expect(principal).to_not be_valid
       end
 
       it 'must be unique' do

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Principal do
   let(:principal) { create(:principal) }
   let(:trading_name) { create(:firm, parent: principal.firm, fca_number: principal.fca_number) }
 
-  include_context 'fca api ok response'
-
   describe '#firm' do
     let(:parent_firm) { Firm.find_by(fca_number: principal.fca_number, parent: nil) }
 
@@ -229,6 +227,24 @@ RSpec.describe Principal do
 
       it 'returns true' do
         expect(principal.onboarded?).to be(true)
+      end
+    end
+  end
+
+  describe '#create' do 
+    context 'when the fca number is verified' do
+      include_context 'fca api ok response'
+
+      it 'sets the verification flag to true' do
+        principal = create(:principal)
+        principal.run_callbacks :create
+        expect(principal.fca_verified).to be_truthy
+      end
+    end
+
+    context 'when the fca number is not verified' do
+      it 'sets the verification flag to false' do
+        expect(principal.fca_verified).to be_falsey
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ Faker::Config.locale = 'en-GB'
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 5
 
-TestAfterCommit.enabled = true
+TestAfterCommit.enabled = false
 
 RSpec.configure do |c|
   c.include Rails.application.routes.url_helpers

--- a/spec/support/admin/firm_page.rb
+++ b/spec/support/admin/firm_page.rb
@@ -9,4 +9,6 @@ class Admin::FirmPage < SitePrism::Page
   element :new_adviser, '.t-new-adviser'
   element :approved, 'p:contains("Approved:")'
   element :approve_button, 'input[value="Approve Firm"]'
+  element :fca_not_verified_warning, '.alert-warning'
+  element :verify_fca_reference_button, 'input[value="Verify FCA reference"]'
 end

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -29,6 +29,8 @@ class Admin::FirmsIndexPage < SitePrism::Page
   element :workplace_financial_advice_flag_field, '.t-workplace-financial-advice-flag'
   element :languages_field, '.t-languages-field'
   element :submit, '.t-submit'
+  elements :xfirms, '.t-firm-row'
+  elements :fca_unverified_firms, '.alert-warning'
 
   sections :firms, RowSection, '.t-firm-row'
 

--- a/spec/support/contexts/fca_api_ok_response.rb
+++ b/spec/support/contexts/fca_api_ok_response.rb
@@ -1,0 +1,10 @@
+RSpec.shared_context 'fca api ok response' do
+  before do
+    allow(FcaApi::Request)
+      .to receive(:new)
+      .and_return(instance_double(
+        FcaApi::Request, get_firm: instance_double(FcaApi::Response, ok?: true)
+      )
+    )
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -24,4 +24,8 @@ VCR.configure do |config|
       request.proceed
     end
   end
+
+  config.ignore_request do |request|
+    request.uri.include?('https://register.fca.org.uk')
+  end
 end


### PR DESCRIPTION
[TP 10527](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/10527)

BACKGROUND
When a new firm is created, we verify its existence against a 'Look Up' table. That table is created from files imported from the FCA. At some point, the FCA will discontinue support for these files and replace them with its API.

REQUIREMENTS
Ensure a new firm is FCA authorised before it is published on RAD. Verify the reference number by checking for its existence on the FCA API, instead of checking the Look up table.

If the fca number does not exist on the FCA Register or the FCA API is not available, we still create the principal and set a flag to indicate the fca number needs verification. The principal is highlighted on the admin section which enables admin users to see on the index page quickly that manual intervention is required. 

On the show page, the admin user can view the full details to check the fca number against their own list, and click a button to verify the fca number. 

TECHNICAL
I had to change how the firm_search_spec features are tested as they were using Firms and with this feature, we introduce a change which requires Firms to have an associated Principal to adequately test these specific features. The creation of Firms to test various search features can probably be improved and I looked at a number of approaches using various FactoryGirl features such as traits, parent, association and after methods but they didn't work or perhaps I applied them incorrectly. As always, open to any and all comments etc.