### PR TITLE
[DEV APPROVED] - Add geolocation data where missing on Office records

### DIFF
--- a/db/migrate/20190717132525_add_missing_geolocation_to_offices.rb
+++ b/db/migrate/20190717132525_add_missing_geolocation_to_offices.rb
@@ -1,0 +1,11 @@
+class AddMissingGeolocationToOffices < ActiveRecord::Migration
+  def up
+    Office
+      .where(id: [302, 854, 1279, 1302, 2461, 2607, 2635])
+      .each(&:save_with_geocoding)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190606111937) do
+ActiveRecord::Schema.define(version: 20190717132525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/10548-rad-firm-office-not-showing-up)

Seven office records are missing geolocation data. It's unclear why this
is, however all of them appear to have been added to the database at the
same time - Mon 12th Oct 2015.

Call the geocode method on each record and persist the changes.

This should address the linked bug, as the absence of geolocation info will prevent an office from being indexed.