### PR TITLE
[TP-11772] - Increase number of positive answers required for successful registration

### DIFF
--- a/app/controllers/travel_insurance_registrations_controller.rb
+++ b/app/controllers/travel_insurance_registrations_controller.rb
@@ -1,5 +1,6 @@
 class TravelInsuranceRegistrationsController < BaseRegistrationsController
   WIZARD_STEPS = [:risk_profile, :medical_conditions, :medical_conditions_questionaire].freeze
+  MIN_REQUIRED_POSITIVE_ANSWERS = 12
 
   def registration_title
     'travel_insurance_registrations.heading'
@@ -130,7 +131,7 @@ class TravelInsuranceRegistrationsController < BaseRegistrationsController
 
   def medical_questionaire_acceptable?
     positive_answers_count = medical_conditions_questionaire_form_params.values.select { |i| i == 'true' }.count
-    positive_answers_count >= (medical_conditions_questionaire_form_params.values.count * 0.5).ceil
+    positive_answers_count >= MIN_REQUIRED_POSITIVE_ANSWERS
   end
 
   def all_registration_answers

--- a/spec/features/register_travel_insurance_account_spec.rb
+++ b/spec/features/register_travel_insurance_account_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Principal provides travel insurance information', :inline_job_que
 
     scenario 'a firm that answers yes to 8 questions and the rest no' do
       given_i_am_on_the_travel_insurance_medical_conditions_questionaire_page
-      and_i_answer_yes_to_questions_on_step_4(8)
+      and_i_answer_yes_to_questions_on_step_4(12)
       then_i_am_shown_a_thank_you_for_registering_message
       and_i_should_have_a_travel_insurance_firm
       and_i_later_receive_an_email_confirming_my_registration
@@ -138,7 +138,7 @@ RSpec.feature 'Principal provides travel insurance information', :inline_job_que
 
     scenario 'a firm that answers yes to 7 questions and the rest no' do
       given_i_am_on_the_travel_insurance_medical_conditions_questionaire_page
-      and_i_answer_yes_to_questions_on_step_4(7)
+      and_i_answer_yes_to_questions_on_step_4(11)
       then_i_am_notified_i_cannot_proceed
       and_admins_later_receive_an_email_about_the_rejection
     end


### PR DESCRIPTION
Before we required at least 50% of answers to be positive, this change sets a hard minimum 12 true answers out of 15