### PR TITLE
Change Jenkins test suite invocation

### DIFF
--- a/jenkins/test
+++ b/jenkins/test
@@ -39,7 +39,8 @@ run bundle update brakeman --quiet
 run bundle exec bowndler install --allow-root
 run mv config/cloud_storage{.example,}.yml
 run bundle exec rake db:drop db:setup
-run bundle exec rspec
+run bundle exec rspec spec/features
+run bundle exec rspec --exclude-pattern='spec/features/**/**'
 run bundle exec ./node_modules/.bin/karma start spec/javascripts/karma.conf.js --single-run
 run bundle exec rubocop -DS
 info bundle exec brakeman -q --no-pager --ensure-latest


### PR DESCRIPTION
Update the Jenkins test script so that we run feature specs separately
from unit tests.

Why?

The RAD test suite currently experiences intermittent failures.

Some of these errors appear to be due to some leaking state from the
feature specs, causing intermittent errors when the test suite is run as
a whole. The errors relate to some kind of database transaction issue,
seemingly originating from the FCA file import code.

Until we isolate the source of this, do two distinct runs to address
some of the intermittent failures and get us closer to a green build.