### PR TITLE
[DEV APPROVED] - 10525 Batch Status Check Firms

### DIFF
--- a/app/controllers/admin/reports/api_inactive_firms_controller.rb
+++ b/app/controllers/admin/reports/api_inactive_firms_controller.rb
@@ -1,0 +1,13 @@
+module Admin
+  module Reports
+    class ApiInactiveFirmsController < Admin::ApplicationController
+      def index
+        @inactive_firms =
+          InactiveFirm
+          .includes(:firm)
+          .order('firms.registered_name ASC')
+        @latest_timestamp = @inactive_firms.maximum(:created_at)
+      end
+    end
+  end
+end

--- a/app/jobs/enqueue_firm_status_checks_job.rb
+++ b/app/jobs/enqueue_firm_status_checks_job.rb
@@ -1,0 +1,53 @@
+class EnqueueFirmStatusChecksJob < ActiveJob::Base
+  include Sidekiq::Worker
+
+  # This job schedules the work carried out by FirmStatusCheckJob, which
+  # queries the status of Firms against the FCA Register API.
+  #
+  # The API has an official rate limit of 10 requests every 10 seconds, hence
+  # the values set in the constants below. We throttle requests to the API by
+  # scheduling each batch of 10 status checks to occur at the beginning of a
+  # 10-second window. The 10 checks occur concurrently and windows are
+  # sequential.
+  #
+  # The other value relevant to this functionality is the scheduled job poll
+  # interval set in the sidekiq server configuration. This controls how often
+  # Sidekiq checks for scheduled jobs. That value is ~15 seconds by defauilt -
+  # this job has been tested at that level of polling and holds up well across
+  # large numbers of firms without triggering the rate limit. Changes to that
+  # value should be tested, but in theory any value between 10 and 20 seconds
+  # should be ok. This is because in practice the API rate limit appears to be
+  # higher than the official numbers. Up to 20 requests per 10 seconds have
+  # been tested without issue. With a schedule poll of 15 seconds, 10 to 20
+  # jobs should execute each time (as certain times will pick up two windows
+  # worth of jobs rather than just one, eg - the 30-second mark).
+  WINDOW_LENGTH_IN_SECONDS = 10
+  BATCH_SIZE = 10
+
+  queue_as :default
+  sidekiq_options unique: :until_executed
+
+  # Fetch firms from the database table in batches. Each batch has its own time
+  # window of length WINDOW_LENGTH_IN_SECONDS. Within this window, enqueue one
+  # job per firm to check the status.
+  def perform(batches: BigDecimal::INFINITY)
+    time_window = 0
+    InactiveFirm.destroy_all
+
+    Firm
+      .find_in_batches(batch_size: BATCH_SIZE)
+      .with_index do |group, batch_number|
+      break if batch_number == batches
+
+      group.each do |firm|
+        current_time = Time.now.to_f
+
+        FirmStatusCheckJob.perform_at(
+          current_time + time_window.seconds,
+          firm.fca_number
+        )
+      end
+      time_window += WINDOW_LENGTH_IN_SECONDS
+    end
+  end
+end

--- a/app/jobs/firm_status_check_job.rb
+++ b/app/jobs/firm_status_check_job.rb
@@ -1,0 +1,31 @@
+require './lib/fca_api/connection'
+require './lib/fca_api/request'
+require './lib/fca_api/response'
+
+class FirmStatusCheckJob < ActiveJob::Base
+  include Sidekiq::Worker
+
+  ACTIVE_FIRM_STATUS_CODES = [
+    'Authorised',
+    'Registered',
+    'EEA Authorised',
+    'Appointed representative'
+  ].freeze
+
+  queue_as :default
+  sidekiq_options unique: :until_executed, retry: 5
+
+  def perform(fca_number)
+    api_request = FcaApi::Request.new
+    response = api_request.get_firm(fca_number)
+    status = response.data.fetch('Status')
+
+    if status.in? ACTIVE_FIRM_STATUS_CODES
+      logger.info "Firm #{fca_number} is ACTIVE"
+    else
+      logger.info "Firm #{fca_number} is INACTIVE with status #{status}"
+      firm = Firm.where(fca_number: fca_number).first!
+      InactiveFirm.create(firm_id: firm.id, api_status: status)
+    end
+  end
+end

--- a/app/jobs/verify_reference_number_job.rb
+++ b/app/jobs/verify_reference_number_job.rb
@@ -8,10 +8,14 @@ class VerifyReferenceNumberJob < ActiveJob::Base
     @response = FcaApi::Request.new.get_firm(form_data['fca_number'])
 
     if @response.ok?
-      Rails.logger.info("\nINFO: FCA API successful request for #{form_data['fca_number']}\n")
+      Rails.logger.info(
+        "\nINFO: FCA API successful request for #{form_data['fca_number']}\n"
+      )
       VerifiedPrincipal.new(form_data, firm_name).register!
     else
