### PR TITLE
[DEV APPROVED] [TP-10531] require admin approval before publishing new firms in the directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
     - 'app/models/snapshot/*.rb'
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'spec/**/*'
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/CollectionMethods:

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ group :test do
   gem 'database_cleaner'
   gem 'launchy'
   gem 'poltergeist'
-  gem 'rb-readline'
   gem 'rspec-collection_matchers'
   gem 'rspec-sidekiq'
   gem 'site_prism'

--- a/app/controllers/admin/advisers_controller.rb
+++ b/app/controllers/admin/advisers_controller.rb
@@ -68,7 +68,7 @@ class Admin::AdvisersController < Admin::ApplicationController
       :travel_distance,
       qualification_ids: [],
       accreditation_ids: [],
-      professional_standing_ids: [],
+      professional_standing_ids: []
     )
   end
 end

--- a/app/controllers/admin/firms_controller.rb
+++ b/app/controllers/admin/firms_controller.rb
@@ -23,4 +23,9 @@ class Admin::FirmsController < Admin::ApplicationController
       end
     end
   end
+
+  def approve
+    Firm.find(params[:firm_id]).approve!
+    redirect_to :back
+  end
 end

--- a/app/controllers/principals_controller.rb
+++ b/app/controllers/principals_controller.rb
@@ -48,6 +48,8 @@ class PrincipalsController < ApplicationController
     Stats.increment('radsignup.principal.created')
 
     Identification.contact(user.principal).deliver_later
+    NewFirmMailer.notify(user.principal.firm).deliver_later
+
     redirect_to user.principal
   end
 

--- a/app/controllers/self_service/advisers_controller.rb
+++ b/app/controllers/self_service/advisers_controller.rb
@@ -61,7 +61,7 @@ module SelfService
         :travel_distance,
         accreditation_ids: [],
         qualification_ids: [],
-        professional_standing_ids: [],
+        professional_standing_ids: []
       )
     end
   end

--- a/app/mailers/new_firm_mailer.rb
+++ b/app/mailers/new_firm_mailer.rb
@@ -1,0 +1,12 @@
+class NewFirmMailer < ActionMailer::Base
+  default(
+    from: 'RADenquiries@moneyadviceservice.org.uk',
+    to: 'RADenquiries@moneyadviceservice.org.uk'
+  )
+
+  def notify(firm)
+    @firm = firm
+    mail(to: FCA::Config.email_recipients,
+         subject: 'New Firm registered in the directory')
+  end
+end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -15,6 +15,7 @@ class Firm < ActiveRecord::Base
     wills_and_probate_flag
   ].freeze
 
+  scope :approved, -> { where.not(approved_at: nil) }
   scope :registered, -> { where.not(REGISTERED_MARKER_FIELD => nil) }
   scope :sorted_by_registered_name, -> { order(:registered_name) }
 

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -192,6 +192,12 @@ class Firm < ActiveRecord::Base
     registered? && offices.any? && advisers.any?
   end
 
+  def approve!
+    # rubocop:disable Rails/SkipsModelValidations
+    update_attribute(:approved_at, Time.zone.now) unless approved_at
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
   private
 
   def infer_primary_advice_method

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -72,6 +72,7 @@
         <th><%= sort_link(@search, :registered_name, 'Firm Registered Name') %></th>
         <th># Advisers</th>
         <th><%= sort_link(@search, :created_at, 'Added') %></th>
+        <th><%= sort_link(@search, :approved_at, 'Approved') %></th>
       </tr>
       <% if @firms.present? %>
         <% @firms.each do |firm| %>
@@ -93,6 +94,7 @@
             </td>
             <td><%= link_to(firm.advisers.count, admin_firm_advisers_path(firm)) %></td>
             <td><%= firm.created_at.to_s(:short) %></td>
+            <td><%= firm.approved_at&.to_s(:short) || 'Not approved' %></td>
           </tr>
         <% end %>
       <% else %>

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -28,6 +28,14 @@
     <p>
       <strong>Approved:</strong> <%= @firm.approved_at&.to_s(:long) || 'Not approved' %>
     </p>
+    <% if @firm.approved_at.blank? %>
+      <p>
+        <%= button_to('Approve Firm',
+                      admin_firm_approve_path(@firm.id),
+                      class: 'btn btn-success',
+                      method: :post) %>
+      </p>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -25,6 +25,9 @@
     <p>
       <strong>Added:</strong> <%= @firm.created_at.to_s(:long) %>
     </p>
+    <p>
+      <strong>Approved:</strong> <%= @firm.approved_at&.to_s(:long) || 'Not approved' %>
+    </p>
   </div>
 </div>
 

