### PR TITLE
[DEV APPROVED] TP 10645 / Refactor hardcoded email address

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :admin_email_address
 
   def after_sign_in_path_for(user)
     stored_location_for(user) || self_service_root_path
@@ -15,5 +16,9 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update) do |u|
       u.permit(:email, :password, :password_confirmation, :current_password)
     end
+  end
+
+  def admin_email_address
+    @admin_email_address = ActionMailer::Base.default[:from]
   end
 end

--- a/app/mailers/admin_contact.rb
+++ b/app/mailers/admin_contact.rb
@@ -1,9 +1,4 @@
 class AdminContact < ActionMailer::Base
-  default(
-    from: 'RADenquiries@moneyadviceservice.org.uk',
-    to: 'RADenquiries@moneyadviceservice.org.uk'
-  )
-
   def contact(email, message)
     @email = email
     @message = message

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
   layout 'mailer'
 end

--- a/app/mailers/failed_registration_mailer.rb
+++ b/app/mailers/failed_registration_mailer.rb
@@ -1,6 +1,4 @@
 class FailedRegistrationMailer < ActionMailer::Base
-  default from: 'RADenquiries@moneyadviceservice.org.uk'
-
   def notify(email)
     mail(
       to: email,

--- a/app/mailers/fca_import_mailer.rb
+++ b/app/mailers/fca_import_mailer.rb
@@ -1,5 +1,4 @@
 class FcaImportMailer < ApplicationMailer
-  default from: 'RADenquiries@moneyadviceservice.org.uk'
   helper_method :protect_against_forgery?
 
   def notify(users, text)

--- a/app/mailers/identification.rb
+++ b/app/mailers/identification.rb
@@ -1,6 +1,4 @@
 class Identification < ActionMailer::Base
-  default from: 'RADenquiries@moneyadviceservice.org.uk'
-
   def contact(principal)
     @principal = principal
 

--- a/app/mailers/new_firm_mailer.rb
+++ b/app/mailers/new_firm_mailer.rb
@@ -1,9 +1,4 @@
 class NewFirmMailer < ActionMailer::Base
-  default(
-    from: 'RADenquiries@moneyadviceservice.org.uk',
-    to: 'RADenquiries@moneyadviceservice.org.uk'
-  )
-
   def notify(firm)
     @firm = firm
     mail(to: FCA::Config.email_recipients,

--- a/app/views/admin/advisers/_form.html.erb
+++ b/app/views/admin/advisers/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= f.label :postcode %>
   <% if @adviser.errors.include?(:address) %>
-    <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation') %></p>
+    <p class="bg-danger"><%= t('adviser.geocoding.failure_explanation', email: @admin_email_address) %></p>
   <% end %>
   <%= f.text_field(:postcode, class: 'form-control t-postcode') %>
 </div>

--- a/app/views/failed_registration_mailer/notify.html.erb
+++ b/app/views/failed_registration_mailer/notify.html.erb
@@ -1,4 +1,4 @@
 <h1>Retirement Adviser Directory Registration</h1>
 <div>
-  We haven't been able to verify your Firm Reference Number against the FCA register. Please contact us at radenquiries@moneyadviceservice.org.uk and we will help you with your registration.
+  We haven't been able to verify your Firm Reference Number against the FCA register. Please contact us at <%= @admin_email_address %> and we will help you with your registration.
 </div>

--- a/app/views/principals/show.html.erb
+++ b/app/views/principals/show.html.erb
@@ -1,5 +1,5 @@
 <section class="l-notice">
   <%= heading_tag(t('success.heading'), level: 1, class: '') %>
   <p><%= t('success.message') %></p>
-  <p><%= t('success.contact_us') %> <%= mail_to t('email_address'), t('email_address') %></p>
+  <p><%= t('success.contact_us') %> <%= mail_to @admin_email_address, @admin_email_address %></p>
 </section>

--- a/app/views/self_service/advisers/_form.html.erb
+++ b/app/views/self_service/advisers/_form.html.erb
@@ -36,7 +36,7 @@
       <%= f.errors_for :geocoding %>
 
       <% if f.object.errors.include?(:geocoding) %>
-        <p><%= t('adviser.geocoding.failure_explanation') %></p>
+        <p><%= t('adviser.geocoding.failure_explanation', email: @admin_email_address) %></p>
       <% end %>
 
       <%= f.form_row :postcode, html_options: { classes: 'form-row--collapsed-margin-bottom' } do %>

--- a/app/views/self_service/offices/_form.html.erb
+++ b/app/views/self_service/offices/_form.html.erb
@@ -10,7 +10,7 @@
     <%= f.errors_for :geocoding %>
 
     <% if f.object.errors.include?(:geocoding) %>
-      <p><%= t('office.geocoding.failure_explanation') %></p>
+      <p><%= t('office.geocoding.failure_explanation', email: @admin_email_address) %></p>
     <% end %>
 
     <%= f.form_row :address_line_one do %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="l-footer">
   <div class="l-constrained">
     <div class="l-footer__inner">
-      <p class="l-footer__text"><%= t('footer.text') %> <%= mail_to t('email_address'), t('email_address') %></p>
+      <p class="l-footer__text"><%= t('footer.text') %> <%= mail_to @admin_email_address, @admin_email_address %></p>
     </div>
   </div>
 </footer>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,10 @@ module Rad
     config.autoload_paths << Rails.root.join('lib')
     config.active_record.raise_in_transactional_callbacks = true
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-
+    config.action_mailer.default_options = {
+      from: 'RADenquiries@moneyadviceservice.org.uk',
+      to: 'RADenquiries@moneyadviceservice.org.uk'
+    }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,6 @@ en:
   authentication_sign_up: Register
   authentication_sign_out: Sign out
   required: "* indicates required fields"
-  email_address: "RADenquiries@moneyadviceservice.org.uk"
   confirmation_statement: By registering your firm's details with the Money Advice Service, you are confirming that these details and any responses you give to our registration questions are true and accurate.
 
   footer:
@@ -193,12 +192,12 @@ en:
     reference_number_unmatched: could not be matched with an existing adviser reference
     geocoding:
       failure_message: could not be found by the mapping service.
-      failure_explanation: We could not find the coordinates of the adviser's postcode to plot it on the map in the directory. Please check and try again. If the postcode is correct and still cannot be found please contact RADenquiries@moneyadviceservice.org.uk for assistance.
+      failure_explanation: We could not find the coordinates of the adviser's postcode to plot it on the map in the directory. Please check and try again. If the postcode is correct and still cannot be found please contact %{email} for assistance.
 
   office:
     geocoding:
       failure_message: could not be found by the mapping service.
-      failure_explanation: We could not find the coordinates of your office address to plot it on the map in the directory. Please check and try again. If the details are correct and still cannot be found please contact RADenquiries@moneyadviceservice.org.uk for assistance.
+      failure_explanation: We could not find the coordinates of your office address to plot it on the map in the directory. Please check and try again. If the details are correct and still cannot be found please contact %{email} for assistance.
     telephone_number:
       invalid_format: must be a valid UK phone number (including the area code) or mobile number
 

--- a/spec/mailers/identification_spec.rb
+++ b/spec/mailers/identification_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Identification, '#contact' do
   end
 
   it 'has a from address' do
-    expect(subject.from).to be_present
+    expect(subject.from.first).to eq('RADenquiries@moneyadviceservice.org.uk')
   end
 
   it 'addressed to the principal' do


### PR DESCRIPTION
[TP 10645](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10645/silent)

### Requirement
The set up and administration of Firms, Advisers and Officers on RAD includes sending automated emails to the business stakeholder. The email address, RADenquiries@moneyadviceservice.org.uk, is hard coded in many different places. The requirement is to store it in one place to improve the maintainability of this application.

### Technical
Use the rails provided ActionMailer::Default settings.