### PR TITLE
Fix issue when submitting blank registrations

### DIFF
--- a/app/controllers/retirement_advice_registrations_controller.rb
+++ b/app/controllers/retirement_advice_registrations_controller.rb
@@ -34,7 +34,7 @@ class RetirementAdviceRegistrationsController < BaseRegistrationsController
   private
 
   def pre_qualification_form_params
-    params.require(:pre_qualification_form).permit(
+    params.fetch(:pre_qualification_form, {}).permit(
       :active_question,
       :business_model_question,
       :status_question,

--- a/spec/features/pre_qualification_for_retirement_advisers_spec.rb
+++ b/spec/features/pre_qualification_for_retirement_advisers_spec.rb
@@ -7,6 +7,11 @@ RSpec.feature 'Principal answers pre-qualification questions' do
     pre_qualification_page.load
   end
 
+  scenario 'Submitting the blank form without answering anything' do
+    when_i_submit_my_answers
+    then_i_am_notified_i_cannot_proceed
+  end
+
   scenario 'Answering all questions "Yes" and choosing "Independent"' do
     given_i_answer_all_questions_yes_and_choose_independent
     when_i_submit_my_answers


### PR DESCRIPTION
Prior to this change it would cause a hard error upon submission of a
blank registration form, rather than redirect to the rejection screen.