--- a/app/views/new_firm_mailer/notify.html.erb
+++ b/app/views/new_firm_mailer/notify.html.erb
@@ -1,0 +1,5 @@
+<h1>New Firm notification</h1>
+<div>
+  A new firm has been registered in the directory:
+  <%= link_to(@firm.registered_name, admin_firm_url(@firm.id)) %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,5 +38,8 @@ Rails.application.configure do
   # Allow previews for emails in development environment
   config.action_mailer.delivery_method = :letter_opener
 
+  # Switch previews location to Rspec forlder
+  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
     resources :advisers, only: [:index, :show, :edit, :update, :destroy]
 
     resources :firms, only: [:index, :show] do
+      post :approve
+
       collection do
         get :login_report
         get :adviser_report

--- a/db/migrate/20190604103603_add_approved_at_to_firms.rb
+++ b/db/migrate/20190604103603_add_approved_at_to_firms.rb
@@ -1,0 +1,18 @@
+class AddApprovedAtToFirms < ActiveRecord::Migration
+  def up
+    add_column :firms, :approved_at, :datetime
+    add_index :firms, :approved_at
+
+    db.execute "UPDATE firms SET approved_at = current_timestamp"
+  end
+
+  def down
+    remove_column :firms, :approved_at
+  end
+
+  private
+
+  def db
+    ActiveRecord::Base.connection
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,8 +108,10 @@ ActiveRecord::Schema.define(version: 20190606111937) do
     t.integer  "status"
     t.boolean  "workplace_financial_advice_flag",          default: false, null: false
     t.boolean  "non_uk_residents_flag",                    default: false, null: false
+    t.datetime "approved_at"
   end
 
+  add_index "firms", ["approved_at"], name: "index_firms_on_approved_at", using: :btree
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree
 
   create_table "firms_in_person_advice_methods", id: false, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,3 +68,51 @@ end
   'Holder of Trust and Estate Practitioner qualification (TEP) i.e. full member of STEP',
   'Fellow of the Chartered Insurance Institute (FCII)'
 ].each.with_index(1) { |item, index| Qualification.find_or_create_by!(id: index, name: item, order: index) }
+
+[
+  {number: '111111', name: 'Rice Inc'},
+  {number: '222222', name: 'Kreiger LLC'},
+  {number: '333333', name: 'Kozey LLC'},
+].each do |firm|
+    Lookup::Firm.create(
+      fca_number: firm[:number],
+      registered_name: firm[:name]
+    )
+  end
+
+[
+  {
+    fca_number: '111111',
+    first_name: 'Mohammed',
+    last_name: 'Hoeger',
+    email: 'mohammed@jones.name',
+    title: 'Legacy Functionality Developer',
+    phone: '07111 333 222'
+  },
+  {
+    fca_number: '222222',
+    first_name: 'Irwin',
+    last_name: 'Bednar',
+    email: 'irwin@bernier.info',
+    title: 'Lead Applications Orchestrator',
+    phone: '07222 137 444'
+  },
+  {
+    fca_number: '333333',
+    first_name: 'Camilla',
+    last_name: 'Heathcote',
+    email: 'camilla@rolfson.info',
+    title: 'Lead Web Architect',
+    phone: '07333 765 396'
+  }
+].each do |principal|
+    Principal.create(
+      fca_number: principal[:fca_number],
+      first_name: principal[:first_name],
+      last_name: principal[:last_name],
+      email_address: principal[:email],
+      job_title: principal[:title],
+      telephone_number: principal[:phone],
+      confirmed_disclaimer: true
+    )
+  end

--- a/lib/algolia_index/models/adviser.rb
+++ b/lib/algolia_index/models/adviser.rb
@@ -7,11 +7,13 @@ module AlgoliaIndex
       end
     end
 
-    delegate :update, to: :firm
+    def update
+      firm.update_advisers
+    end
 
     def destroy
       AlgoliaIndex.indexed_advisers.delete_object(id)
-      firm.update
+      firm.update_advisers
     end
   end
 end

--- a/lib/algolia_index/models/firm.rb
+++ b/lib/algolia_index/models/firm.rb
@@ -1,15 +1,33 @@
 module AlgoliaIndex
   class Firm < Base
     def update
+      return unless approved?
+      update_offices
+      update_advisers
+    end
+
+    def update_advisers
       advisers = object&.advisers&.geocoded
-      return if advisers.blank?
+      return unless approved? && advisers.present?
 
       serialized = advisers.map(&AlgoliaIndex::AdviserSerializer.method(:new))
       AlgoliaIndex.indexed_advisers.add_objects(serialized)
     end
 
+    def update_offices
+      offices = object&.offices&.geocoded
+      return unless approved? && offices.present?
+
+      serialized = offices.map(&AlgoliaIndex::OfficeSerializer.method(:new))
+      AlgoliaIndex.indexed_offices.add_objects(serialized)
+    end
+
     def destroy
       # Do nothing, because we don't maintain a Firm index.
+    end
+
+    def approved?
+      object&.approved_at.present?
     end
   end
 end

