### PR TITLE
Add Algolia directory feature tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :test do
   gem 'rspec-collection_matchers'
   gem 'rspec-sidekiq'
   gem 'site_prism'
+  gem 'test_after_commit'
   gem 'tzinfo-data'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,8 @@ GEM
     statsd-ruby (1.4.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    test_after_commit (1.2.2)
+      activerecord (>= 3.2, < 5.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -530,6 +532,7 @@ DEPENDENCIES
   site_prism
   slack-ruby-client
   statsd-ruby (~> 1.4.0)
+  test_after_commit
   timecop
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -35,7 +35,7 @@ class Adviser < ActiveRecord::Base
   after_commit :notify_indexer
 
   def notify_indexer
-    UpdateAlgoliaIndexJob.perform_async(model_name.name, id, firm_id)
+    UpdateAlgoliaIndexJob.perform_later(model_name.name, id, firm_id)
   end
 
   def self.on_firms_with_fca_number(fca_number)

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -113,7 +113,7 @@ class Firm < ActiveRecord::Base
   after_commit :notify_indexer
 
   def notify_indexer
-    UpdateAlgoliaIndexJob.perform_async(model_name.name, id)
+    UpdateAlgoliaIndexJob.perform_later(model_name.name, id)
   end
 
   # A heuristic that allows us to infer validity

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -43,7 +43,7 @@ class Office < ActiveRecord::Base
   after_commit :notify_indexer
 
   def notify_indexer
-    UpdateAlgoliaIndexJob.perform_async(model_name.name, id, firm_id)
+    UpdateAlgoliaIndexJob.perform_later(model_name.name, id, firm_id)
   end
 
   def field_order

--- a/spec/features/admin/delete_adviser_spec.rb
+++ b/spec/features/admin/delete_adviser_spec.rb
@@ -1,20 +1,34 @@
-RSpec.feature 'Deleting an adviser from the admin interface' do
+RSpec.feature 'Deleting an adviser from the admin interface', :inline_job_queue do
+  include_context 'algolia directory double'
+
   let(:admin_adviser_page) { AdminAdviserPage.new }
 
   scenario 'Deleting an adviser' do
-    given_there_is_an_adviser
+    given_there_are_advisers_for_a_firm
+    and_the_advisers_are_present_in_the_directory
     when_i_visit_an_adviser_page
     and_i_click_delete_adviser
     then_the_adviser_is_deleted
+    and_the_adviser_gets_removed_from_the_directory
     and_i_am_redirected_to_the_adviser_list_page
   end
 
-  def given_there_is_an_adviser
-    @adviser = create(:adviser)
+  def given_there_are_advisers_for_a_firm
+    @adviser_first = create(:adviser)
+    @firm = @adviser_first.firm
+    @adviser_second = create(:adviser, firm: @firm)
+  end
+
+  def and_the_advisers_are_present_in_the_directory
+    directory_advisers = firm_advisers_in_directory(@firm)
+    expect(directory_advisers.size).to eq 2
+    expect(firm_total_advisers_in_directory(@firm)).to eq 2
+    expect(directory_advisers.map { |adviser| adviser['objectID'] })
+      .to eq [@adviser_first.id, @adviser_second.id]
   end
 
   def when_i_visit_an_adviser_page
-    visit(admin_adviser_path(@adviser))
+    visit(admin_adviser_path(@adviser_first))
   end
 
   def and_i_click_delete_adviser
@@ -22,7 +36,15 @@ RSpec.feature 'Deleting an adviser from the admin interface' do
   end
 
   def then_the_adviser_is_deleted
-    expect(Adviser.find_by_id(@adviser.id)).to be_nil
+    expect(Adviser.find_by_id(@adviser_first.id)).to be_nil
+  end
+
+  def and_the_adviser_gets_removed_from_the_directory
+    directory_advisers = firm_advisers_in_directory(@firm)
+    expect(directory_advisers.size).to eq 1
+    expect(firm_total_advisers_in_directory(@firm)).to eq 1
+    expect(directory_advisers.map { |adviser| adviser['objectID'] })
+      .to eq [@adviser_second.id]
   end
 
   def and_i_am_redirected_to_the_adviser_list_page

--- a/spec/features/self_service/advisers_edit_spec.rb
+++ b/spec/features/self_service/advisers_edit_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'The self service firm edit page' do
+RSpec.feature 'The self service firm edit page', :inline_job_queue do
   include CheckboxGroupHelpers
+  include_context 'algolia directory double'
 
   let(:advisers_index_page) { SelfService::AdvisersIndexPage.new }
   let(:adviser_edit_page) { SelfService::AdviserEditPage.new }
@@ -23,6 +24,7 @@ RSpec.feature 'The self service firm edit page' do
     and_i_click_save
     then_i_see_a_success_notice
     and_the_information_is_changed
+    and_the_adviser_information_is_updated_in_the_directory
   end
 
   scenario 'The system shows validation messages if there are invalid inputs' do
@@ -106,5 +108,13 @@ RSpec.feature 'The self service firm edit page' do
 
     @adviser.reload
     expect(@adviser.postcode).to eq original_postcode
+  end
+
+  def and_the_adviser_information_is_updated_in_the_directory
+    directory_adviser = advisers_in_directory.find do |elem|
+      elem['objectID'] == @adviser.id
+    end
+
+    expect(directory_adviser['postcode']).to eq updated_postcode
   end
 end

--- a/spec/features/self_service/offices_edit_spec.rb
+++ b/spec/features/self_service/offices_edit_spec.rb
@@ -1,4 +1,6 @@
-RSpec.feature 'The self service office edit page' do
+RSpec.feature 'The self service office edit page', :inline_job_queue do
+  include_context 'algolia directory double'
+
   let(:offices_index_page) { SelfService::OfficesIndexPage.new }
   let(:office_edit_page) { SelfService::OfficeEditPage.new }
 
@@ -40,6 +42,7 @@ RSpec.feature 'The self service office edit page' do
     then_no_errors_are_displayed_on(the_page: office_edit_page)
     then_i_see_a_success_notice
     then_the_information_is_changed
+    and_the_office_information_is_updated_in_the_directory
   end
 
   scenario 'The system shows validation messages if there are invalid inputs' do
@@ -118,6 +121,15 @@ RSpec.feature 'The self service office edit page' do
     office.reload
     expect(office.address_line_one).to eq updated_line_one
     expect(office.disabled_access).to eq true
+  end
+
+  def and_the_office_information_is_updated_in_the_directory
+    directory_office = offices_in_directory.find do |elem|
+      elem['objectID'] == office.id
+    end
+
+    expect(directory_office['address_line_one']).to eq updated_line_one
+    expect(directory_office['disabled_access']).to eq true
   end
 
   def then_the_information_is_not_changed

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Adviser do
     subject { FactoryGirl.create(:adviser) }
 
     it 'notifies the indexer that the office has changed' do
-      expect(UpdateAlgoliaIndexJob).to receive(:perform_async)
+      expect(UpdateAlgoliaIndexJob).to receive(:perform_later)
         .with('Adviser', subject.id, subject.firm_id)
 
       subject.notify_indexer

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -435,34 +435,22 @@ RSpec.describe Firm do
   end
 
   describe 'after_commit' do
-    before { expect(subject).to receive(:notify_indexer) }
-
-    context 'when a new firm is saved' do
-      subject { FactoryGirl.build(:firm) }
-
-
-      it 'calls notify_indexer' do
-        subject.save
-        subject.run_callbacks(:commit)
-      end
+    it 'saving a new firm calls notify_indexer' do
+      firm = FactoryGirl.build(:firm)
+      expect(firm).to receive(:notify_indexer)
+      firm.save
     end
 
-    context 'when a firm is updated' do
-      subject { FactoryGirl.create(:firm) }
-
-      it 'calls notify_indexer' do
-        subject.update_attributes(registered_name: 'A new name')
-        subject.run_callbacks(:commit)
-      end
+    it 'updating a firm calls notify_indexer' do
+      firm = FactoryGirl.create(:firm)
+      expect(firm).to receive(:notify_indexer)
+      firm.update_attributes(registered_name: 'A new name')
     end
 
-    context 'when a firm is destroyed' do
-      subject { FactoryGirl.create(:firm) }
-
-      it 'calls notify_indexer' do
-        firm.destroy
-        subject.run_callbacks(:commit)
-      end
+    it 'destroying a firm calls notify_indexer' do
+      firm = FactoryGirl.create(:firm)
+      expect(firm).to receive(:notify_indexer)
+      firm.destroy
     end
   end
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe Firm do
 
   describe '#notify_indexer' do
     it 'notifies the indexer that the firm has changed' do
-      expect(UpdateAlgoliaIndexJob).to receive(:perform_async)
+      expect(UpdateAlgoliaIndexJob).to receive(:perform_later)
         .with('Firm', subject.id)
 
       subject.notify_indexer

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Office do
 
   describe '#notify_indexer' do
     it 'notifies the indexer that the office has changed' do
-      expect(UpdateAlgoliaIndexJob).to receive(:perform_async)
+      expect(UpdateAlgoliaIndexJob).to receive(:perform_later)
         .with('Office', subject.id, subject.firm_id)
 
       office.notify_indexer

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -18,34 +18,25 @@ RSpec.describe Office do
       expect(UpdateAlgoliaIndexJob).to receive(:perform_async)
         .with('Office', subject.id, subject.firm_id)
 
-      subject.notify_indexer
+      office.notify_indexer
     end
   end
 
   describe 'after_commit' do
-    before { expect(subject).to receive(:notify_indexer) }
-
-    context 'when a new office is saved' do
-      subject { FactoryGirl.build(:office, firm: firm) }
-
-      it 'calls notify_indexer' do
-        subject.save
-        subject.run_callbacks(:commit)
-      end
+    it 'saving a new office calls notify_indexer' do
+      office = FactoryGirl.build(:office, firm: firm)
+      expect(office).to receive(:notify_indexer)
+      office.save
     end
 
-    context 'when an office is updated' do
-      it 'calls notify_indexer' do
-        subject.update_attributes(address_line_one: 'A new street')
-        subject.run_callbacks(:commit)
-      end
+    it 'updating an office calls notify_indexer' do
+      expect(office).to receive(:notify_indexer)
+      office.update_attributes(address_line_one: 'A new street')
     end
 
-    context 'when an office is destroyed' do
-      it 'calls notify_indexer' do
-        office.destroy
-        subject.run_callbacks(:commit)
-      end
+    it 'destroying an office calls notify_indexer' do
+      expect(office).to receive(:notify_indexer)
+      office.destroy
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ Faker::Config.locale = 'en-GB'
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 5
 
+TestAfterCommit.enabled = true
+
 RSpec.configure do |c|
   c.include Rails.application.routes.url_helpers
 

--- a/spec/support/contexts/algolia_directory_double.rb
+++ b/spec/support/contexts/algolia_directory_double.rb
@@ -1,0 +1,98 @@
+RSpec.shared_context 'algolia directory double' do
+  let(:algolia_advisers_index) { AlgoliaIndexDouble.new('firm-advisers-test') }
+  let(:algolia_offices_index) { AlgoliaIndexDouble.new('firm-offices-test') }
+
+  before do
+    allow(Algolia::Index).to receive(:new)
+      .with('firm-advisers-test')
+      .and_return(algolia_advisers_index)
+    allow(Algolia::Index).to receive(:new)
+      .with('firm-offices-test')
+      .and_return(algolia_offices_index)
+  end
+
+  after do
+    algolia_advisers_index.clear_index
+    algolia_offices_index.clear_index
+  end
+
+  def advisers_in_directory
+    JSON.parse(AlgoliaIndex.indexed_advisers.browse(''))['hits']
+  end
+
+  def offices_in_directory
+    JSON.parse(AlgoliaIndex.indexed_offices.browse(''))['hits']
+  end
+
+  def firm_advisers_in_directory(firm)
+    advisers_in_directory.select do |adviser|
+      adviser.dig('firm', 'id') == firm.id
+    end
+  end
+
+  def firm_offices_in_directory(firm)
+    offices_in_directory.select do |office|
+      office['firm_id'] == firm.id
+    end
+  end
+
+  def firm_total_offices_in_directory(firm)
+    firm_advisers_in_directory(firm).first.dig('firm', 'total_offices')
+  end
+
+  def firm_total_advisers_in_directory(firm)
+    firm_advisers_in_directory(firm).first.dig('firm', 'total_advisers')
+  end
+
+  class AlgoliaIndexDouble
+    attr_reader :name
+
+    RESPONSE_ATTRS ||= {
+      'processingTimeMS' => 7,
+      'query' => '',
+      'params' => 'filters=level%3D20',
+      'cursor' => 'ARJmaWx0ZXJzPWxldmVsJTNEMjABARoGODA4OTIzvwgAgICAgICAgICAAQ=='
+    }.freeze
+
+    def initialize(index_name)
+      @name = index_name
+      @collection = []
+    end
+
+    def delete_object(id)
+      collection.delete_if { |elem| elem.objectID == id }
+    end
+
+    def add_object(elem)
+      stored_at = collection.index { |item| item.objectID == elem.objectID }
+
+      if stored_at
+        @collection[stored_at] = elem
+      else
+        @collection << elem
+      end
+    end
+
+    def add_objects(elements)
+      elements.each { |elem| add_object(elem) }
+    end
+
+    def replace_all_objects(elements)
+      @collection = [elements]
+    end
+
+    def browse(_foo)
+      {
+        'hits' => collection
+      }.merge(RESPONSE_ATTRS).to_json
+    end
+
+    def clear_index
+      @collection = []
+    end
+
+    private
+
+    attr_reader :collection
+  end
+end


### PR DESCRIPTION
[TP-10560](https://moneyadviceservice.tpondemand.com/entity/10560-add-expectations-over-directory-contentupdates-in)

Current integration tests cover the management of
Principals, Firms, Advisers and Offices from both the Principals and
Admins user flows.

The test coverage is missing a key part of RAD business logic though:
"What and when gets pushed/removed to the RAD Directory?"

The main purpose of RAD, besides allow Principals/Admins to maintain
firms advisers and offices, is to provide that data to the public
consuming Retirement Adviser Directory. And that should be covered
with integration tests.

The retirement adviser directory publicly accessible information gets
pushed from this app to Algolia. Containing:
- One index for firm Advisers.
- One index for firm Offices.

Being able to inspect what the index contains at the end of user flows
is quite tricky, and can have different approaches:

(TLDR: Jump to the fifth Approach - We used an Algolia Test Double)

### First approach: Use real Algolia cloud stored test indexes.

We have shared Algolia test indexes running exactly as in production.
The problem is that this data is shared between different test/runs and
data from one test can pollute the expectations of other tests.

On top of the test isolation issue, we would have a real dependency on
the ALGOLIA API KEY for testing and we would need to hit
Algolia service multiple times for each feature test run.

### Second approach: Set expectations over Webmock/VCR cassetes.

This would cover when we want to check that "this object gets pushed to
Algolia" or "this object gets removed from Algolia", but it would imply
a quite big number of cassettes and also doesn't make easy to just check:
"Algolia Index contains X but not Y" expectations at the end of an user
flow.

### Third approach: Use Algolia provided testing Mocks.

Algolia gem provides Webmock stubs collection for testing purposes.
Problem is that those stubs return fixed data, with fixed ID and
information. If we want to test what do we actually push/delete from
our indexes, this approach wouldn't allow us, as indexes will always
return the same unrelated dummy data.

### Fourth approach: Just set expectations over calls on Algolia Indexes.

Classic "I expect Algolia to receive a call over add element to the
index".

This stubbing works great for Unit testing, when you isolate bits of
business logic and just expect "X to be called", but we are doing
end to end feature testing, and we mainly want to check "What Algolia
contains after this user flow happen".
In order to get anything similar
to that setting call expectations over Algolia Index stubs, we would
need to know too much about the implementation and define lots of
stubs, making tests quite brittle and coupled with the implementation.

### Fifth approach: Replace real Algolia for a local test double.
We don't want to be stubbing all the Algolia calls, we don't want to
use real Algolia service with network dependency and lack of test env
isolation... what do we have left?
We can just replace Algolia all together with a fake test directory
providing the same interface as Algolia but just storing the indexes
into an array.

This allow us to:
- Not have any network/api dependency.
- Test end to end what indexes contain at the end of an user flow.
- Minimal use of Stubs (we only stub the calls for instantiating a
  new Algolia::Index object).
- Reduce the coupling with implementation details.
  As a single spec context file contains all the Algolia::Index stub
  and helper methods to query the index from tests.
  If something happens to change in real Algolia gem interface/service,
  we basically have a single point to maintain, instead having
  implementation details polluting all our test files.

After trying/examining all the options, went for the fifth/last
approach, as allows us to test what we want to test with minimum
pain.