### PR TITLE
Remove useless logging line from FCA import code

### DIFF
--- a/lib/fca/row.rb
+++ b/lib/fca/row.rb
@@ -85,7 +85,6 @@ module FCA
       match = repairs.find { |pair| pair['line'] == line }
 
       if match.nil?
-        logger.warn(name) { "Possibly malformed row detected: #{line}" } if line.include? '""'
         line
       else
         match['replacement']


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/11007-fix-broken-fca-file-import)

This code hasn't been triggered in a while because this specific case
hasn't occurred recently in the data:

- No match on the repairs list.
- The line nonetheless includes superfluous inverted commas.

The line is useless, not least because there's no logger instance
instantiated anywhere in the class.