### PR TITLE
Temporarily patch FCA import data

### DIFF
--- a/lib/fca/repairs.yml
+++ b/lib/fca/repairs.yml
@@ -5,6 +5,3 @@ repairs:
   -
     line: 'KCS01025|Mr "Konstantinos ""Constantine""" Sarafopoulos|||3|SARAFOPOULOSKONSTANTINOSCONSTANTINE|20160305|'
     replacement: 'KCS01025|Mr Konstantinos "Constantine" Sarafopoulos|||3|SARAFOPOULOSKONSTANTINOSCONSTANTINE|20160305|'
-  -
-    line: '847616|,,BROKER INS " LTD|8|5||||||||||||||||EEA Authorised|20190903||BROKERINSLTD|20190903|||||'
-    replacement: '847616|,,BROKER INS LTD|8|5||||||||||||||||EEA Authorised|20190903||BROKERINSLTD|20190903|||||'

--- a/lib/fca/row.rb
+++ b/lib/fca/row.rb
@@ -69,7 +69,21 @@ module FCA
     end
 
     def repair
+      # TODO: this is obviously terrible and needs replacing. This is a
+      # temporary fix for the firms master list entry with ID 847616. It
+      # contains an unterminated quote which breaks the Postgres import.
+      #
+      # The FCA take a very long time to correct the source data. We need to
+      # either change how Postgres handles unterminated quotes when writing to
+      # a table or overhaul the repair functionality. Currently line repairs
+      # are invalidated with every new set of import files because a timestamp
+      # on each line changes every week.
+      if line.include?(%(BROKER INS " LTD))
+        line.gsub!(%r(BROKER INS " LTD), '')
+      end
+
       match = repairs.find { |pair| pair['line'] == line }
+
       if match.nil?
         logger.warn(name) { "Possibly malformed row detected: #{line}" } if line.include? '""'
         line


### PR DESCRIPTION
The line repair functionality isn't adequate for long term fixes of bad
data. Add this temporary fix until we have time to either change how
Postgres handles unterminated quotes or change how the repair
functionality works.

See code comment for more detail.