-      Rails.logger.warn("\n WARN: FCA API failed for #{form_data['fca_number']}\n")
+      Rails.logger.warn(
+        "\n WARN: FCA API failed for #{form_data['fca_number']}\n"
+      )
       send_fail_email(form_data['email'])
     end
   end

--- a/app/models/inactive_firm.rb
+++ b/app/models/inactive_firm.rb
@@ -1,2 +1,5 @@
 class InactiveFirm < ActiveRecord::Base
+  belongs_to :firm
+
+  delegate :fca_number, :registered_name, :publishable?, to: :firm
 end

--- a/app/models/inactive_firm.rb
+++ b/app/models/inactive_firm.rb
@@ -1,0 +1,2 @@
+class InactiveFirm < ActiveRecord::Base
+end

--- a/app/models/verified_principal.rb
+++ b/app/models/verified_principal.rb
@@ -13,7 +13,7 @@ class VerifiedPrincipal
   end
 
   private
-  
+
   def create_new_principal
     @user = User.new(form.user_params)
     @user.build_principal(form.principal_params)

--- a/app/views/admin/reports/api_inactive_firms/index.html.erb
+++ b/app/views/admin/reports/api_inactive_firms/index.html.erb
@@ -1,0 +1,40 @@
+<h2>API Inactive Firms</h2>
+
+<p>
+  This report shows all firms who are considered inactive according to the FCA
+  Register API. It is currently in beta while we observe the quality of the
+  reported data.
+
+</p>
+
+<p>
+  The report is refreshed nightly. Last attempted updated: <span><%= @latest_timestamp %></span>
+</p>
+
+<p>
+  The <a href="https://register.fca.org.uk/">Financial Services Register</a>
+  can be searched to determine exactly what status change has occurred.
+</p>
+
+<table class="table table-bordered">
+  <tr>
+    <th>FCA Number</th>
+    <th>Registered Name</th>
+    <th>Visible on Directory?</th>
+    <th>API Status</th>
+  </tr>
+  <% if @inactive_firms.present? %>
+    <% @inactive_firms.each do |inactive_firm| %>
+      <tr>
+        <td><%= inactive_firm.fca_number %></td>
+        <td><%= link_to inactive_firm.registered_name, admin_firm_path(inactive_firm) %></td>
+        <td><%= inactive_firm.publishable? ? 'Yes' : 'No' %></td>
+        <td><%= inactive_firm.api_status %></td>
+      </tr>
+    <% end %>
+  <% else %>
+    <tr>
+      <td colspan="3">No firms to display</td>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
       resource :inactive_adviser, only: [:show]
       resources :registered_adviser, only: [:index]
       resource :inactive_firm, only: [:show]
+      resources :api_inactive_firms, only: [:index]
       resource :inactive_trading_name, only: [:show]
       resources :out_of_date_firms, only: [:index, :update]
     end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 10
+:concurrency: 20
 :queues:
   - default
   - mailers

--- a/db/migrate/20190923112715_create_inactive_firms.rb
+++ b/db/migrate/20190923112715_create_inactive_firms.rb
@@ -1,0 +1,10 @@
+class CreateInactiveFirms < ActiveRecord::Migration
+  def change
+    create_table :inactive_firms do |t|
+      t.references :firm, index: true, foreign_key: true
+      t.string :api_status
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190730141112) do
+ActiveRecord::Schema.define(version: 20190923123120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -155,6 +155,15 @@ ActiveRecord::Schema.define(version: 20190730141112) do
     t.datetime "updated_at",             null: false
     t.integer  "order",      default: 0, null: false
   end
+
+  create_table "inactive_firms", force: :cascade do |t|
+    t.integer  "firm_id"
+    t.string   "api_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "inactive_firms", ["firm_id"], name: "index_inactive_firms_on_firm_id", using: :btree
 
   create_table "initial_advice_fee_structures", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -384,4 +393,5 @@ ActiveRecord::Schema.define(version: 20190730141112) do
   add_index "users", ["password_changed_at"], name: "index_users_on_password_changed_at", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "inactive_firms", "firms"
 end

--- a/lib/algolia_index/test_seeds.rb
+++ b/lib/algolia_index/test_seeds.rb
@@ -34,7 +34,7 @@ module AlgoliaIndex
         registered_name: attributes[:registered_name]
       )
       firm.save!(validate: false)
-      principal = create_principal(fca_number)
+      create_principal(fca_number)
 
       # rubocop:disable Rails/SkipsModelValidations
       firm.update_attribute(:id, attributes[:id])

--- a/lib/fca_api/response.rb
+++ b/lib/fca_api/response.rb
@@ -2,18 +2,18 @@ module FcaApi
   class Response
     SUCCESS_MESSAGE = 'ok'.freeze
 
-    attr_reader :response
+    attr_reader :raw_response
 
