### PR TITLE
#11030 - Add "years" value to dates in admin

### DIFF
--- a/app/views/admin/advisers/index.html.erb
+++ b/app/views/admin/advisers/index.html.erb
@@ -78,7 +78,7 @@
                                     class: 't-firm-registered-name' %></td>
                 <% end %>
                 <td class="t-postcode"><%= adviser.postcode %></td>
-                <td><%= adviser.created_at.to_s(:short) %></td>
+                <td><%= adviser.created_at.strftime("%d %b %Y") %></td>
               </tr>
           <% end %>
       <% else %>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -93,8 +93,8 @@
               <% end %>
             </td>
             <td><%= link_to(firm.advisers.count, admin_firm_advisers_path(firm)) %></td>
-            <td><%= firm.created_at.to_s(:short) %></td>
-            <td><%= firm.approved_at&.to_s(:short) || 'Not approved' %></td>
+            <td><%= firm.created_at.strftime("%d %b %Y") %></td>
+            <td><%= firm.approved_at&.strftime("%d %b %Y") || 'Not approved' %></td>
           </tr>
         <% end %>
       <% else %>

--- a/app/views/admin/firms/show.html.erb
+++ b/app/views/admin/firms/show.html.erb
@@ -71,7 +71,7 @@
 
   <ul>
     <% @firm.advisers.each do |adviser| %>
-      <li class='t-adviser'><%= link_to adviser.name, admin_adviser_path(adviser) %>, added <%= adviser.created_at.to_s(:short) %></li>
+      <li class='t-adviser'><%= link_to adviser.name, admin_adviser_path(adviser) %>, added <%= adviser.created_at.strftime("%d %b %Y") %></li>
     <% end %>
   </ul>
 

--- a/app/views/admin/principals/index.html.erb
+++ b/app/views/admin/principals/index.html.erb
@@ -48,7 +48,7 @@
             <td><%= link_to principal.firm.registered_name, admin_firm_path(principal.firm) %></td>
             <td><%= principal.fca_number %></td>
             <td><%= link_to "#{principal.first_name} #{principal.last_name}", admin_principal_path(principal) %></td>
-            <td><%= principal.created_at.to_s(:short) %></td>
+            <td><%= principal.created_at.strftime("%d %b %Y") %></td>
           </tr>
         <% end %>
       <% else %>

--- a/spec/features/admin/firm_approval_spec.rb
+++ b/spec/features/admin/firm_approval_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'Approving firms on the admin interface', :inline_job_queue do
     firm_info = index_page.firms.select do |firm|
                   firm.fca_number.to_s == approved_firm.fca_number.to_s
                 end.first
-    expect(firm_info.approved).to eq approval_date.to_s(:short)
+    expect(firm_info.approved).to eq approval_date.strftime('%d %b %Y')
   end
 
   def then_the_firm_advisers_and_offices_get_pushed_to_the_directory(firm)


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRUQyNEQ1RkMxREUwMDEwRjA4QUEzMjJCQTZCRTJEQjIifQ==&boardPopup=userstory/11030/silent)  

We would like to see years in date values in rad admin and particularly dates showing up in Firms,Advisers and Principles.They are currently showing only day and month. This commit modifies the date values below.

- Add Years in firms index page at "Added" and "Approved" fields and remove
    time from the columns
  - Add Years in firms show page at advisers section
  - Add Years in advisers index page at "Added" field and remove time from the
    columns
  - Add Years in principals index page at "Added" field and remove time from the
    columns