### PR TITLE
[TP-11913] Create Test; Catch error when firm missing from API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   active_link_to

--- a/app/views/admin/lookup/fca_import/index.html.erb
+++ b/app/views/admin/lookup/fca_import/index.html.erb
@@ -94,7 +94,7 @@
     <div class="col-xs-10 col-xs-push-2">
       <h1>
         FCA Import
-        <small>(There is not files ready for import)</small>
+        <small>(There are no files ready for import)</small>
       </h1>
     </div>
   </div>

--- a/spec/jobs/firm_status_check_job_spec.rb
+++ b/spec/jobs/firm_status_check_job_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe FirmStatusCheckJob do
+  describe '#perform' do
+    let(:invalid_firm) { double(InvalidFirm) }
+    let(:request) { FcaApi::Request }
+    let(:response) { double(FcaApi::Response, ok?: result, data: data) }
+
+    before do
+      expect(request)
+        .to receive_message_chain(:new, :get_firm)
+        .with(firm.fca_number)
+        .and_return(response)
+    end
+
+    context 'successful response from the api' do
+      let(:firm) { FactoryBot.create(:firm, registered_name: 'Acme Finance', fca_number: 100013) }
+      let(:result) { true }
+
+      context 'the firm is active' do
+        let(:data) { { 'Status' => 'Active', 'FRN' => firm.fca_number } }
+
+        it 'creates an Inactive Firm' do
+          expect(InactiveFirm).to_not receive(:create).with(api_status: 'Inactive', firmable: firm)
+
+          described_class.perform_now(firm)
+        end
+      end
+
+      context 'the firm is inactive' do
+        let(:data) { { 'Status' => 'Inactive', 'FRN' => firm.fca_number } }
+
+        it 'creates an Inactive Firm' do
+          expect(InactiveFirm).to receive(:create).with(api_status: 'Inactive', firmable: firm)
+
+          described_class.perform_now(firm)
+        end
+      end
+    end
+
+    context 'failed response from the api' do
+      let(:firm) { FactoryBot.create(:firm, registered_name: 'Acme Finance', fca_number: 10001) }
+      let(:result) { false }
+      let(:data) { nil }
+
+      it 'creates an Inactive Firm' do
+        expect(InactiveFirm).to receive(:create).with(api_status: 'Not Found', firmable: firm)
+
+        described_class.perform_now(firm)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP-11913](https://maps.tpondemand.com/entity/11913-bug-firm-status-check-error)
Create spec for FirmStatusCheckJob 
Check that `response.ok?` for each firm.  If not, then firm is missing from API and log this status so admins can manage it manually.
Correct minor spelling error.