### PR TITLE
[DEV APPROVED] - Fix Geocoder redis connection

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -2,5 +2,5 @@ Geocoder.configure(
   lookup: :google,
   use_https: Rails.env.production?,
   api_key: ENV['GOOGLE_GEOCODER_API_KEY'],
-  cache: Rails.env.production? ? Redis.new(url: ENV['REDISTOGO_URL']) : nil
+  cache: Rails.env.production? ? Redis.new(url: ENV['REDISCLOUD_URL']) : nil
 )


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/11001-rad-add-adviser-and-addedit-office)

This is breaking in production currently. It's configured to connect to
a Redis To Go instance for its production cache. We've replaced that
Redis instance with one from RedisCloud.

Update the ENV var to a generic descriptor of the correct URL.