### PR TITLE
[DEV APPROVED] Modify dashes in Qualification names

### DIFF
--- a/db/migrate/20190730141112_modify_hyphens_on_qualifications.rb
+++ b/db/migrate/20190730141112_modify_hyphens_on_qualifications.rb
@@ -1,0 +1,25 @@
+class ModifyHyphensOnQualifications < ActiveRecord::Migration
+  def up
+    # The point of this migration may be unclear depending on how your text
+    # editor displays hyphens and dashes. The first array is a list of existing
+    # qualification names. They contain short dashes. The second array below
+    # contains longer hyphens instead.
+    current = [
+      'Chartered Financial Planner - accredited by the Chartered Insurance Institute / Personal Finance Society',
+      'Certified Financial Planner - accredited by the Chartered Institute of Securities and Investments',
+      'Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent'
+    ]
+
+    [
+      'Chartered Financial Planner – accredited by the Chartered Insurance Institute / Personal Finance Society',
+      'Certified Financial Planner – accredited by the Chartered Institute of Securities and Investments',
+      'Pension transfer qualifications – holder of G60, AF3, AwPETR®, or equivalent'
+    ].each_with_index do |name, index|
+      Qualification.find_by(name: current[index]).update(name: name)
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190717132525) do
+ActiveRecord::Schema.define(version: 20190730141112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/10558-rad-different-hyphen-types-on-edit)

There's a small inconsistency in the use of hyphens and dashes in the
names of Qualifications. Update the three that are using shorter dashes
with longer hyphens.