--- a/lib/algolia_index/models/firm.rb
+++ b/lib/algolia_index/models/firm.rb
@@ -2,6 +2,7 @@ module AlgoliaIndex
   class Firm < Base
     def update
       return unless approved?
+
       update_offices
       update_advisers
     end

--- a/lib/algolia_index/models/office.rb
+++ b/lib/algolia_index/models/office.rb
@@ -8,14 +8,16 @@ module AlgoliaIndex
     end
 
     def update
+      return unless firm.approved?
+
       serialized = AlgoliaIndex::OfficeSerializer.new(object)
       AlgoliaIndex.indexed_offices.add_object(serialized)
-      firm.update
+      firm.update_advisers
     end
 
     def destroy
       AlgoliaIndex.indexed_offices.delete_object(id)
-      firm.update
+      firm.update_advisers
     end
   end
 end

--- a/lib/fca_api/connection.rb
+++ b/lib/fca_api/connection.rb
@@ -13,9 +13,7 @@ module FcaApi
       configure_raw_connection
     end
 
-    def get(path)
-      raw_connection.get(path)
-    end
+    delegate :get, to: :raw_connection
 
     private
 

--- a/lib/fca_api/request.rb
+++ b/lib/fca_api/request.rb
@@ -1,11 +1,11 @@
 module FcaApi
   class Request
     FIRM_ENDPOINT = '/services/V0.1/Firm'.freeze
-      
+
     attr_reader :connection, :product_connection
 
     def initialize
-      @connection = Connection.new(ENV.fetch('FCA_API_DOMAIN'))      
+      @connection = Connection.new(ENV.fetch('FCA_API_DOMAIN'))
     end
 
     def get_firm(firm_id)

--- a/lib/fca_api/response.rb
+++ b/lib/fca_api/response.rb
@@ -1,7 +1,7 @@
 module FcaApi
   class Response
-    SUCCESS_MESSAGE = 'ok'
-      
+    SUCCESS_MESSAGE = 'ok'.freeze
+
     attr_reader :response
 
     def initialize(response)

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -21,12 +21,14 @@ namespace :index do
     Rails.logger.info 'Querying the db (this might take some time...)'
 
     advisers = Firm.registered
+                   .approved
                    .includes(:advisers)
                    .map(&:advisers)
                    .flatten
                    .reject(&no_geoloc)
 
     offices = Firm.registered
+                  .approved
                   .includes(:offices)
                   .map(&:offices)
                   .flatten

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -19,6 +19,7 @@ FactoryGirl.define do
     inheritance_tax_and_estate_planning_flag true
     wills_and_probate_flag true
     status :independent
+    approved_at { Time.zone.now }
 
     transient do
       offices_count 1
@@ -45,6 +46,8 @@ FactoryGirl.define do
     factory :firm_without_advisers, traits: [:without_advisers]
     factory :firm_with_offices, traits: [:with_offices]
     factory :firm_without_offices, traits: [:without_offices]
+    factory :firm_with_advisers_and_offices,
+            traits: %i[with_advisers with_offices]
     factory :firm_with_principal, traits: [:with_principal]
     factory :firm_with_no_business_split, traits: [:with_no_business_split]
     factory :firm_with_remote_advice, traits: [:with_remote_advice]
@@ -55,6 +58,10 @@ FactoryGirl.define do
     trait :invalid do
       # Invalidate the marker field without referencing it directly
       __registered false
+    end
+
+    trait :not_approved do
+      approved_at nil
     end
 
     trait :with_no_business_split do

