### PR TITLE
Fix spec non-determinism

### DIFF
--- a/spec/features/register_travel_insurance_account_spec.rb
+++ b/spec/features/register_travel_insurance_account_spec.rb
@@ -1,4 +1,6 @@
 RSpec.feature 'Principal provides travel insurance information', :inline_job_queue do
+  include_context 'algolia index fake'
+
   let(:travel_insurance_registration_page) do
     TravelInsuranceRegistrationPage.new
   end


### PR DESCRIPTION
This was tricky to trace but when the specs run with specific seeds
(thus specifically ordered) there are occassions where the
`Algolia::Index` is already memoized as non-fake. Any subsequent specs
would fail thereafter. This could be traced back to this missing,
expected context to be around for the feature I have modified in this
commit.

An example failing seed would be `49365`.