### PR TITLE
TP-11952; TP-11955 TAD Fix pdatealgoliaindexjob errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config/cloud_storage.yml
 config/database.yml
 node_modules/
 spec/test_status.txt
+latest.dump

--- a/app/helpers/admin/lookup/fca_import_helper.rb
+++ b/app/helpers/admin/lookup/fca_import_helper.rb
@@ -13,7 +13,9 @@ module Admin::Lookup::FcaImportHelper
 
   def prepare_table_info(import, table_name)
     formatted_diff(*import.send(table_name.to_sym))
+  # rubocop:disable Style/RescueStandardError
   rescue
     { error: 'Could not calculate difference. Try reloading the page.' }
   end
+  # rubocop:enable Style/RescueStandardError
 end

--- a/app/helpers/admin/lookup/fca_import_helper.rb
+++ b/app/helpers/admin/lookup/fca_import_helper.rb
@@ -10,4 +10,10 @@ module Admin::Lookup::FcaImportHelper
       diff:    b - a
     }
   end
+
+  def prepare_table_info(import, table_name)
+    formatted_diff(*import.send(table_name.to_sym))
+  rescue
+    { error: 'Could not calculate difference. Try reloading the page.' }
+  end
 end

--- a/app/models/fca_import.rb
+++ b/app/models/fca_import.rb
@@ -1,5 +1,6 @@
 class FcaImport < ApplicationRecord
   STATUSES = %w[processing processed confirmed cancelled].freeze
+  FCA_IMPORT_EXCEPTIONS = [PG::InFailedSqlTransaction, StandardError].freeze
 
   scope :not_confirmed, -> { where(status: STATUSES.take(2)) }
 
@@ -64,13 +65,12 @@ class FcaImport < ApplicationRecord
   # Either remove the need for temporary tables
   # Use the API instead of file imports
   # Or failing the above make the temporary tables Rails models.
-  FCA_IMPORT_EXCEPTIONS = [PG::InFailedSqlTransaction, StandardError].freeze
 
   def exec(sql)
     result = ActiveRecord::Base.connection.execute(sql)
     result[0]['total'].to_i
   rescue *FCA_IMPORT_EXCEPTIONS
     ActiveRecord::Base.connection.clear_cache!
-    return 0
+    0
   end
 end

--- a/app/views/admin/lookup/fca_import/index.html.erb
+++ b/app/views/admin/lookup/fca_import/index.html.erb
@@ -36,49 +36,49 @@
 </div>
 
 <% if @import.try(:processed?) %>
-<div class="row">
   <div class="row">
-    <div class="col-xs-10 col-xs-push-2">
-      <h1>
-        FCA Import Result
-        <small>(Import ready for confirmation)</small>
-      </h1>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-xs-2">
-    </div>
-    <div class="col-xs-10">
-      <%= form_tag(admin_lookup_fca_import_path(@import), method: :put) do %>
-      <%= hidden_field_tag 'apply' %>
-      <table class="table table-bordered">
-        <tr>
-          <% @tables.each do |t| %>
-            <th><%= t %></th>
-          <% end %>
-        </tr>
-        <tr>
-          <% @tables.each do |t| %>
-          <td>
-            <ul>
-              <% formatted_diff(*@import.send(t.to_sym)).each do |k, v| %>
-                <li><%= "#{k}: #{v}" %></li>
-              <% end %>
-              </ul>
-          </td>
-          <% end %>
-        </tr>
-      </table>
-      <div class="row">
-        <div class="col-xs-11"><%= submit_tag "Confirm"%></div>
-        <%= submit_tag "Cancel"%>
+    <div class="row">
+      <div class="col-xs-10 col-xs-push-2">
+        <h1>
+          FCA Import Result
+          <small>(Import ready for confirmation)</small>
+        </h1>
       </div>
-      <% end %>
+    </div>
+    <div class="row">
+      <div class="col-xs-2">
+      </div>
+      <div class="col-xs-10">
+        <%= form_tag(admin_lookup_fca_import_path(@import), method: :put) do %>
+        <%= hidden_field_tag 'apply' %>
+        <table class="table table-bordered">
+          <tr>
+            <% @tables.each do |t| %>
+              <th><%= t %></th>
+            <% end %>
+          </tr>
+          <tr>
+            <% @tables.each do |t| %>
+              <td>
+                <ul>
+                  <% prepare_table_info(@import, t).each do |k, v| %>
+                    <li><%= "#{k}: #{v}" %></li>
+                  <% end %>
+                  </ul>
+              </td>
+            <% end %>
+          </tr>
+        </table>
+        <div class="row">
+          <div class="col-xs-11"><%= submit_tag "Confirm"%></div>
+          <%= submit_tag "Cancel"%>
+        </div>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
-
 <% end %>
+
 <% if @import.try(:processing?)%>
   <div class="row">
     <div class="col-xs-10 col-xs-push-2">

--- a/lib/algolia_index/serializers/travel_insurance_firm_offering_serializer.rb
+++ b/lib/algolia_index/serializers/travel_insurance_firm_offering_serializer.rb
@@ -30,6 +30,14 @@ module AlgoliaIndex
       object.id
     end
 
