### PR TITLE
Make inactive firms dependent destroy

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -34,6 +34,7 @@ class Firm < ApplicationRecord
   belongs_to :principal, primary_key: :fca_number, foreign_key: :fca_number
   belongs_to :parent, class_name: 'Firm'
 
+  has_one :inactive_firm, dependent: :destroy
   has_many :advisers, dependent: :destroy
   has_many :offices, -> { order created_at: :asc }, dependent: :destroy
   has_many :subsidiaries, class_name: 'Firm',
@@ -108,8 +109,7 @@ class Firm < ApplicationRecord
     errors.add(:advice_types, :invalid) unless advice_types.values.any?
   end
 
-  validates :investment_sizes,
-            length: { minimum: 1 }
+  validates :investment_sizes, length: { minimum: 1 }
 
   after_commit :notify_indexer
 


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/10938-deleting-principal-broken)

When a firm gets destroyed, make sure its inactive firm record gets
destroyed too.

This fixes an issue where a foreign key error gets triggered when
attempting to destroy a firm that has a corresponding record in the
inactive_firms table.