### PR TITLE
[TP-11518] - Remove "Later Life Academy" accreditation

### DIFF
--- a/lib/data_migrations/remove_later_life_accreditation.rb
+++ b/lib/data_migrations/remove_later_life_accreditation.rb
@@ -16,7 +16,7 @@ class RemoveLaterLifeAccreditation
 
     # There should be no advisers with this accreditation, this is just in case one gets added in the meantime
     Adviser.includes(:accreditations).where(accreditations: { id: accreditation.id }).find_each do |adviser|
-      adviser.delete(accreditation)
+      adviser.accreditations.delete(accreditation)
     end
 
     # Remove the accreditation so it's not available for advisers to add it

--- a/lib/data_migrations/remove_later_life_accreditation.rb
+++ b/lib/data_migrations/remove_later_life_accreditation.rb
@@ -1,0 +1,25 @@
+class RemoveLaterLifeAccreditation
+  def run_migration
+    Rails.logger.info 'BEGIN Remove Later Life Accreditation'
+
+    remove_accreditation
+
+    Rails.logger.info 'END Remove Later Life Accreditation'
+  end
+
+  private
+
+  def remove_accreditation
+    accreditation = Accreditation.find_by(id: 2, name: 'Later Life Academy')
+
+    return unless accreditation
+
+    # There should be no advisers with this accreditation, this is just in case one gets added in the meantime
+    Adviser.includes(:accreditations).where(accreditations: { id: accreditation.id }).find_each do |adviser|
+      adviser.delete(accreditation)
+    end
+
+    # Remove the accreditation so it's not available for advisers to add it
+    accreditation.destroy
+  end
+end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,4 +1,5 @@
 require_relative '../data_migrations/merge_ifp_with_cis'
+require_relative '../data_migrations/remove_later_life_accreditation'
 
 namespace :data_migration do
   desc 'Migrate any Professional Standings from the Institute of Financial \
@@ -6,5 +7,10 @@ namespace :data_migration do
   and Investments'
   task merge_ifp_with_cis: :environment do
     MergeIfpWithCis.new.run_migration
+  end
+
+  desc 'Remove Later Life Accreditation and remove the accreditation from any advisers'
+  task remove_later_life_accreditation: :environment do
+    RemoveLaterLifeAccreditation.new.run_migration
   end
 end


### PR DESCRIPTION
Script to remove the accreditation entry from the accreditations table and also an extra check to remove any Adviser accreditations if they exit (So far there are no advisers that have it, but this is just in case one gets added before deployment)

Run the rake task to remove the entry for Later Life accreditation:
```
bin/rake data_migration:remove_later_life_accreditation  
```