--- a/spec/features/admin/firm_approval_spec.rb
+++ b/spec/features/admin/firm_approval_spec.rb
@@ -1,0 +1,84 @@
+RSpec.feature 'Approving firms on the admin interface' do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:index_page) { Admin::FirmsIndexPage.new }
+  let(:firm_page) { Admin::FirmPage.new }
+  let(:approval_date) { Time.utc(2019, 6, 1) }
+
+  scenario 'Approving a Firm' do
+    given_there_are_fully_registered_principal_users
+    given_i_am_at_the_admin_firms_index_page
+    then_i_see_all_firms
+    then_all_firms_are_not_approved
+    when_i_visit_a_firm_page(@firms.first)
+    then_i_see_the_firm_is_not_approved
+
+    travel_to(approval_date) do
+      when_i_approve_the_firm
+    end
+
+    then_the_firm_becomes_approved
+    then_i_dont_see_the_approve_button
+    then_the_firm_is_listed_as_approved_in_the_index(@firms.first)
+  end
+
+  def given_i_am_at_the_admin_firms_index_page
+    index_page.load
+    expect(index_page).to be_displayed
+    expect_no_errors
+  end
+
+  def given_there_are_fully_registered_principal_users
+    @users = FactoryGirl.create_list(:user, 2)
+    @principals = @users.map(&:principal)
+    @firms = @principals.map(&:firm)
+  end
+
+  def then_i_see_all_firms
+    expect(index_page.total_firms).to eq(@firms.count)
+    expect(index_page.firms.count).to eq(@firms.count)
+  end
+
+  def then_all_firms_are_not_approved
+    expect(index_page.firms.map(&:approved)).to rspec_all(eq('Not approved'))
+  end
+
+  def expect_no_errors
+    return unless status_code == 500
+    expect(index_page).not_to have_text %r{[Ee]rror|[Ww]arn|[Ee]xception}
+  end
+
+  def when_i_visit_a_firm_page(firm)
+    firm_page.load(firm_id: firm.id)
+    expect(firm_page).to be_displayed
+    expect_no_errors
+  end
+
+  def then_i_see_the_firm_is_not_approved
+    expect(firm_page.approved.text).to eq('Approved: Not approved')
+  end
+
+  def when_i_approve_the_firm
+    firm_page.approve_button.click
+  end
+
+  def then_the_firm_becomes_approved
+    expect(firm_page.approved.text)
+      .to eq("Approved: #{approval_date.to_s(:long)}")
+  end
+
+  def then_i_dont_see_the_approve_button
+    expect(firm_page).not_to have_approve_button
+  end
+
+  def then_the_firm_is_listed_as_approved_in_the_index(approved_firm)
+    index_page.load
+    expect(index_page).to be_displayed
+    expect_no_errors
+
+    firm_info = index_page.firms.select do |firm|
+                  firm.fca_number.to_s == approved_firm.fca_number.to_s
+                end.first
+    expect(firm_info.approved).to eq approval_date.to_s(:short)
+  end
+end

--- a/spec/features/admin/firm_approval_spec.rb
+++ b/spec/features/admin/firm_approval_spec.rb
@@ -1,15 +1,18 @@
-RSpec.feature 'Approving firms on the admin interface' do
+RSpec.feature 'Approving firms on the admin interface', :inline_job_queue do
   include ActiveSupport::Testing::TimeHelpers
+  include_context 'algolia directory double'
 
   let(:index_page) { Admin::FirmsIndexPage.new }
   let(:firm_page) { Admin::FirmPage.new }
   let(:approval_date) { Time.utc(2019, 6, 1) }
 
   scenario 'Approving a Firm' do
-    given_there_are_fully_registered_principal_users
+    given_there_are_fully_registered_principal_users_with_advisers_and_offices
     given_i_am_at_the_admin_firms_index_page
     then_i_see_all_firms
     then_all_firms_are_not_approved
+    and_no_advisers_or_offices_are_present_in_the_directory
+
     when_i_visit_a_firm_page(@firms.first)
     then_i_see_the_firm_is_not_approved
 
@@ -18,8 +21,9 @@ RSpec.feature 'Approving firms on the admin interface' do
     end
 
     then_the_firm_becomes_approved
+    then_the_firm_advisers_and_offices_get_pushed_to_the_directory(@firms.first)
     then_i_dont_see_the_approve_button
-    then_the_firm_is_listed_as_approved_in_the_index(@firms.first)
+    then_the_firm_is_listed_as_approved_in_the_firms_index(@firms.first)
   end
 
   def given_i_am_at_the_admin_firms_index_page
@@ -28,10 +32,14 @@ RSpec.feature 'Approving firms on the admin interface' do
     expect_no_errors
   end
 
-  def given_there_are_fully_registered_principal_users
+  def given_there_are_fully_registered_principal_users_with_advisers_and_offices
     @users = FactoryGirl.create_list(:user, 2)
     @principals = @users.map(&:principal)
     @firms = @principals.map(&:firm)
+    @firms.each do |firm|
+      firm.advisers << FactoryGirl.create(:adviser, firm: firm)
+      firm.offices << FactoryGirl.create(:office, firm: firm)
+    end
   end
 
   def then_i_see_all_firms
@@ -41,6 +49,15 @@ RSpec.feature 'Approving firms on the admin interface' do
 
   def then_all_firms_are_not_approved
     expect(index_page.firms.map(&:approved)).to rspec_all(eq('Not approved'))
+  end
+
+  def and_no_advisers_or_offices_are_present_in_the_directory
+    aggregate_failures 'empty directory' do
+      @firms.each do |firm|
+        expect(firm_advisers_in_directory(firm)).to be_empty
+        expect(firm_offices_in_directory(firm)).to be_empty
+      end
+    end
   end
 
   def expect_no_errors
@@ -71,7 +88,7 @@ RSpec.feature 'Approving firms on the admin interface' do
     expect(firm_page).not_to have_approve_button
   end
 
-  def then_the_firm_is_listed_as_approved_in_the_index(approved_firm)
+  def then_the_firm_is_listed_as_approved_in_the_firms_index(approved_firm)
     index_page.load
     expect(index_page).to be_displayed
     expect_no_errors
