### PR TITLE
[DEV APPROVED] - 10678 Incorrect website address being displayed

### DIFF
--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -20,7 +20,7 @@
       <strong>Registered Name:</strong> <%= @firm.registered_name %>
     </p>
     <p>
-      <strong>Website Address:</strong> <%= link_to @firm.website_address %>
+      <strong>Website Address:</strong> <%= link_to @firm.website_address if @firm.website_address %>
     </p>
     <p>
       <strong>Added:</strong> <%= @firm.created_at.to_s(:long) %>


### PR DESCRIPTION
[TP 10678](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=bug/10678/silent)

BACKGROUND
The website for principals who have not added any firms or offices is incorrect. Currently a url path which includes the firm's id is being displayed.
 ![Screenshot 2019-08-21 at 17 57 38](https://user-images.githubusercontent.com/3481059/63452121-6f3f9d80-c43d-11e9-84fe-cef2660144be.png)
REQUIREMENT
If no firm has been entered or a firm has been entered without a website, nothing should be displayed in the website field.
![Screenshot 2019-08-21 at 17 59 08](https://user-images.githubusercontent.com/3481059/63452108-69e25300-c43d-11e9-8ada-c5e46a08ba7c.png)

