### PR TITLE
TP-11965 Undefined Method in Firm Status Check

### DIFF
--- a/lib/fca_api/response.rb
+++ b/lib/fca_api/response.rb
@@ -9,6 +9,8 @@ module FcaApi
     end
 
     def ok?
+      return false if raw_response.body['Message'].nil?
+
       raw_response.body['Message'].downcase.include?(SUCCESS_MESSAGE)
     end
 


### PR DESCRIPTION
[TP-11965](https://maps.tpondemand.com/entity/11965-rad-undefined-method-in-firm-status)

Catch error when there is no response from API on checking a firm.