@@ -80,5 +97,17 @@ RSpec.feature 'Approving firms on the admin interface' do
                   firm.fca_number.to_s == approved_firm.fca_number.to_s
                 end.first
     expect(firm_info.approved).to eq approval_date.to_s(:short)
+  end
+
+  def then_the_firm_advisers_and_offices_get_pushed_to_the_directory(firm)
+    directory_advisers = firm_advisers_in_directory(firm)
+    directory_offices = firm_offices_in_directory(firm)
+
+    aggregate_failures 'firm info in directory' do
+      expect(directory_advisers.map { |adviser| adviser['objectID'] })
+        .to eq firm.advisers.pluck(:id)
+      expect(directory_offices.map { |office| office['objectID'] })
+        .to eq firm.offices.pluck(:id)
+    end
   end
 end

--- a/spec/features/principal_provides_identifying_information_spec.rb
+++ b/spec/features/principal_provides_identifying_information_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
   let(:firms_index_page) { SelfService::FirmsIndexPage.new }
   let(:sign_in_page) { SignInPage.new }
 
+  before { ActionMailer::Base.deliveries.clear }
+
   scenario 'Identifying as a Firm Principal' do
     given_i_have_passed_the_pre_qualification_step
     when_i_provide_my_firms_fca_reference_number
@@ -11,6 +13,7 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
     then_my_firms_fca_reference_number_is_matched_to_the_directory
     and_i_am_shown_a_confirmation_message
     and_i_am_sent_a_verification_email
+    and_directory_admins_get_a_new_firm_notification_email
 
     when_i_visit_the_email_link
     then_i_am_asked_to_sign_in
@@ -96,7 +99,17 @@ RSpec.feature 'Principal provides identifying information', :inline_job_queue do
 
   def and_i_am_sent_a_verification_email
     expect(ActionMailer::Base.deliveries).to_not be_empty
-    expect(ActionMailer::Base.deliveries.last.body).to include new_user_session_path
+    expect(ActionMailer::Base.deliveries.first.body).to include new_user_session_path
+  end
+
+  def and_directory_admins_get_a_new_firm_notification_email
+    expect(ActionMailer::Base.deliveries).to_not be_empty
+
+    last_email = ActionMailer::Base.deliveries.last
+    expect(last_email.subject).to eq('New Firm registered in the directory')
+    expect(last_email.to).to include('dev@moneyadviceservice.org.uk')
+    expect(last_email.body).to include('Ben Lovell Ltd')
+    expect(last_email.body).to include(admin_firm_path(Firm.last.id))
   end
 
   def when_i_visit_the_email_link

--- a/spec/lib/algolia_index/models/adviser_spec.rb
+++ b/spec/lib/algolia_index/models/adviser_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe AlgoliaIndex::Adviser do
   let(:klass) { 'Adviser' }
   let(:id) { 1 }
 
-  let(:indexed_advisers) { instance_double(Algolia::Index) }
+  let(:indexed_advisers) do
+    instance_double(Algolia::Index,
+                    add_object: true,
+                    add_objects: true,
+                    delete_object: true)
+  end
 
   before do
     allow(AlgoliaIndex).to receive(:indexed_advisers)
@@ -34,13 +39,13 @@ RSpec.describe AlgoliaIndex::Adviser do
     end
   end
 
-  describe '#update' do
+  shared_examples('update firm advisers') do |trigger_call|
     let!(:adviser) { FactoryGirl.create(:adviser, id: id) }
-    let!(:dependant_advisers) do
+    let(:dependant_advisers) do
       FactoryGirl.create_list(:adviser, 3, firm: adviser.firm)
     end
 
-    let(:serialized) do
+    let(:serialized_advisers) do
       ([adviser] + dependant_advisers).map do |adv|
         AlgoliaIndex::AdviserSerializer.new(adv)
       end
@@ -48,21 +53,36 @@ RSpec.describe AlgoliaIndex::Adviser do
 
     before do
       allow(AlgoliaIndex::AdviserSerializer).to receive(:new)
-        .and_return(*serialized)
+        .and_return(*serialized_advisers)
     end
 
-    it 'updates the adviser in the index' do
-      expect(indexed_advisers).to receive(:add_objects)
-        .with(serialized).exactly(:once)
+    context 'when the adviser firm is approved' do
+      it 'updates all the firm advisers in the index' do
+        expect(indexed_advisers).to receive(:add_objects)
+          .with(serialized_advisers).exactly(:once)
+        instance.send(trigger_call)
+      end
+    end
 
-      instance.update
+    context 'when the adviser firm is not approved' do
+      before { adviser.firm.update_column(:approved_at, nil) }
+
+      it 'does not update the firm advisers in the index' do
+        expect(indexed_advisers).not_to receive(:add_objects)
+        instance.send(trigger_call)
+      end
     end
   end
 
