### PR TITLE
Add attributes to enable ordering

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -45,7 +45,7 @@ class Adviser < ApplicationRecord
   end
 
   def self.ransackable_attributes(*)
-    %w[firm_id id latitude longitude name postcode reference_number travel_distance]
+    %w[created_at firm_id id latitude longitude name postcode reference_number travel_distance]
   end
 
   def self.on_firms_with_fca_number(fca_number)

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -132,6 +132,8 @@ class Firm < ApplicationRecord # rubocop:disable Metrics/ClassLength
       sharia_investing_flag
       wills_and_probate_flag
       workplace_financial_advice_flag
+      created_at
+      approved_at
     ]
   end
 

--- a/app/models/lookup/adviser.rb
+++ b/app/models/lookup/adviser.rb
@@ -8,7 +8,11 @@ module Lookup
     end
 
     def self.ransackable_attributes(*)
-      ['reference_number', 'name']
+      %w[created_at reference_number name]
+    end
+
+    def self.ransackable_associations(*)
+      []
     end
   end
 end

--- a/app/models/lookup/firm.rb
+++ b/app/models/lookup/firm.rb
@@ -15,7 +15,11 @@ module Lookup
     end
 
     def self.ransackable_attributes(*)
-      ['fca_number', 'registered_name']
+      %w[created_at fca_number registered_name]
+    end
+
+    def self.ransackable_associations(*)
+      ['subsidiaries']
     end
   end
 end

--- a/app/models/lookup/subsidiary.rb
+++ b/app/models/lookup/subsidiary.rb
@@ -9,7 +9,11 @@ module Lookup
     end
 
     def self.ransackable_attributes(*)
-      ['fca_number', 'name']
+      %w[created_at fca_number name]
+    end
+
+    def self.ransackable_associations(*)
+      []
     end
   end
 end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -46,7 +46,7 @@ class Principal < ApplicationRecord
   validates :confirmed_disclaimer, acceptance: { accept: true }
 
   def self.ransackable_attributes(*)
-    %w[email_address fca_number first_name id individual_reference_number job_title last_name telephone_number]
+    %w[created_at email_address fca_number first_name id individual_reference_number job_title last_name telephone_number]
   end
 
   def self.ransackable_associations(*)


### PR DESCRIPTION
These were misconfigured for ransack after the recent upgrades.