### PR TITLE
[TP-11466] - Add more copy/descriptions to registration pages

### DIFF
--- a/app/views/travel_insurance_registrations/medical_conditions_questionaire_form.html.erb
+++ b/app/views/travel_insurance_registrations/medical_conditions_questionaire_form.html.erb
@@ -2,6 +2,9 @@
 <p><%= t('travel_insurance_registrations.intro') %></p>
 
 <p class="registration__progress">Step 4 of 4</p>
+<p>
+  <strong><%= t('travel_insurance_registrations.questionaire_instructions') %></strong>
+</p>
 
 <div class="l-2col-even-row">
   <div class="l-2col">

--- a/app/views/travel_insurance_registrations/new.html.erb
+++ b/app/views/travel_insurance_registrations/new.html.erb
@@ -65,6 +65,14 @@
   </div>
 
   <div class="l-identity__row">
+    <div class="l-identity__field l-identity__field--wide">
+      <p>
+        <strong><%= t('travel_insurance_registrations.email_and_phone_message') %></strong>
+      </p>
+    </div>
+  </div>
+
+  <div class="l-identity__row">
     <div class="l-identity__field">
       <%= f.form_row(:email) do %>
         <%= f.errors_for :email %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
     confirmation_statement_html: |
       By registering your firm’s details with the Money & Pensions Service you are confirming that the information supplied, and the responses given to our registration questions, are correct and accurately reflect the services offered by your firm and any trading names registered on the Directory under this FRN.
       <br/><br/>
-      Firms also consent to MaPS sharing any information provided by firms as part of the application Process with the FCA or about the conduct of firms, if, during the course of operating the Directory, MaPS becomes aware of practices by FCA-regulated persons which it considers to be detrimental to consumers.
+      Firms also consent to MaPS sharing any information provided by firms as part of the registration process with the FCA or about the conduct of firms, if, during the course of operating the Directory, MaPS becomes aware of practices by FCA-regulated persons which it considers to be detrimental to consumers.
     register_button: Continue
     previous_question_button: Previous question
   retirement_advice_registrations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,8 @@ en:
     prompt_explanation: "*An individual approved by the FCA to perform a senior management function and listed on the FCA Register."
     reference_number: FCA Firm Reference Number (FRN)
     frn_linked_trading_names_info: You can register the main firm and up to two trading names linked to this FRN.
-
+    email_and_phone_message: Enter the email address and telephone number of the named Senior Manager or a person appointed to act on their behalf.
+    questionaire_instructions: "You have confirmed that you will offer travel insurance to people with any/most types of serious medical conditions. Please now confirm in which of the fifteen hypothetical scenarios below your firm would offer single trip cover (without medical exclusions). Please select ‘yes’’ or ‘no’ for each scenario"
     confirmation_statement_html: |
       By registering your firm’s details with the Money & Pensions Service you are confirming that the information supplied, and the responses given to our registration questions, are correct and accurately reflect the services offered by your firm and any trading names registered on the Directory under this FRN.
       <br/><br/>


### PR DESCRIPTION
<img width="1271" alt="Screenshot 2020-05-27 at 10 41 43" src="https://user-images.githubusercontent.com/788057/83004049-0d811500-a007-11ea-8ffb-c0104ce8c61f.png">
<img width="877" alt="Screenshot 2020-05-27 at 10 29 52" src="https://user-images.githubusercontent.com/788057/83004052-0e19ab80-a007-11ea-9e77-700a51521b29.png">