+  describe '#update' do
+    include_examples 'update firm advisers', :update
+  end
+
   describe '#destroy' do
+    include_examples 'update firm advisers', :destroy
+
     it 'deletes the adviser in the index' do
       expect(indexed_advisers).to receive(:delete_object).with(id)
-
       instance.destroy
     end
   end

--- a/spec/lib/algolia_index/models/firm_spec.rb
+++ b/spec/lib/algolia_index/models/firm_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe AlgoliaIndex::Firm do
   let(:klass) { 'Firm' }
   let(:id) { 1 }
 
-  let(:indexed_advisers) { instance_double(Algolia::Index) }
-  let(:indexed_offices) { instance_double(Algolia::Index) }
+  let(:indexed_advisers) { instance_double(Algolia::Index, add_objects: true) }
+  let(:indexed_offices) { instance_double(Algolia::Index, add_objects: true) }
 
   before do
     allow(AlgoliaIndex).to receive(:indexed_advisers)
@@ -18,19 +18,32 @@ RSpec.describe AlgoliaIndex::Firm do
   it { expect(described_class < AlgoliaIndex::Base).to eq(true) }
 
   describe '#update' do
-    context 'when the firm does not have any advisers' do
-      let!(:firm) { FactoryGirl.create(:firm_without_advisers, id: id) }
+    context 'when the firm has not been approved' do
+      let!(:firm) do
+        FactoryGirl.create(:firm_with_advisers_and_offices,
+                           :not_approved, 
+                           id: id)
+      end
 
       it 'does not update any advisers in the index' do
         expect(indexed_advisers).not_to receive(:add_objects)
+        instance.update
+      end
 
+      it 'does not update any offices in the index' do
+        expect(indexed_offices).not_to receive(:add_objects)
         instance.update
       end
     end
 
-    context 'when the firm does have advisers' do
-      let!(:firm) { FactoryGirl.create(:firm_with_advisers, id: id) }
-      let(:serialized) do
+    context 'when the approved firm has advisers but no offices' do
+      let!(:firm) do
+        FactoryGirl.create(:firm_with_advisers,
+                           :without_offices,
+                           id: id)
+      end
+
+      let(:serialized_advisers) do
         firm.advisers.geocoded.map do |adviser|
           AlgoliaIndex::AdviserSerializer.new(adviser)
         end
@@ -38,14 +51,132 @@ RSpec.describe AlgoliaIndex::Firm do
 
       before do
         allow(AlgoliaIndex::AdviserSerializer).to receive(:new)
-          .and_return(*serialized)
+          .and_return(*serialized_advisers)
       end
 
       it 'updates all associated advisers in the index' do
         expect(indexed_advisers).to receive(:add_objects)
-          .with(serialized).exactly(:once)
-
+          .with(serialized_advisers).exactly(:once)
         instance.update
+      end
+
+      it 'does not update any offices in the index' do
+        expect(indexed_offices).not_to receive(:add_objects)
+        instance.update
+      end
+    end
+
+    context 'when the approved firm has offices but no advisers' do
+      let!(:firm) do
+        FactoryGirl.create(:firm_with_offices,
+                           :without_advisers,
+                           id: id)
+      end
+
+      let(:serialized_offices) do
+        firm.offices.geocoded.map do |office|
+          AlgoliaIndex::OfficeSerializer.new(office)
+        end
+      end
+
+      before do
+        allow(AlgoliaIndex::OfficeSerializer).to receive(:new)
+          .and_return(*serialized_offices)
+      end
+
+      it 'updates all associated offices in the index' do
+        expect(indexed_offices).to receive(:add_objects)
+          .with(serialized_offices).exactly(:once)
+        instance.update
+      end
+
+      it 'does not update any advisers in the index' do
+        expect(indexed_advisers).not_to receive(:add_objects)
+        instance.update
+      end
+    end
+
+    context 'when the approved firm has advisers and offices' do
+      let!(:firm) do
+        FactoryGirl.create(:firm_with_advisers_and_offices, id: id)
+      end
+
+      let(:serialized_advisers) do
+        firm.advisers.geocoded.map do |adviser|
+          AlgoliaIndex::AdviserSerializer.new(adviser)
+        end
+      end
+
+      let(:serialized_offices) do
+        firm.offices.geocoded.map do |office|
+          AlgoliaIndex::OfficeSerializer.new(office)
+        end
+      end
+
+      before do
+        allow(AlgoliaIndex::AdviserSerializer).to receive(:new)
+          .and_return(*serialized_advisers)
+        allow(AlgoliaIndex::OfficeSerializer).to receive(:new)
+          .and_return(*serialized_offices)
+      end
+
+      it 'updates all associated advisers in the index' do
+        expect(indexed_advisers).to receive(:add_objects)
+          .with(serialized_advisers).exactly(:once)
+        instance.update
+      end
+
+      it 'updates all associated offices in the index' do
+        expect(indexed_offices).to receive(:add_objects)
+          .with(serialized_offices).exactly(:once)
+        instance.update
+      end
+    end
+  end
+
+  describe '#update_advisers' do
+    context 'when the firm does not have any advisers' do
+      let!(:firm) { FactoryGirl.create(:firm_without_advisers, id: id) }
+
+      it 'does not update any advisers in the index' do
+        expect(indexed_advisers).not_to receive(:add_objects)
+        instance.update
+      end
+    end
+
+    context 'when the firm does have advisers' do
+      context 'when the firm has been approved' do
+        let!(:firm) do
+          FactoryGirl.create(:firm_with_advisers, id: id)
+        end
+
+        let(:serialized) do
+          firm.advisers.geocoded.map do |adviser|
+            AlgoliaIndex::AdviserSerializer.new(adviser)
+          end
+        end
+
+        before do
+          allow(AlgoliaIndex::AdviserSerializer).to receive(:new)
+            .and_return(*serialized)
+        end
+
+        it 'updates all associated advisers in the index' do
+          expect(indexed_advisers).to receive(:add_objects)
+            .with(serialized).exactly(:once)
+          instance.update_advisers
+        end
+      end
+
+      context 'when the firm has not been approved' do
+        let!(:firm) do
+          FactoryGirl.create(:firm_with_advisers, :not_approved, id: id)
+        end
+
+        it 'does not update any advisers in the index' do
+          expect(indexed_advisers).not_to receive(:add_objects)
+          instance.update_advisers
+        end
       end
     end
   end
