### PR TITLE
Allow up to 7 digits for FCA numbers

### DIFF
--- a/app/models/lookup/firm.rb
+++ b/app/models/lookup/firm.rb
@@ -3,7 +3,7 @@ module Lookup
     has_many :subsidiaries, primary_key: :fca_number, foreign_key: :fca_number
 
     validates :fca_number,
-              length: { is: 6 },
+              length: { in: 6..7 },
               numericality: { only_integer: true }
 
     def subsidiaries?

--- a/app/models/lookup/subsidiary.rb
+++ b/app/models/lookup/subsidiary.rb
@@ -1,7 +1,7 @@
 module Lookup
   class Subsidiary < ApplicationRecord
     validates :fca_number,
-              length: { is: 6 },
+              length: { in: 6..7 },
               numericality: { only_integer: true }
 
     def self.table_name

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -25,7 +25,7 @@ class Principal < ApplicationRecord
   validates :fca_number,
             presence: true,
             uniqueness: true,
-            length: { is: 6 },
+            length: { in: 6..7 },
             numericality: { only_integer: true }
 
   validates :email_address,

--- a/spec/models/lookup/firm_spec.rb
+++ b/spec/models/lookup/firm_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Lookup::Firm do
         expect(described_class.new(fca_number: '123A45')).to_not be_valid
       end
 
-      it 'accepts only 6 digits' do
-        expect(described_class.new(fca_number: 1_234_567)).to_not be_valid
+      it 'accepts between 6 and 7 digits' do
+        expect(described_class.new(fca_number: 1_234_567)).to be_valid
+        expect(described_class.new(fca_number: 1_234_567_8)).to_not be_valid
       end
     end
   end


### PR DESCRIPTION
FCA now has entries listed with up to 7 digits for identification. We only allowed 6 digits precisely before so this change permits FCA numbers between 6-7 digits long.

A new run of FCA data will need to run first to backfill the reference data as prior to this change we were quietly dropping any reference data identified by FCA numbers not precisely 6 digits long.