+    # Comment (TG 18-01-2021). This file needs refactoring
+    # Firstly the define_method code should apply to all attributes,
+    # The 'bool_to_string' method should be part of that method
+    # Anything which needs a different method name should be aliased
+    # Duplicate methods should be removed
+    # We should try to bring it inline with the other serializers which are much more simple,
+    # and use delegate method where appropriate
+
     # Trip covers
     def cover_area
       [I18n.t("self_service.travel_insurance_firms_edit.#{object.cover_area}")]

--- a/spec/features/admin/travel_insurance_firm_approval_spec.rb
+++ b/spec/features/admin/travel_insurance_firm_approval_spec.rb
@@ -12,8 +12,13 @@ RSpec.feature 'Approving travel insurance firms', :inline_job_queue do
 
   let(:approval_date) { Time.utc(2019, 6, 1) }
 
+  # Comment (TG 19-01-2021). This file needs refactoring
+  # This scenario needs to be reviewed but is inline with usage of the application
+  # Admins currently approve firms with missing information
+  # They want the firms added to the index even if firm.publishable? is false
   scenario 'Approving a travel insurance firm' do
-    given_there_are_registered_travel_insurance_firms
+    given_there_are_unapproved_travel_insurance_firms
+    and_the_firm_is_not_publishable
     when_i_visit_a_travel_insurance_firm_page
     and_i_approve_the_firm
     then_the_firm_becomes_approved
@@ -22,11 +27,17 @@ RSpec.feature 'Approving travel insurance firms', :inline_job_queue do
     then_the_travel_insurance_firm_and_offerings_gets_pushed_to_the_directory
   end
 
-  def given_there_are_registered_travel_insurance_firms
+  def given_there_are_unapproved_travel_insurance_firms
+    @principal = FactoryBot.create(:principal, manually_build_firms: true)
     @firm = FactoryBot.create(:travel_insurance_firm,
-      completed_firm: true,
+      principal: @principal,
+      fca_number: @principal.fca_number,
+      registered_name: 'Acme Travel',
       approved_at: nil)
-    @user = FactoryBot.create(:user, principal: @firm.principal)
+  end
+
+  def and_the_firm_is_not_publishable
+    expect(@firm.publishable?).to be_falsey
   end
 
   def when_i_visit_a_travel_insurance_firm_page

--- a/spec/support/contexts/algolia_index_fake.rb
+++ b/spec/support/contexts/algolia_index_fake.rb
@@ -78,6 +78,7 @@ RSpec.shared_context 'algolia index fake' do
   def parse_index(index_name)
     a = AlgoliaIndex.send(index_name).browse('')
     return a['hits'] unless a.is_a?(String)
+
     JSON.parse(a)['hits']
   end
 end

--- a/spec/support/contexts/algolia_index_fake.rb
+++ b/spec/support/contexts/algolia_index_fake.rb
@@ -6,6 +6,12 @@ RSpec.shared_context 'algolia index fake' do
   let(:algolia_travel_firms_offerings_index) { AlgoliaIndex::Fake.new('travel-firm-offerings-test') }
 
   before do
+    algolia_advisers_index.clear_index
+    algolia_offices_index.clear_index
+
+    algolia_travel_firms_index.clear_index
+    algolia_travel_firms_offerings_index.clear_index
+
     allow(Algolia::Index).to receive(:new)
       .with('firm-advisers-test')
       .and_return(algolia_advisers_index)
@@ -32,19 +38,19 @@ RSpec.shared_context 'algolia index fake' do
   end
 
   def travel_firms_in_directory
-    JSON.parse(AlgoliaIndex.indexed_travel_insurance_firms.browse(''))['hits']
+    parse_index('indexed_travel_insurance_firms')
   end
 
   def travel_firm_offerings_in_directory
-    JSON.parse(AlgoliaIndex.indexed_travel_insurance_firm_offerings.browse(''))['hits']
+    parse_index('indexed_travel_insurance_firm_offerings')
   end
 
   def advisers_in_directory
-    JSON.parse(AlgoliaIndex.indexed_advisers.browse(''))['hits']
+    parse_index('indexed_advisers')
   end
 
   def offices_in_directory
-    JSON.parse(AlgoliaIndex.indexed_offices.browse(''))['hits']
+    parse_index('indexed_offices')
   end
 
   def firm_advisers_in_directory(firm)
@@ -65,5 +71,13 @@ RSpec.shared_context 'algolia index fake' do
 
   def firm_total_advisers_in_directory(firm)
     firm_advisers_in_directory(firm).first.dig('firm', 'total_advisers')
+  end
+
+  private
+
+  def parse_index(index_name)
+    a = AlgoliaIndex.send(index_name).browse('')
+    return a['hits'] unless a.is_a?(String)
+    JSON.parse(a)['hits']
   end
 end


### PR DESCRIPTION
[11952](https://maps.tpondemand.com/entity/11952-tad-fix-updatealgoliaindexjob-errors)
Add error catching to Serializers when data is missing
Improve Algolia Index Fake specs to account for missing data

[11955](https://maps.tpondemand.com/entity/11955-tad-fca-import-failure-causes-template)
Improve Error catching in model
Add second level of error catching to template