### PR TITLE
10570 Fix broken snapshot advisers queries

### DIFF
--- a/app/models/snapshot/metrics_in_order.rb
+++ b/app/models/snapshot/metrics_in_order.rb
@@ -53,12 +53,6 @@ module Snapshot::MetricsInOrder
       advisers_with_qualification_in_long_term_care_planning
       advisers_with_qualification_in_tep
       advisers_with_qualification_in_fcii
-      advisers_part_of_personal_finance_society
-      advisers_part_of_institute_financial_planning
-      advisers_part_of_institute_financial_services
-      advisers_part_of_ci_bankers_scotland
-      advisers_part_of_ci_securities_and_investments
-      advisers_part_of_cfa_institute advisers_part_of_chartered_accountants
     ]
   end
 end

--- a/spec/models/snapshot_spec.rb
+++ b/spec/models/snapshot_spec.rb
@@ -666,12 +666,6 @@ RSpec.describe Snapshot do
                                                advisers_with_qualification_in_long_term_care_planning
                                                advisers_with_qualification_in_tep
                                                advisers_with_qualification_in_fcii
-                                               advisers_part_of_personal_finance_society
-                                               advisers_part_of_institute_financial_planning
-                                               advisers_part_of_institute_financial_services
-                                               advisers_part_of_ci_bankers_scotland
-                                               advisers_part_of_ci_securities_and_investments
-                                               advisers_part_of_cfa_institute advisers_part_of_chartered_accountants
                                              ])
     end
   end


### PR DESCRIPTION
[TP 10570](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=bug/10570)

Remove broken queries from full list of queries to be run since they are no longer required.