### PR TITLE
Escape html in a name matcher spec.

### DIFF
--- a/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
+++ b/spec/controllers/admin/reports/inactive_advisers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::Reports::InactiveAdvisersController, type: :request do
       inactive_adviser.save!(validate: false)
 
       get admin_reports_inactive_adviser_path
-      expect(response.body).to include(inactive_adviser.name)
+      expect(response.body).to include(CGI.escapeHTML(inactive_adviser.name))
     end
 
     it 'excludes advisers that have skipped the reference number check' do


### PR DESCRIPTION
Faker can generate names that have apostrophes in them and they cause an intermittent test failures.

`Christopher Wall' ace` doesn’t match with `Christopher Wall&#39; ace`

Rather than `gsub`bing out the special chars in the factory, opted to escape the string we’re matching against because IRL there might be names with special chars so better not to exclude the possibility in tests.