### PR TITLE
Remove cache on registration new page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,4 +9,5 @@ require(['jquery'], function ($) {
   require(['AdviserAjaxCall']);
   require(['RemoteAndFaceToFaceOptions']);
   require(['WizardForm']);
+  require(['CacheBuster']);
 });

--- a/app/assets/javascripts/modules/CacheBuster.js
+++ b/app/assets/javascripts/modules/CacheBuster.js
@@ -1,0 +1,13 @@
+define(['jquery'], function($) {
+  'use strict';
+
+  var bustCache = $('.travel-registration-form').length;
+
+  if(bustCache > 0){
+    window.onpageshow = function(event) {
+      if (event.persisted) {
+        window.location.reload();
+      }
+    };
+  }
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -34,6 +34,7 @@
       AdviserAjaxCall: requirejs_path('modules/AdviserAjaxCall'),
       RemoteAndFaceToFaceOptions: requirejs_path('modules/RemoteAndFaceToFaceOptions'),
       WizardForm: requirejs_path('modules/WizardForm'),
+      CacheBuster: requirejs_path('modules/CacheBuster'),
       MultiTableFilter: requirejs_path('modules/MultiTableFilter'),
       ConfirmableForm: requirejs_path('modules/ConfirmableForm'),
       LanguageSelector: requirejs_path('modules/LanguageSelector'),

--- a/app/controllers/base_registrations_controller.rb
+++ b/app/controllers/base_registrations_controller.rb
@@ -1,6 +1,6 @@
 class BaseRegistrationsController < ApplicationController
   before_action :validate_registration_type, only: [:create]
-
+  before_action :set_cache_buster, only: :new
   def new
     @form = NewPrincipalForm.new
     Stats.increment('radsignup.prequalification.success')
@@ -46,5 +46,11 @@ class BaseRegistrationsController < ApplicationController
       .in?(
         DirectoryRegistrationService::REGISTRATION_TYPE_TO_FIRM_MAPPING.keys
       )
+  end
+
+  def set_cache_buster
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 1.year.ago.httpdate
   end
 end

--- a/app/views/travel_insurance_registrations/medical_conditions_form.html.erb
+++ b/app/views/travel_insurance_registrations/medical_conditions_form.html.erb
@@ -3,7 +3,7 @@
 
 <p class="registration__progress">Step 3 of 4</p>
 
-<%= form_for @form, url: medical_conditions_travel_insurance_registrations_path, html: { class: 'form' },builder: Dough::Forms::Builders::Validation do |f| %>
+<%= form_for @form, url: medical_conditions_travel_insurance_registrations_path, html: { class: 'form travel-registration-form' },builder: Dough::Forms::Builders::Validation do |f| %>
   <%= f.validation_summary %>
 
   <%= f.form_row :covers_medical_condition_question do %>

--- a/app/views/travel_insurance_registrations/medical_conditions_questionaire_form.html.erb
+++ b/app/views/travel_insurance_registrations/medical_conditions_questionaire_form.html.erb
@@ -6,7 +6,7 @@
 <div class="l-2col-even-row">
   <div class="l-2col">
     <section class="l-2col-main" data-wizard-form>
-      <%= form_for @form, url: medical_conditions_questionaire_travel_insurance_registrations_path, html: { class: 'wizard-form' }, builder: Dough::Forms::Builders::Validation do |f| %>
+      <%= form_for @form, url: medical_conditions_questionaire_travel_insurance_registrations_path, html: { class: 'wizard-form travel-registration-form' }, builder: Dough::Forms::Builders::Validation do |f| %>
         <%= f.validation_summary %>
 
         <% t('registration.medical_conditions_questionaire').each_with_index do |(key, item), index| %>

--- a/app/views/travel_insurance_registrations/risk_profile_form.html.erb
+++ b/app/views/travel_insurance_registrations/risk_profile_form.html.erb
@@ -3,7 +3,7 @@
 
 <p class="registration__progress">Step 2 of 4</p>
 
-<%= form_for @form, url: risk_profile_travel_insurance_registrations_path, html: { class: 'form' }, builder: Dough::Forms::Builders::Validation do |f| %>
+<%= form_for @form, url: risk_profile_travel_insurance_registrations_path, html: { class: 'form travel-registration-form' }, builder: Dough::Forms::Builders::Validation do |f| %>
   <%= f.validation_summary %>
 
   <%= f.form_row :covered_by_ombudsman_question do %>


### PR DESCRIPTION
If you hit the back button and go back to the new action, the page was cached in browser so authenticity tokens would be invalid. This makes sure that the new action always gets reloaded