@@ -54,7 +185,6 @@ RSpec.describe AlgoliaIndex::Firm do
     it 'doesn\'t delete anything', :aggregate_failures do
       expect(indexed_advisers).not_to receive(:delete_objects)
       expect(indexed_offices).not_to receive(:delete_objects)
-
       instance.destroy
     end
   end

--- a/spec/lib/algolia_index/models/firm_spec.rb
+++ b/spec/lib/algolia_index/models/firm_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AlgoliaIndex::Firm do
     context 'when the firm has not been approved' do
       let!(:firm) do
         FactoryGirl.create(:firm_with_advisers_and_offices,
-                           :not_approved, 
+                           :not_approved,
                            id: id)
       end
 

--- a/spec/lib/fca_api/connection_spec.rb
+++ b/spec/lib/fca_api/connection_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FcaApi::Connection do
   let(:mock_raw_connection) { double(Faraday) }
-  let(:domain) { 'http://test-domain/'}
+  let(:domain) { 'http://test-domain/' }
 
   before do
     stub_env('FCA_API_MAX_RETRIES', 2)
@@ -14,7 +14,7 @@ RSpec.describe FcaApi::Connection do
         headers: {
           'X-Auth-Email' => 'email@maps.org.uk',
           'X-Auth-Key' => 'xyz123abc'
-        },
+        }
       )
       .and_return(mock_raw_connection)
   end

--- a/spec/lib/fca_api/request_spec.rb
+++ b/spec/lib/fca_api/request_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe FcaApi::Request do
 
   let(:connection) { FcaApi::Connection.new(domain) }
   let(:domain) { 'http://fca.org.uk' }
-  let(:firm_id) { 100001 }
+  let(:firm_id) { 100_001 }
   let(:response) { instance_double(Faraday::Response) }
 
   before do
@@ -19,7 +19,7 @@ RSpec.describe FcaApi::Request do
   end
 
   describe '#get_firm' do
-    let(:response_message) { {"Message"=>"Ok. Firm Found"} }
+    let(:response_message) { { 'Message' => 'Ok. Firm Found' } }
     it 'returns a firm with the provided reference number' do
       expect(connection)
         .to receive(:get)

--- a/spec/lib/fca_api/response_spec.rb
+++ b/spec/lib/fca_api/response_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe FcaApi::Response do
   subject { described_class.new(response) }
-  
+
   let(:response) do
-    instance_double(Faraday::Response, body: {'Message' => response_message} )
+    instance_double(Faraday::Response, body: { 'Message' => response_message })
   end
 
   describe '#ok?' do
     context 'successful response' do
       let(:response_message) { 'Ok. Firm Found' }
- 
+
       it 'returns true' do
         expect(subject.ok?).to be_truthy
       end

--- a/spec/mailers/previews/new_firm_mailer_preview.rb
+++ b/spec/mailers/previews/new_firm_mailer_preview.rb
@@ -1,0 +1,6 @@
+class NewFirmMailerPreview < ActionMailer::Preview
+  def notify
+    firm = Struct.new(:registered_name, :id).new('Foo Bar ltd', '4321')
+    NewFirmMailer.notify(firm)
+  end
+end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe Firm do
 
   describe '#approve!' do
     context "when the firm hasn't been already approved" do
