### PR TITLE
Bump `mime-magic` to fix yanked gem issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,6 +2,7 @@ FROM masdevtestregistry.azurecr.io/jenkins/sfgb-base-ruby-2.6.5:latest
 
 RUN apt-get -qq update > /dev/null && \
   apt-get -qq dist-upgrade > /dev/null && \
+  apt-get install -y shared-mime-info && \
   apt-get -qq clean  > /dev/null && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Also installs the `shared-mime-info` package for compatibility.