### PR TITLE
Consistently downcase Principal email addresses

### DIFF
--- a/app/forms/new_principal_form.rb
+++ b/app/forms/new_principal_form.rb
@@ -10,6 +10,12 @@ class NewPrincipalForm
   attr_accessor(*PARAMS)
   alias email_address email
 
+  def initialize(attributes = {})
+    super(attributes)
+    self.email = email&.downcase
+    self.email_address = email_address&.downcase
+  end
+
   validate do
     user = validated_user
 

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -1,6 +1,7 @@
 class Principal < ApplicationRecord
   self.primary_key = 'token'
 
+  before_validation :downcase_email
   before_create :generate_token
 
   has_one :user, foreign_key: :principal_token
@@ -82,5 +83,9 @@ class Principal < ApplicationRecord
 
   def generate_token
     self.token = SecureRandom.hex(4)
+  end
+
+  def downcase_email
+    self.email_address = email_address.downcase
   end
 end

--- a/db/migrate/20200129133118_downcase_all_principal_email_addresses.rb
+++ b/db/migrate/20200129133118_downcase_all_principal_email_addresses.rb
@@ -1,0 +1,13 @@
+class DowncaseAllPrincipalEmailAddresses < ActiveRecord::Migration[5.2]
+  def up
+    Principal.find_in_batches do |batch|
+      batch.each do |principal|
+        principal.update(email_address: principal.email_address.downcase)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_05_134556) do
+ActiveRecord::Schema.define(version: 2020_01_29_133118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Principal do
         long_email = "a@#{'a' * 50}.com"
         expect(build(:principal, email_address: long_email)).to_not be_valid
       end
+
+      it 'is downcased before validation' do
+        principal.email_address = 'Foo.Bar@email.com'
+        expect(principal).to be_valid
+        expect(principal.email_address).to eq 'foo.bar@email.com'
+      end
     end
 
     describe 'First name' do


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/entity/11110-stored-emails-have-inconsistent-cases)

All emails stored in the Users table are lower case. The codebase also
stores email addresses in the Principals table. There doesn't appear to
be an obvious reason for recording this information twice, and it may
well be a design flaw that needs correcting.

In the meantime, however, we have an issue whereby the Principal emails
are stored in whatever case the user provides. This causes issues when
retrieving records, in that we have to be aware of case-sensitivity in
any queries.

Address this as follows:

- Add a callback to Principal to ensure the email is downcased before
  the object is validated and persisted.
- Add a migration to downcase all existing Principal emails.
- Add logic to the NewPrincipalForm that consistently downcases the
  email fields. This may seem redundant given the callback on the model,
  however the data in this form is also used to check for existing
  principals by email address in cases where a principal is signing up
  their firm for more than one directory.