### PR TITLE
Fix new firm mailer for travel insurance firms

### DIFF
--- a/app/views/new_firm_mailer/notify.html.erb
+++ b/app/views/new_firm_mailer/notify.html.erb
@@ -1,5 +1,10 @@
 <h1>New Firm notification</h1>
 <div>
   A new firm has been registered in the directory:
-  <%= link_to(@firm.registered_name, admin_retirement_firm_url(@firm.id)) %>
+
+  <% if @firm.is_a?(TravelInsuranceFirm) %>
+    <%= link_to(@firm.registered_name, admin_travel_insurance_firm_url(@firm.id)) %>
+  <% else %>
+    <%= link_to(@firm.registered_name, admin_retirement_firm_url(@firm.id)) %>
+  <% end %>
 </div>

--- a/spec/new_firm_mailer_spec.rb
+++ b/spec/new_firm_mailer_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe NewFirmMailer, type: :mailer do
+  let(:recipient)    { ENV['TAD_ADMIN_EMAIL'] }
+  let(:subject_line) { 'New Firm registered in the directory' }
+  let(:retirement_firm) { create(:firm, registered_name: 'OrgName') }
+
+  shared_examples_for 'new firm notification mailer' do
+    describe '#notify' do
+      subject { NewFirmMailer.notify(firm) }
+
+      specify { expect(subject.to).to eq FCA::Config.email_recipients }
+      specify { expect(subject.subject).to eq(subject_line) }
+      specify { expect(subject.body.encoded).to include(firm.registered_name) }
+    end
+  end
+
+  describe 'retirement advice firm' do
+    let(:firm) { create(:firm, registered_name: 'OrgName') }
+    it_behaves_like 'new firm notification mailer'
+  end
+
+  describe 'travel insurance firm' do
+    let(:firm) { create(:travel_insurance_firm, registered_name: 'TavelInsurance') }
+    it_behaves_like 'new firm notification mailer'
+  end
+end


### PR DESCRIPTION
When a travel insurance firm was saved, the link in the email to the firm was using the incorrect path