-      let(:firm) { FactoryGirl.create(:firm) }
+      let(:firm) { FactoryGirl.create(:firm, :not_approved) }
 
       it 'sets the approval timestamp to the current time' do
         travel_to(Time.zone.now) do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Firm do
+  include ActiveSupport::Testing::TimeHelpers
+
   subject(:firm) { build(:firm) }
 
   describe 'languages_used' do
@@ -558,6 +560,34 @@ RSpec.describe Firm do
       context 'when remote advice methods are not set' do
         before { firm.in_person_advice_methods = [] }
         it { is_expected.to be nil }
+      end
+    end
+  end
+
+  describe '#approve!' do
+    context "when the firm hasn't been already approved" do
+      let(:firm) { FactoryGirl.create(:firm) }
+
+      it 'sets the approval timestamp to the current time' do
+        travel_to(Time.zone.now) do
+          expect do
+            firm.approve!
+            firm.reload
+          end.to change { firm.approved_at }.from(nil).to(Time.zone.now)
+        end
+      end
+    end
+
+    context 'when the firm has been already approved' do
+      let(:firm) { FactoryGirl.create(:firm, approved_at: 1.hour.ago) }
+
+      it 'keeps the original approval timestamp value' do
+        travel_to(Time.zone.now) do
+          expect do
+            firm.approve!
+            firm.reload
+          end.not_to(change { firm.approved_at })
+        end
       end
     end
   end

--- a/spec/support/admin/firm_page.rb
+++ b/spec/support/admin/firm_page.rb
@@ -7,4 +7,6 @@ class Admin::FirmPage < SitePrism::Page
   element :move_advisers, '.t-move-advisers'
   element :sign_in_as_principal, '.t-sign-in-as-principal'
   element :new_adviser, '.t-new-adviser'
+  element :approved, 'p:contains("Approved:")'
+  element :approve_button, 'input[value="Approve Firm"]'
 end

--- a/spec/support/admin/firms_index_page.rb
+++ b/spec/support/admin/firms_index_page.rb
@@ -5,6 +5,7 @@ class Admin::FirmsIndexPage < SitePrism::Page
   class RowSection < SitePrism::Section
     element :fca_number_elem, '.t-fca-number'
     element :registered_name_elem, '.t-registered-name'
+    element :approved_elem, 'td:last-child'
 
     def fca_number
       fca_number_elem.text
@@ -12,6 +13,10 @@ class Admin::FirmsIndexPage < SitePrism::Page
 
     def registered_name
       registered_name_elem.text
+    end
+
+    def approved
+      approved_elem.text
     end
   end
 


### PR DESCRIPTION
[TP-10531](https://moneyadviceservice.tpondemand.com/entity/10531-rad-require-manual-admin-approval-before)

## What this PR does?

This PR:
- Notifies RAD admins by email when a new firm is registered through a new Principal signup.
- Requires the firms to be manually approved by RAD admins before they're pushed into the directory.
- Provides the RAD admin an interface to approve firms in the firm admin page.

## How do I review it?
Commit by commit helps to check the individual logic changes.

## Things to Highlight

- Once the migration runs in production, all the existent firms will be approved during the migration. So only the new firms added after this feature deploy will require a manual approval.
- Firms cannot be "unnaproved". Admins have tools to easily delete the firm though. 

## Implementation Highlights 

- Individual elements in Algolia Adviser Index contain a subset of firm information with info like `total_advisers` and `total_offices` in each adviser entry. This is why after each update on any office or adviser we need to regenerate all the firm advisers information in the index.

- We had to introduce a way to, once the admin approves a firm, trigger the push to Algolia of both advisers and offices of the firm, as they weren't in the directory while waiting for approval.  This has been done through the `AlgoliaIndex::Firm#update` method. While its previous logic for refreshing the advisers has been moved to a more explicit `AlgoliaIndex::Firm#update_advisers` 


### Email received by admins once a Principal Signs up and the firms gets associated to it
![Screenshot from 2019-06-04 09-42-12](https://user-images.githubusercontent.com/1227578/60179976-f0e8c580-9816-11e9-8952-a1eae8592997.png)


### Admin firms index interface displaying approval status
![Screenshot from 2019-06-11 16-02-13](https://user-images.githubusercontent.com/1227578/60179894-ad8e5700-9816-11e9-9924-45e6ab08d438.png)

### Firm admin page enabling the firm to be approved
![Screenshot from 2019-06-11 16-03-57](https://user-images.githubusercontent.com/1227578/60179907-be3ecd00-9816-11e9-9465-c7c7458b678a.png)


### Firm admin page after approving the firm displaying approval data.
![Screenshot from 2019-06-11 16-02-31](https://user-images.githubusercontent.com/1227578/60179896-b3843800-9816-11e9-87d6-8e3a508a4afd.png)
