### PR TITLE
Remove poltergeist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,6 @@ group :test do
   gem 'danger-rubocop', require: false
   gem 'database_cleaner'
   gem 'launchy'
-  gem 'poltergeist'
   gem 'rspec-collection_matchers'
   gem 'rspec-sidekiq'
   gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cliver (0.3.2)
     coderay (1.1.2)
     colored2 (3.1.2)
     concurrent-ruby (1.1.5)
@@ -285,10 +284,6 @@ GEM
     parser (2.5.3.0)
       ast (~> 2.4.0)
     pg (0.20.0)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     polyamorous (1.3.3)
       activerecord (>= 3.0)
     powerpack (0.1.2)
@@ -509,7 +504,6 @@ DEPENDENCIES
   mailjet
   oga
   pg (~> 0.20.0)
-  poltergeist
   pry-byebug
   pry-rails
   rails (= 4.2.11.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require_relative '../config/environment'
 
 require 'rspec/rails'
 require 'factory_bot_rails'
-require 'capybara/poltergeist'
 require 'sidekiq/testing'
 
 Dir[File.join(File.dirname(__FILE__), 'support', '**', '*_section.rb')].each { |f| require f }
@@ -14,7 +13,6 @@ require File.join(File.dirname(__FILE__), 'support/fca_test_helpers.rb')
 
 Faker::Config.locale = 'en-GB'
 
-Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 5
 
 TestAfterCommit.enabled = true


### PR DESCRIPTION
We don't use it in our feature specs at all. Remove it completely - when
we have a need for JS-enabled tests, we can set up and use a modern
alternative (eg - headless Chrome).