### PR TITLE
Update methods used to invoke firm status checks

### DIFF
--- a/app/jobs/enqueue_firm_status_checks_job.rb
+++ b/app/jobs/enqueue_firm_status_checks_job.rb
@@ -40,10 +40,9 @@ class EnqueueFirmStatusChecksJob < ApplicationJob
       group.each do |firm|
         current_time = Time.now.to_f
 
-        FirmStatusCheckJob.perform_at(
-          current_time + time_window.seconds,
-          firm.fca_number
-        )
+        FirmStatusCheckJob
+          .set(wait_until: current_time + time_window.seconds)
+          .perform_later(firm.fca_number)
       end
       time_window += WINDOW_LENGTH_IN_SECONDS
     end


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/10941-fix-nightly-status-check-job)

These were missed in the recent round of changes introduced by the
upgrade to Sidekiq 6. Because we don't include Sidekiq::Worker in our
jobs anymore, we have to use the ActiveJob API.