### PR TITLE
Modify redirect behaviour after Principal deletion

### DIFF
--- a/app/controllers/admin/principals_controller.rb
+++ b/app/controllers/admin/principals_controller.rb
@@ -33,7 +33,7 @@ class Admin::PrincipalsController < Admin::ApplicationController
       user.destroy!
     end
 
-    redirect_to admin_retirement_principals_path, notice: message
+    redirect_to collection_path, notice: message
   end
 
   private

--- a/spec/controllers/admin/principals_controller_spec.rb
+++ b/spec/controllers/admin/principals_controller_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe Admin::PrincipalsController, type: :request do
   let(:principal) { FactoryBot.create(:principal) }
 
   describe 'DELETE #destroy' do
+    subject { delete admin_retirement_principal_path(principal) }
+
     context 'when successful' do
       it 'removes the principal and the user', :aggregate_failures do
-        expect { delete admin_retirement_principal_path(principal) }
+        expect { subject }
           .to change(Principal, :count)
           .by(-1)
           .and change(User, :count)
           .by(-1)
 
         expect(flash[:notice]).to match(/Successfully deleted/)
+      end
+
+      it 'redirects to the principals index' do
+        expect(subject).to redirect_to(admin_retirement_principals_path)
       end
     end
   end


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/11061-delete-firm-action-to-redirect-to)

Ensure that deleting a principal results in a redirect to the
appropriate index page. For example, deleting a principal from the
Travel Insurance admin takes you back to the Travel Insurance principals
index.