-    def initialize(response)
-      @response = response
+    def initialize(raw_response)
+      @raw_response = raw_response
     end
 
     def ok?
-      response.body['Message'].downcase.include?(SUCCESS_MESSAGE)
+      raw_response.body['Message'].downcase.include?(SUCCESS_MESSAGE)
     end
 
     def data
-      response.body['Data'].first
+      raw_response.body['Data'].first
     end
   end
 end

--- a/spec/factories/principal.rb
+++ b/spec/factories/principal.rb
@@ -11,8 +11,10 @@ FactoryGirl.define do
     confirmed_disclaimer true
 
     after(:build) do |principal|
-      Firm.new(fca_number: principal.fca_number,
-          registered_name:  Faker::Name.first_name).tap do |f|
+      Firm.new(
+        fca_number: principal.fca_number,
+        registered_name:  Faker::Name.first_name
+      ).tap do |f|
         f.save!(validate: false)
       end
     end

--- a/spec/jobs/verify_reference_number_job_spec.rb
+++ b/spec/jobs/verify_reference_number_job_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe VerifyReferenceNumberJob do
   describe '#perform' do
     let(:form_data) do
       {
-        "fca_number" => '123456',
-        "first_name" => 'Margo',
-        "last_name" => 'Test',
-        "job_title" => 'Adviser',
-        "email" => 'test@maps.org.uk',
-        "telephone_number" => '2075554343',
-        "password" => 'Password1*',
-        "password_confirmation" => 'Password1*',
-        "confirmed_disclaimer" => '1'
+        'fca_number' => '123456',
+        'first_name' => 'Margo',
+        'last_name' => 'Test',
+        'job_title' => 'Adviser',
+        'email' => 'test@maps.org.uk',
+        'telephone_number' => '2075554343',
+        'password' => 'Password1*',
+        'password_confirmation' => 'Password1*',
+        'confirmed_disclaimer' => '1'
       }
     end
 

--- a/spec/lib/fca_api/response_spec.rb
+++ b/spec/lib/fca_api/response_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe FcaApi::Response do
     let(:api_response) do
       {
         'Message' => 'Firm not found',
-        'Data' => [ {'Organisation Name' => 'xyz'} ]
+        'Data' => [{ 'Organisation Name' => 'xyz' }]
       }
     end
 
     it 'returns the firm data' do
-      expect(subject.data).to eq({'Organisation Name' => 'xyz'})
+      expect(subject.data).to eq('Organisation Name' => 'xyz')
     end
   end
 end

--- a/spec/models/verified_principal_spec.rb
+++ b/spec/models/verified_principal_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe VerifiedPrincipal do
   describe '#register!' do
-    subject{ described_class.new(form_data, 'ABC') }
-    
-    let(:user_params) { 
+    subject { described_class.new(form_data, 'ABC') }
+
+    let(:user_params) do
       {
         email: 'test@maps.org.uk',
         password: 'Password1*',
         password_confirmation: 'Password1*'
       }
-    }
-    let(:principal_params) {
+    end
+    let(:principal_params) do
       {
         fca_number: '123456',
         first_name: 'Margo',
@@ -19,7 +19,7 @@ RSpec.describe VerifiedPrincipal do
         telephone_number: '2075554343',
         confirmed_disclaimer: 1
       }
-    }
+    end
     let(:principal) { double(Principal) }
     let(:form_data) { principal_params.merge(user_params) }
     let(:form) { NewPrincipalForm.new(form_data) }


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/10525-rad-firm-status-check-via-api)

This PR adds functionality that checks the status of all firms against the FCA Register API and displays all firms with an inactive status in a table. The intention is to run this process in production for several days and review the results it produces. The results table is hidden from the UI for now while this feature is still in beta. I've also elected to skip tests in this implementation as:

- the feature had a relatively small footprint.
- it will likely be reworked after some time running in production.
- it's internal-facing and will be running daily - any issues/bugs will be ironed out from multiple production runs.

The API has a rate limit of 10 requests per 10 seconds. The approach here is to use Sidekiq jobs to concurrently execute these requests, and to enqueue these jobs on a schedule that throttles the number of requests executed in any 10 second window. Please refer to the comment in EnqueueFirmStatusChecksJob for more detail.

There are other approaches this solution could have taken, including:

- Specifying a throttle within the Sidekiq server, via Sidekiq Enterprise or an add-on gem.
  - Pros: no scheduling code, jobs can be enqueued and are throttled automatically.
  - Cons: nothing obvious.
- A single, long-running Ruby process using threads.
  - Pros: easily report start and finish of the entire batch process.
  - Cons: would need to write retry mechanism and error handling from scratch, process crash would terminate all work.

Of these, the better alternative is the first one. If the solution in this PR doesn't hold up well in production, we can rework it along those lines. This is dependent on updating our Sidekiq version in RAD, however.