### PR TITLE
TP-11914 Catch Faraday Error; Update Tests

### DIFF
--- a/lib/fca_api/request.rb
+++ b/lib/fca_api/request.rb
@@ -9,7 +9,12 @@ module FcaApi
     end
 
     def get_firm(firm_id)
-      response = connection.get(full_path(FIRM_ENDPOINT, firm_id))
+      begin 
+        response = connection.get(full_path(FIRM_ENDPOINT, firm_id)) 
+      rescue Faraday::ParsingError
+        response = Faraday::Response.new(body: { 'Message': 'Failure' })
+      end
+
       FcaApi::Response.new(response)
     end
 

--- a/lib/fca_api/request.rb
+++ b/lib/fca_api/request.rb
@@ -9,8 +9,8 @@ module FcaApi
     end
 
     def get_firm(firm_id)
-      begin 
-        response = connection.get(full_path(FIRM_ENDPOINT, firm_id)) 
+      begin
+        response = connection.get(full_path(FIRM_ENDPOINT, firm_id))
       rescue Faraday::ParsingError
         response = Faraday::Response.new(body: { 'Message': 'Failure' })
       end

--- a/spec/lib/fca_api/request_spec.rb
+++ b/spec/lib/fca_api/request_spec.rb
@@ -2,24 +2,29 @@ RSpec.describe FcaApi::Request do
   subject { described_class.new }
 
   let(:connection) { FcaApi::Connection.new(domain) }
-  let(:domain) { 'http://fca.org.uk' }
+  let(:domain) { 'https://www.fca.org.uk' }
   let(:firm_id) { 100_001 }
   let(:response) { instance_double(Faraday::Response) }
-
+  let(:response_failed) { instance_double(FcaApi::Response) }
+  
   before do
     stub_env('FCA_API_DOMAIN', domain)
     stub_env('FCA_API_MAX_RETRIES', 2)
     stub_env('FCA_API_TIMEOUT', 1)
     stub_env('FCA_API_EMAIL', 'email@maps.org.uk')
     stub_env('FCA_API_KEY', 'xyz123abc')
-    allow(FcaApi::Connection)
-      .to receive(:new)
-      .with(domain)
-      .and_return(connection)
   end
 
   describe '#get_firm' do
+    before do
+      allow(FcaApi::Connection)
+        .to receive(:new)
+        .with(domain)
+        .and_return(connection)
+    end
+
     let(:response_message) { { 'Message' => 'Ok. Firm Found' } }
+
     it 'returns a firm with the provided reference number' do
       expect(connection)
         .to receive(:get)
@@ -27,6 +32,31 @@ RSpec.describe FcaApi::Request do
         .and_return(response)
 
       expect(FcaApi::Response).to receive(:new).with(response)
+
+      subject.get_firm(firm_id)
+    end
+  end
+
+  describe 'API down for maintenance' do
+    let(:response_failure_message) { { :Message => 'Failure' } }
+    let(:down_for_maintenance) { { 'Success' => 'true', 'Message' => 'The Application Programming Interface (API) will be out of service'} }
+
+
+    before do
+      allow(FcaApi::Connection)
+        .to receive(:new)
+        .with(domain)
+        .and_return(connection)
+    end
+
+    it 'returns a failed response' do
+      allow(connection)
+        .to receive(:get)
+        .and_raise(Faraday::ParsingError.new(down_for_maintenance))
+
+      allow(Faraday::Response).to receive(:new).with(body: response_failure_message).and_return(response)
+
+      expect(FcaApi::Response).to receive(:new).with(response).and_return(response_failed)
 
       subject.get_firm(firm_id)
     end

--- a/spec/lib/fca_api/request_spec.rb
+++ b/spec/lib/fca_api/request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FcaApi::Request do
   let(:firm_id) { 100_001 }
   let(:response) { instance_double(Faraday::Response) }
   let(:response_failed) { instance_double(FcaApi::Response) }
-  
+
   before do
     stub_env('FCA_API_DOMAIN', domain)
     stub_env('FCA_API_MAX_RETRIES', 2)
@@ -38,8 +38,10 @@ RSpec.describe FcaApi::Request do
   end
 
   describe 'API down for maintenance' do
+    # rubocop:disable Style/HashSyntax
     let(:response_failure_message) { { :Message => 'Failure' } }
-    let(:down_for_maintenance) { { 'Success' => 'true', 'Message' => 'The Application Programming Interface (API) will be out of service'} }
+    # rubocop:enable Style/HashSyntax
+    let(:down_for_maintenance) { { 'Success' => 'true', 'Message' => 'API down' } }
 
 
     before do

--- a/spec/lib/fca_api/request_spec.rb
+++ b/spec/lib/fca_api/request_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe FcaApi::Request do
     # rubocop:enable Style/HashSyntax
     let(:down_for_maintenance) { { 'Success' => 'true', 'Message' => 'API down' } }
 
-
     before do
       allow(FcaApi::Connection)
         .to receive(:new)


### PR DESCRIPTION
[TP-11914](https://maps.tpondemand.com/entity/11914-fca-api-down-for-maintenance)
When FCA API down for maintenance it returns a response which cannot be parsed.
Catch `Faraday::ParsingError` and fail gracefully.
Update test suite to include scenario where API is down.